### PR TITLE
removing skip to main content from Header and HomeHero

### DIFF
--- a/src/library/structure/Header/Header.tsx
+++ b/src/library/structure/Header/Header.tsx
@@ -9,7 +9,6 @@ import GDSLogo from "../../components/logos/GDSLogo/logo";
 import NorthColoured from "../../components/logos/NorthColouredLogo/logo";
 import WestColoured from "../../components/logos/WestColouredLogo/logo";
 import WestWhite from "../../components/logos/WestWhiteLogo/logo";
-import { SkipToMainContent } from "../PageStructures";
 import Searchbar from "../Searchbar/Searchbar";
 
 /**

--- a/src/library/structure/HomeHero/HomeHero.tsx
+++ b/src/library/structure/HomeHero/HomeHero.tsx
@@ -8,7 +8,6 @@ import * as Styles from "./HomeHero.styles";
 import GDSLogo from "../../components/logos/GDSLogo/logo";
 import NorthColoured from "../../components/logos/NorthColouredLogo/logo";
 import WestColoured from "../../components/logos/WestColouredLogo/logo";
-import { SkipToMainContent } from "../PageStructures";
 import LazyImage from "react-lazy-progressive-image";
 import Searchbar from "../Searchbar/Searchbar";
 import PhaseBanner from "../PhaseBanner/PhaseBanner";
@@ -32,7 +31,6 @@ const HomeHero: React.FC<HomeHeroProps> = ({
 
   return(
     <>
-      <SkipToMainContent />
       {/* <PhaseBanner isHome /> */}
       <Styles.Wrapper>
         <LazyImage


### PR DESCRIPTION
To remove duplicate skip to main content link on homepage and remove unused import