### PR TITLE
Update Accordion signifiers

### DIFF
--- a/src/library/slices/Accordion/Accordion.stories.tsx
+++ b/src/library/slices/Accordion/Accordion.stories.tsx
@@ -1,9 +1,8 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import Accordion from "./Accordion";
-import { AccordionProps } from "./Accordion.types";
-import Divider from "./../Divider/Divider";
+import Accordion from './Accordion';
+import { AccordionProps } from './Accordion.types';
+import Divider from './../Divider/Divider';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 
 export default {
@@ -12,120 +11,218 @@ export default {
   parameters: {
     status: {
       type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-    }
+    },
   },
 };
 
-const Template: Story<AccordionProps> = (args) => <SBPadding><Accordion {...args} /></SBPadding>;
+const Template: Story<AccordionProps> = (args) => (
+  <SBPadding>
+    <Accordion {...args} />
+  </SBPadding>
+);
 
-export const ExampleAccordion = Template.bind({});    
+export const ExampleAccordion = Template.bind({});
 ExampleAccordion.args = {
   sections: [
     {
-      title: "Tortor Magna",
-      content: <p><strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
+      title: 'Tortor Magna',
+      content: (
+        <p>
+          <strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
     },
     {
-      title: "Fusce Risus Malesuada",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
-    }
-  ]
+      title: 'Fusce Risus Malesuada',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+    },
+  ],
 };
 
+export const AccordionWithoutReadMore = Template.bind({});
+AccordionWithoutReadMore.args = {
+  withReadMore: false,
+  sections: [
+    {
+      title: 'Tortor Magna',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+    },
+    {
+      title: 'Fusce Risus Malesuada',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+    },
+  ],
+};
 
-export const ExampleAccordionWithSummary = Template.bind({});    
+export const ExampleAccordionWithSummary = Template.bind({});
 ExampleAccordionWithSummary.args = {
   sections: [
     {
-      title: "Tortor Magna",
-      summary: "Purus Tristique Sem Ornare Inceptos",
-      content: <p><strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
+      title: 'Tortor Magna',
+      summary: 'Purus Tristique Sem Ornare Inceptos',
+      content: (
+        <p>
+          <strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
     },
     {
-      title: "Fusce Risus Malesuada",
-      summary: "Tortor Ultricies Nullam Malesuada Pellentesque",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
-    }
-  ]
+      title: 'Fusce Risus Malesuada',
+      summary: 'Tortor Ultricies Nullam Malesuada Pellentesque',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+    },
+  ],
 };
 
-
-export const ExampleAccordionExpanded = Template.bind({});    
+export const ExampleAccordionExpanded = Template.bind({});
 ExampleAccordionExpanded.args = {
   sections: [
     {
-      title: "Tortor Magna",
-      summary: "Purus Tristique Sem Ornare Inceptos",
-      content: <p><strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>,
-      isExpanded: true
+      title: 'Tortor Magna',
+      summary: 'Purus Tristique Sem Ornare Inceptos',
+      content: (
+        <p>
+          <strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+      isExpanded: true,
     },
     {
-      title: "Fusce Risus Malesuada",
-      summary: "Tortor Ultricies Nullam Malesuada Pellentesque",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
+      title: 'Fusce Risus Malesuada',
+      summary: 'Tortor Ultricies Nullam Malesuada Pellentesque',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
     },
     {
-      title: "Tortor Magna",
-      summary: "Purus Tristique Sem Ornare Inceptos",
-      content: <p><strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>,
-      isExpanded: false
+      title: 'Tortor Magna',
+      summary: 'Purus Tristique Sem Ornare Inceptos',
+      content: (
+        <p>
+          <strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+      isExpanded: false,
     },
     {
-      title: "Fusce Risus Malesuada",
-      summary: "Tortor Ultricies Nullam Malesuada Pellentesque",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>,
-      isExpanded: true
-    }
-  ]
+      title: 'Fusce Risus Malesuada',
+      summary: 'Tortor Ultricies Nullam Malesuada Pellentesque',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+      isExpanded: true,
+    },
+  ],
 };
 
