### PR TITLE
Prevent max height when header is hidden

### DIFF
--- a/src/library/structure/ServicesLinksList/ServicesLinksList.styles.js
+++ b/src/library/structure/ServicesLinksList/ServicesLinksList.styles.js
@@ -1,10 +1,23 @@
 import styled, { css } from 'styled-components';
 import Heading from '../../components/Heading/Heading';
 
+const containerMaxHeight = (props) => {
+  if (props.hideHeader) {
+    return css`
+      max-height: none;
+      overflow: visible;
+    `;
+  } else {
+    return css`
+      max-height: 385px;
+      overflow: hidden;
+    `;
+  }
+};
+
 export const Container = styled.div`
   ${(props) => props.theme.fontStyles}
-  max-height: 385px;
-  overflow: hidden;
+  ${containerMaxHeight}
 
   &.open {
     max-height: none;

--- a/src/library/structure/ServicesLinksList/ServicesLinksList.test.tsx
+++ b/src/library/structure/ServicesLinksList/ServicesLinksList.test.tsx
@@ -100,4 +100,17 @@ describe('Services Links List', () => {
     expect(queryByText('Most used')).toBeNull();
     expect(queryByText('Alphabetical')).toBeNull();
   });
+
+  it('should hide the view more/less services button', () => {
+    const customProps = { ...props, ...{ hideHeader: true } };
+    const renderComponent = () =>
+      render(
+        <ThemeProvider theme={west_theme}>
+          <ServicesLinksList {...customProps} />
+        </ThemeProvider>
+      );
+    const { queryByText } = renderComponent();
+    expect(queryByText('View more services')).toBeNull();
+    expect(queryByText('View less services')).toBeNull();
+  });
 });

--- a/src/library/structure/ServicesLinksList/ServicesLinksList.tsx
+++ b/src/library/structure/ServicesLinksList/ServicesLinksList.tsx
@@ -44,7 +44,7 @@ const ServicesLinksList: React.FunctionComponent<ServicesLinksListProps> = ({
 
   return (
     <>
-      <Styles.Container id={serviceId} className={open && 'open'}>
+      <Styles.Container id={serviceId} className={open && 'open'} hideHeader={hideHeader}>
         {!hideHeader && (
           <Styles.HomeTitle data-testid="servicesLinksListHeader">
             <Heading text="Council services" />


### PR DESCRIPTION
There is a max height set on mobile and a view more button appears, but the view more button only appears if `hideHeader == true`. Top Services hides the header so the view more button doesn't appear and the max-height is applied, cutting the content.

It now passes hideHeader to the Container styles. If it's true it will not set a max height. 

If the header isn't hidden, then the view more button will appear and the max-height will be applied on mobile.