### PR TITLE
Featured news articles display in lines of no more than 3

### DIFF
--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.styles.js
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.styles.js
@@ -98,13 +98,17 @@ export const ArticleContainer = styled.a`
   @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
     width: 100%;
     margin-right: 30px;
-    margin-bottom: 0px;
+    margin-bottom: 20px;
     display: block;
     flex: 1;
     max-width: 50%;
+    min-width: 30%;
 
     &:nth-of-type(2n) {
         margin-right: 30px;
+    }
+    &:nth-of-type(3n) {
+        margin-right: 0;
     }
     &:last-of-type {
         margin-right: 0;

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlockData.js
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlockData.js
@@ -27,6 +27,36 @@ export const newsArticleData = {
       "image720x405": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/1440/810/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
       "image72x41": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/144/81/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
       "imageAltText": "The alt text"
+    },
+    {
+      "id": "6036694ed3c1de9114024a02",
+      "url": "/",
+      "title": "Vestibulum et enim quam. Praesent congue lacinia tellus ut posuere. Cras.",
+      "excerpt": "Cillum occaecat eiusmod pariatur cillum Lorem sunt pariatur proident aliquip pariatur aute nostrud. Veniam aliqua qui id consectetur sit incididunt. Sint non voluptate adipisicing anim. Amet tempor id in adipisicing sunt. Aliquip dolore ipsum occaecat officia anim aliqua minim consequat Lorem ipsum.\r\n",
+      "date": 1614178638,
+      "image720x405": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/1440/810/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
+      "image72x41": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/144/81/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
+      "imageAltText": "The alt text"
+    },
+    {
+      "id": "6036694ed3c1de9114024a02",
+      "url": "/",
+      "title": "Donec at pharetra libero. Etiam varius finibus magna at hendrerit. Cras.",
+      "excerpt": "Cillum occaecat eiusmod pariatur cillum Lorem sunt pariatur proident aliquip pariatur aute nostrud. Veniam aliqua qui id consectetur sit incididunt. Sint non voluptate adipisicing anim. Amet tempor id in adipisicing sunt. Aliquip dolore ipsum occaecat officia anim aliqua minim consequat Lorem ipsum.\r\n",
+      "date": 1614178638,
+      "image720x405": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/1440/810/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
+      "image72x41": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/144/81/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
+      "imageAltText": "The alt text"
+    },
+    {
+      "id": "6036694ed3c1de9114024a02",
+      "url": "/",
+      "title": "Phasellus ut lacus aliquet velit placerat aliquam. Fusce pretium ligula ante.",
+      "excerpt": "Cillum occaecat eiusmod pariatur cillum Lorem sunt pariatur proident aliquip pariatur aute nostrud. Veniam aliqua qui id consectetur sit incididunt. Sint non voluptate adipisicing anim. Amet tempor id in adipisicing sunt. Aliquip dolore ipsum occaecat officia anim aliqua minim consequat Lorem ipsum.\r\n",
+      "date": 1614178638,
+      "image720x405": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/1440/810/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
+      "image72x41": "https://core-cms.bfi.org.uk/sites/default/files/styles/responsive/public/144/81/1/2020-08/bfi-film-academy-2020-recruitment-campaign-watershed-two-girls-behind-camera.jpeg",
+      "imageAltText": "The alt text"
     }
   ]
 }


### PR DESCRIPTION
Upped the minimum size of a featured news article in the featured news block to be a little less than 1/3rd of the width so no more than 3 appear in one line. Demo page now has 6 news articles rather than 3 to demonstrate.

Related backend PR: https://github.com/FutureNorthants/northants-website/pull/147