-
-
-export const ExampleAccordionWithSlices = Template.bind({});    
+export const ExampleAccordionWithSlices = Template.bind({});
 ExampleAccordionWithSlices.args = {
   sections: [
     {
-      title: "Tortor Magna",
-      summary: "Purus Tristique Sem Ornare Inceptos",
-      content: <><p><strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. <Divider /> Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p></>,
-      isExpanded: true
+      title: 'Tortor Magna',
+      summary: 'Purus Tristique Sem Ornare Inceptos',
+      content: (
+        <>
+          <p>
+            <strong>Maecenas faucibus mollis interdum.</strong> Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+            venenatis vestibulum. <Divider /> Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra
+            augue.
+          </p>
+        </>
+      ),
+      isExpanded: true,
     },
     {
-      title: "Fusce Risus Malesuada",
-      summary: "Tortor Ultricies Nullam Malesuada Pellentesque",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>,
-      isExpanded: true
-    }
-  ]
+      title: 'Fusce Risus Malesuada',
+      summary: 'Tortor Ultricies Nullam Malesuada Pellentesque',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+      isExpanded: true,
+    },
+  ],
 };
 
-
-
-
-export const ExampleSingleAccordion = Template.bind({});    
+export const ExampleSingleAccordion = Template.bind({});
 ExampleSingleAccordion.args = {
   sections: [
     {
-      title: "Tortor Magna",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
-    }
-  ]
+      title: 'Tortor Magna',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+    },
+  ],
 };
 
-export const ExampleLongTitleAccordion = Template.bind({});    
+export const ExampleLongTitleAccordion = Template.bind({});
 ExampleLongTitleAccordion.args = {
   sections: [
     {
-      title: "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.",
-      content: <p><h2>Cras justo odio</h2>, dapibus ac facilisis in, <strong>egestas eget quam.</strong> Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod.</p>
+      title: 'Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.',
+      content: (
+        <p>
+          <h2>Cras justo odio</h2>, dapibus ac facilisis in, <strong>egestas eget quam.</strong> Fusce dapibus, tellus
+          ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Maecenas faucibus
+          mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Praesent commodo
+          cursus magna, vel scelerisque nisl consectetur et. Donec ullamcorper nulla non metus auctor fringilla. Etiam
+          porta sem malesuada magna mollis euismod.
+        </p>
+      ),
     },
     {
-      title: "Tortor Magna",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
+      title: 'Tortor Magna',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
     },
     {
-      title: "Fusce Risus Malesuada",
-      content: <p>Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.</p>
-    }
-  ]
+      title: 'Fusce Risus Malesuada',
+      content: (
+        <p>
+          Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+        </p>
+      ),
+    },
+  ],
 };

--- a/src/library/slices/Accordion/Accordion.styles.js
+++ b/src/library/slices/Accordion/Accordion.styles.js
@@ -170,14 +170,14 @@ export const AccordionIcon = styled.span`
 
   &:before {
     border-style: solid;
-    border-width: 6px 6px 0 0;
+    border-width: 4px 4px 0 0;
     content: '';
     display: inline-block;
-    height: 16px;
+    height: 12px;
     position: relative;
     vertical-align: top;
-    width: 16px;
-    border-color: ${(props) => props.theme.theme_vars.colours.action};
+    width: 12px;
+    border-color: ${(props) => props.theme.theme_vars.colours.black};
     top: 0;
     left: 6px;
     transform: rotate(135deg);

--- a/src/library/slices/Accordion/Accordion.styles.js
+++ b/src/library/slices/Accordion/Accordion.styles.js
@@ -1,232 +1,225 @@
-import styled, { css } from "styled-components";
+import styled, { css } from 'styled-components';
 
 // Accordion
 
 export const Container = styled.div`
-  ${props => props.theme.fontStyles}
+  ${(props) => props.theme.fontStyles}
   margin-bottom: 20px;
-  border-bottom: 1px solid ${props => props.theme.theme_vars.colours.grey};
+  border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey};
 
   @media (min-width: 40.0625em) {
-        margin-bottom: 30px
+    margin-bottom: 30px;
   }
-`
+`;
 
 export const AccordionControls = styled.div`
-    text-align: right;
-`
+  text-align: right;
+`;
 
 export const OpenAllButton = styled.button`
