### PR TITLE
#42 pagination fix

### DIFF
--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
@@ -38,7 +38,7 @@ const CheckboxListFilter: React.FC<CheckboxListFilterProps> = ({ options, checke
         checked = newCheckboxState.filter(c => c.checked === true);
         
         let articleTypes = checked.map((c) => c.value).join(',');
-        handleParams('news', [{key: NewsArticleFilterFields.articleType.queryParamKey, value: articleTypes}]);
+        handleParams('news', [{key: NewsArticleFilterFields.articleType.queryParamKey, value: articleTypes}],["page"]);
     }
 
     

--- a/src/library/components/DropDownFilter/DropDownFilter.tsx
+++ b/src/library/components/DropDownFilter/DropDownFilter.tsx
@@ -15,7 +15,7 @@ const DropDownFilter: React.FC<DropDownFilterProps> = ({ id, label, options, sel
     
     const optionPicked = (e) => {
         setValue(e.target.value)
-        handleParams('news', [{key: NewsArticleFilterFields.services.queryParamKey, value: e.target.value}]);
+        handleParams('news', [{key: NewsArticleFilterFields.services.queryParamKey, value: e.target.value}],["page"]);
     }
 
     return (

--- a/src/library/components/SortBy/SortBy.tsx
+++ b/src/library/components/SortBy/SortBy.tsx
@@ -11,7 +11,7 @@ import { NewsArticleFilterFields } from "./../../structure/NewsArticleFilterAcco
 const SortBy: React.FC<SortByProps> = ({ selected, options }) => {
     
     const optionPicked = (e) => {
-        handleParams('news', [{key: NewsArticleFilterFields.sortBy.queryParamKey, value: e.target.value}]);
+        handleParams('news', [{key: NewsArticleFilterFields.sortBy.queryParamKey, value: e.target.value}],["page"]);
     }
 
     return (

--- a/src/library/helpers/url-helpers.js
+++ b/src/library/helpers/url-helpers.js
@@ -8,9 +8,9 @@ import Uri from 'jsuri';
 
  // https://github.com/derek-watson/jsUri
 
- export const handleParams = (postTo, newParams) => {
+ export const handleParams = (postTo, newParams, clearParams=[]) => {
    var uri = new Uri(window.location)
-
+   
     // check where we're posting to (news / search etc)
    const path = (uri.path().substring(0,1) === '/') ? uri.path().substring(1) : uri.path();
    if(postTo !== path) {
@@ -23,12 +23,12 @@ import Uri from 'jsuri';
    if(uri.query() === '') {
       newParams.forEach(param => {
          // console.info('No existing params adding new ' + param.key + ' value with ' + param.value)
-         uri.addQueryParam(param.key, param.value) 
+         uri.addQueryParam(param.key, param.value)  
       });
    } else {
       // we already have params
       newParams.forEach(param => {    
-            if(uri.hasQueryParam(param.key)) {
+            if(uri.hasQueryParam(param.key)) {   
                // param already exists but value not null
                if(uri.getQueryParamValue(param.key) !== param.value) {
                      // param not the same - update it
@@ -44,9 +44,13 @@ import Uri from 'jsuri';
 
 
    }
+   clearParams.map(param => {
+      // console.info('Deleting the following from the query ' + param.key + ' value with ' + param.value)
+      uri.deleteQueryParam(param) 
+   });
 
    // if anything has no value remove the url param for it
-   const removeEmpty = uri.queryPairs.filter(query => query[1] === "");
+   const removeEmpty = uri.queryPairs.filter(query => query[1] === ""); 
    removeEmpty.map(emptyQuery => uri.deleteQueryParam(emptyQuery[0]))
 
    // console.log(uri.toString());

--- a/src/library/structure/Searchbar/Searchbar.tsx
+++ b/src/library/structure/Searchbar/Searchbar.tsx
@@ -30,7 +30,7 @@ const Searchbar: React.FC<SearchbarProps> = ({placeholder, isLight, isLarge, sea
       let keyValueFormat = Object.keys(submitParams).map(function(key) {
           return {key, value: submitParams[key]};
       })
-      handleParams(postTo, keyValueFormat);
+      handleParams(postTo, keyValueFormat,["page"]);
     }
   }
 


### PR DESCRIPTION
Added in some code that used map to go through params to look for page param, and set to remove the page number from the search bar upon any changes to the search term. Also added in functionality to remove page numbers when changing search filters in news items or searching for different news items. 

To test in story book
comment out line 19 in url-helpers.js then open up examples--search-results change to another page and then change the default search term to something else and the page number should be deleted in the url bar. once happy then open up example-news-article-list and again move to a new page, then check the following remove the page numbers from the url, changing the sort by list, unticking an article type and changing the dropdown for the services