-    font-size: ${props => props.theme.theme_vars.fontSizes.extra_small};
-    position: relative;
-    z-index: 1;
-    margin: 0;
-    margin-bottom: 15px;
-    padding: 0;
-    border-width: 0;
-    color: ${props => props.theme.theme_vars.colours.action};
-    background: none;
-    cursor: pointer;
-    &:hover {
-        ${props => props.theme.linkStylesHover};
-    }
-    &:focus {
-        ${props => props.theme.linkStylesFocus};
-    }
-    &:active {
-        ${props => props.theme.linkStylesActive};
-    }
-`
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.extra_small};
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+  border-width: 0;
+  color: ${(props) => props.theme.theme_vars.colours.action};
+  background: none;
+  cursor: pointer;
+  &:hover {
+    ${(props) => props.theme.linkStylesHover};
+  }
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus};
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive};
+  }
+`;
 
 export const VisuallyHidden = styled.span`
-    ${props => props.theme.visuallyHidden}
-`
+  ${(props) => props.theme.visuallyHidden}
+`;
 
 // AccordionSection
 
 export const Section = styled.div`
   padding-top: 0;
-`
+`;
 
 export const SectionHeader = styled.div`
-    ${props => props.theme.headingStyles}
-    position: relative;
-    padding-right: 40px;
-    border-top: 1px solid ${props => props.theme.theme_vars.colours.grey};
-    color: ${props => props.theme.theme_vars.colours.action};
-    cursor: pointer;
-    padding-bottom: 15px;
+  ${(props) => props.theme.headingStyles}
+  position: relative;
+  padding-right: 40px;
+  border-top: 1px solid ${(props) => props.theme.theme_vars.colours.grey};
+  color: ${(props) => props.theme.theme_vars.colours.action};
+  cursor: pointer;
+  padding-bottom: 15px;
 
-    &:hover {
-        border-top-color: ${props => props.theme.theme_vars.colours.action};
-        -webkit-box-shadow: inset 0 2px 0 0 ${props => props.theme.theme_vars.colours.action};
-        box-shadow: inset 0 2px 0 0 ${props => props.theme.theme_vars.colours.action}
-    }
-`
+  &:hover {
+    border-top-color: ${(props) => props.theme.theme_vars.colours.action};
+    -webkit-box-shadow: inset 0 2px 0 0 ${(props) => props.theme.theme_vars.colours.action};
+    box-shadow: inset 0 2px 0 0 ${(props) => props.theme.theme_vars.colours.action};
+  }
+`;
 
 export const SectionHeading = styled.div`
-    margin-top: 10px;
-    margin-bottom: 5px;
-`
+  margin-top: 10px;
+  margin-bottom: 5px;
+`;
 
-
-const SectionButtonIsFilteredStyles = props => {
-    if(props.isFilter) {
-        return css`
-            ${props => props.theme.theme_vars.h4}
-        `
-    } else {
-        return css`
-            ${props => props.theme.theme_vars.h3}
-        `
-    }
-}
-
+const SectionButtonIsFilteredStyles = (props) => {
+  if (props.isFilter) {
+    return css`
+      ${(props) => props.theme.theme_vars.h4}
+    `;
+  } else {
+    return css`
+      ${(props) => props.theme.theme_vars.h3}
+    `;
+  }
+};
 
 export const SectionButton = styled.button`
-    display: inline-block;
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-left: 0;
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding: 0;
+  border-width: 0;
+  color: inherit;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  -webkit-appearance: none;
+  text-decoration: underline;
+
+  ${SectionButtonIsFilteredStyles}
+
+  &:focus {
+    outline: 3px solid transparent;
+    color: ${(props) => props.theme.theme_vars.colours.black};
+    background-color: ${(props) => props.theme.theme_vars.colours.focus};
+    -webkit-box-shadow: 0 -2px ${(props) => props.theme.theme_vars.colours.focus},
+      0 4px ${(props) => props.theme.theme_vars.colours.black};
+    box-shadow: 0 -2px ${(props) => props.theme.theme_vars.colours.focus},
+      0 4px ${(props) => props.theme.theme_vars.colours.black};
+    text-decoration: none;
+  }
+
+  &::-moz-focus-inner {
     padding: 0;
-    border-width: 0;
-    color: inherit;
-    background: none;
-    text-align: left;
-    cursor: pointer;
-    -webkit-appearance: none;
+    border: 0;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+
+  &:hover:not(:focus) {
     text-decoration: underline;
+    text-decoration-style: dotted;
+  }
 
-    ${SectionButtonIsFilteredStyles}
-
-    &:focus {
-        outline: 3px solid transparent;
-        color: ${props => props.theme.theme_vars.colours.black};
-        background-color: ${props => props.theme.theme_vars.colours.focus};
-        -webkit-box-shadow: 0 -2px ${props => props.theme.theme_vars.colours.focus}, 0 4px ${props => props.theme.theme_vars.colours.black};
-        box-shadow: 0 -2px ${props => props.theme.theme_vars.colours.focus}, 0 4px ${props => props.theme.theme_vars.colours.black};
-        text-decoration: none
-    }
-
-    &::-moz-focus-inner {
-        padding: 0;
-        border: 0
-    }
-
-    &:after {
-    content: "";
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0
-    }
-
-    &:hover:not(:focus) {
-        text-decoration: underline;
-        text-decoration-style: dotted;
-    }
-
-    &:hover {
-        text-decoration: none;
-    }
-`
+  &:hover {
+    text-decoration: none;
+  }
+`;
 
 export const ReadMore = styled.button`
-    ${props => props.theme.linkStyles}
-    background: none;
-    border: none;
-    margin-top: 15px;
-    margin-bottom: 10px;
-    padding: 0;
-    font-size: ${props => props.theme.theme_vars.fontSizes.extra_small}; 
-`
+  ${(props) => props.theme.linkStyles}
+  background: none;
+  border: none;
+  margin-top: 15px;
+  margin-bottom: 10px;
+  padding: 0;
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.extra_small};
+`;
 export const ShowLessButton = styled.button`
-    ${props => props.theme.linkStyles}
-    background: none;
-    border: none;
-    margin-top: 15px;
-    padding: 0;
-    font-size: ${props => props.theme.theme_vars.fontSizes.extra_small}; 
-    cursor: pointer;
-    
-    &:hover {
-        ${props => props.theme.linkStylesHover}
-    }
-    &:focus {
-        ${props => props.theme.linkStylesFocus}
-    }
-    &:active {
-        ${props => props.theme.linkStylesActive}
-    }
-`
+  ${(props) => props.theme.linkStyles}
+  background: none;
+  border: none;
+  margin-top: 15px;
+  padding: 0;
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.extra_small};
+  cursor: pointer;
 
+  &:hover {
+    ${(props) => props.theme.linkStylesHover}
+  }
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus}
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
+  }
+`;
 
 export const AccordionIcon = styled.span`
-    position: absolute;
-    top: 50%;
-    right: 15px;
-    width: 16px;
+  position: absolute;
+  top: 22px;
+  right: 4px;
+  width: 34px;
+  height: 32px;
+
+  &:before {
+    border-style: solid;
+    border-width: 6px 6px 0 0;
+    content: '';
+    display: inline-block;
     height: 16px;
-    margin-top: -8px;
+    position: relative;
+    vertical-align: top;
+    width: 16px;
+    border-color: ${(props) => props.theme.theme_vars.colours.action};
+    top: 0;
+    left: 6px;
+    transform: rotate(135deg);
+  }
 
-    &:after,
-    &:before {
-    content: "";
-        -webkit-box-sizing: border-box;
-        box-sizing: border-box;
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        width: 25%;
-        height: 25%;
-        margin: auto;
-        border: 2px solid transparent;
-        background-color: ${props => props.theme.theme_vars.colours.black};
+  &:before {
+    .accordion__section--expanded & {
+      transform: rotate(-45deg);
+      top: 10px;
     }
-
-    &:before {
-        width: 100%;
-    }
-
-    &:after {
-        height: 100%;
-
-        .accordion__section--expanded & {
-            content: " ";
-            display: none;
-        }
-    }
-`
+  }
+`;
 
 export const SectionSummary = styled.div`
-    margin-top: 10px;
-    margin-bottom: 0;
-    color: ${props => props.theme.theme_vars.colours.black};
-`
+  margin-top: 10px;
+  margin-bottom: 0;
+  color: ${(props) => props.theme.theme_vars.colours.black};
+`;
 
 export const SectionContent = styled.div`
-    display: none;
-    padding-top: 5px;
-    padding-bottom: 15px;
+  display: none;
+  padding-top: 5px;
+  padding-bottom: 15px;
 
-    h2, h3, h4, h5 {
-        &:first-child {
-            margin-top: 0;
-        }
+  h2,
+  h3,
+  h4,
+  h5 {
+    &:first-child {
+      margin-top: 0;
     }
+  }
 
-    @media (min-width: 40.0625em) {
-        padding-bottom: 25px
-    }
+  @media (min-width: 40.0625em) {
+    padding-bottom: 25px;
+  }
 
-    >:last-child {
-        margin-bottom: 0
-    }
+  > :last-child {
+    margin-bottom: 0;
+  }
 
-    .accordion__section--expanded & {
-        display: block;
-    }
-`
+  .accordion__section--expanded & {
+    display: block;
+  }
+`;

--- a/src/library/slices/Accordion/Accordion.types.ts
+++ b/src/library/slices/Accordion/Accordion.types.ts
@@ -8,6 +8,7 @@ export interface AccordionProps {
    * We reuse this on filter pages - but it looks slightly different
    */
   isFilter?: boolean;
+
   /**
    * Should there be a read more link at the bottom of each section?
    */
@@ -31,7 +32,7 @@ export interface AccordionSectionProps {
   summary?: string;
 
   /**
-   * Section summary
+   * Is the section expanded
    */
   isExpanded?: boolean;
 
@@ -41,12 +42,12 @@ export interface AccordionSectionProps {
   accordionSectionId?: number;
 
   /**
-   * Method used internally for opening closing eelment
+   * Method used internally for opening closing element
    */
   onToggle?: (title, value) => void;
 
   /**
-   * We reuse this on filter pages - but it looks slightly different
+   * We reuse this on filter pages where the section buttons have h4 styles, instead of h3 styles
    */
   isFilter?: boolean;
 

--- a/src/library/slices/Accordion/Accordion.types.ts
+++ b/src/library/slices/Accordion/Accordion.types.ts
@@ -1,4 +1,3 @@
-
 export interface AccordionProps {
   /**
    * accepts multiple sections
@@ -13,44 +12,51 @@ export interface AccordionProps {
    * Should there be a read more link at the bottom of each section?
    */
   withReadMore?: boolean;
-    
 }
 
 export interface AccordionSectionProps {
   /**
    * Section title
    */
-  title: string,
+  title: string;
+
   /**
    * Section content
    */
-  content: React.ReactNode
+  content: React.ReactNode;
+
   /**
    * Section summary
    */
-  summary?: string,
+  summary?: string;
+
   /**
    * Section summary
    */
-  isExpanded?: boolean,
+  isExpanded?: boolean;
+
   /**
    * Identify the section so sections can have the same title
    */
-  accordionSectionId?: number,
+  accordionSectionId?: number;
+
   /**
    * Method used internally for opening closing eelment
    */
-  onToggle?: ((title, value) => void)
+  onToggle?: (title, value) => void;
+
   /**
    * We reuse this on filter pages - but it looks slightly different
    */
   isFilter?: boolean;
-   /**
+
+  /**
    * Should there be a read more link at the bottom of each section?
    */
   withReadMore?: boolean;
+
   /**
    * unique ID for the section
    */
-   sectionId?: string
-} 
+  sectionId?: string;
+}

--- a/src/library/slices/Accordion/AccordionSection.tsx
+++ b/src/library/slices/Accordion/AccordionSection.tsx
@@ -1,41 +1,55 @@
+import React from 'react';
+import { AccordionSectionProps } from './Accordion.types';
+import * as Styles from './Accordion.styles';
+import { uniqueID } from './../../helpers/helpers';
 
-import React from "react";
-import { AccordionSectionProps } from "./Accordion.types";
-import * as Styles from "./Accordion.styles";
-import { uniqueID } from './../../helpers/helpers'; 
+const AccordionSection: React.FunctionComponent<AccordionSectionProps> = ({
+  title,
+  content,
+  summary,
+  isExpanded,
+  accordionSectionId,
+  onToggle,
+  isFilter = false,
+  withReadMore,
+  sectionId = false,
+}) => {
+  const onSectionToggle = () =>
+    isExpanded === true ? onToggle(accordionSectionId, false) : onToggle(accordionSectionId, true);
+  const thisSectionId = sectionId === false ? `accordion_section${uniqueID()}` : sectionId;
+  return (
+    <Styles.Section id={thisSectionId} className={isExpanded && 'accordion__section--expanded'}>
+      <Styles.SectionHeader onClick={onSectionToggle}>
+        <Styles.SectionHeading as={isFilter ? 'h3' : 'h2'}>
+          <Styles.SectionButton
+            title={isExpanded ? 'Minimise ' + title : title}
+            isFilter={isFilter}
+            type="button"
+            id={`${thisSectionId}_${accordionSectionId}-heading`}
+            aria-controls={`${thisSectionId}_${accordionSectionId}-content`}
+            aria-expanded={isExpanded ? 'true' : 'false'}
+          >
+            {title}
+            <Styles.AccordionIcon aria-hidden="true"></Styles.AccordionIcon>
+          </Styles.SectionButton>
+        </Styles.SectionHeading>
 
-const AccordionSection: React.FC<AccordionSectionProps> = ({ title, content, summary, isExpanded, accordionSectionId, onToggle, isFilter = false, withReadMore, sectionId = false }) => {
-    const onSectionToggle = () => (isExpanded === true) ? onToggle(accordionSectionId, false) : onToggle(accordionSectionId, true);
-    const thisSectionId = (sectionId === false) ? `accordion_section${uniqueID()}` : sectionId ;
-    return (
-            <Styles.Section id={thisSectionId} className={isExpanded && "accordion__section--expanded"}>
-                <Styles.SectionHeader onClick={onSectionToggle}>
-                    
-                    <Styles.SectionHeading as={isFilter ? "h3" : "h2"}>
-                        <Styles.SectionButton title={isExpanded ? "Minimise "+ title : title} isFilter={isFilter} type="button" id={`${thisSectionId}_${accordionSectionId}-heading`} aria-controls={`${thisSectionId}_${accordionSectionId}-content`} aria-expanded={isExpanded ? "true" : "false"}>
-                          {title}
-                          <Styles.AccordionIcon aria-hidden="true"></Styles.AccordionIcon>
-                        </Styles.SectionButton>
-                    </Styles.SectionHeading>
-
-                    {summary && 
-                        <Styles.SectionSummary id={`${thisSectionId}_${accordionSectionId}-summary`}>
-                            {summary}
-                        </Styles.SectionSummary>
-                    }
-                    {!isExpanded && withReadMore && 
-                        <Styles.ReadMore title={"Read more about " + title}>Read more</Styles.ReadMore>
-                    }
-                </Styles.SectionHeader>
-                <Styles.SectionContent id={`${thisSectionId}_${accordionSectionId}-content`} aria-labelledby={`${thisSectionId}_${accordionSectionId}-heading`}>
-                    {content}
-                    {isExpanded && withReadMore && 
-                        <Styles.ShowLessButton onClick={onSectionToggle}>Show less</Styles.ShowLessButton>
-                    }
-                </Styles.SectionContent>
-                
-            </Styles.Section>
-    );
+        {summary && (
+          <Styles.SectionSummary id={`${thisSectionId}_${accordionSectionId}-summary`}>{summary}</Styles.SectionSummary>
+        )}
+        {!isExpanded && withReadMore && <Styles.ReadMore title={'Read more about ' + title}>Read more</Styles.ReadMore>}
+      </Styles.SectionHeader>
+      <Styles.SectionContent
+        id={`${thisSectionId}_${accordionSectionId}-content`}
+        aria-labelledby={`${thisSectionId}_${accordionSectionId}-heading`}
+      >
+        {content}
+        {isExpanded && withReadMore && (
+          <Styles.ShowLessButton onClick={onSectionToggle}>Show less</Styles.ShowLessButton>
+        )}
+      </Styles.SectionContent>
+    </Styles.Section>
+  );
 };
 
 export default AccordionSection;


### PR DESCRIPTION
- Update accordion signifiers to chevrons instead of plus and minus (using [css borders](https://codepen.io/stepher/pen/yLOaEOP))
- Add story to show without the read more links `withReadMore: false`
- Prettier formatting

To test, run `npm run test Accordion`.

[Preview here](https://deploy-preview-99--northants-design-system.netlify.app/?path=/story/library-slices-accordion--accordion-without-read-more)