### PR TITLE
Make AlertBannerService title optional

### DIFF
--- a/src/library/structure/AlertBannerService/AlertBannerService.stories.tsx
+++ b/src/library/structure/AlertBannerService/AlertBannerService.stories.tsx
@@ -1,36 +1,80 @@
-
-import React from "react";
-import AlertBannerService from "./AlertBannerService";
-import { AlertBannerServiceProps } from "./AlertBannerService.types";
+import React from 'react';
+import AlertBannerService from './AlertBannerService';
+import { AlertBannerServiceProps } from './AlertBannerService.types';
 import { Story } from '@storybook/react/types-6-0';
-import MaxWidthContainer from "../MaxWidthContainer/MaxWidthContainer";
-import PageMain from "../PageMain/PageMain";
+import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
+import PageMain from '../PageMain/PageMain';
 
 export default {
-    title: 'Library/structure/Alert banner service level (secondary)',
-    component: AlertBannerService,
-    parameters: {
-      status: {
-        type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      }
+  title: 'Library/structure/Alert banner service level (secondary)',
+  component: AlertBannerService,
+  parameters: {
+    status: {
+      type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
     },
+  },
 };
 
-const Template: Story<AlertBannerServiceProps> = (args) => <MaxWidthContainer><AlertBannerService {...args}><p>Children of the page container goes here</p><p>There should probably be some sort of <a href="#">Call to action</a></p></AlertBannerService></MaxWidthContainer>;
-const TemplateIE: Story<AlertBannerServiceProps> = (args) => <PageMain><MaxWidthContainer><AlertBannerService {...args}>
-      <p>It looks like you are using an out of date version of Internet Explorer. Using this browser will mean that certain features of this website will not work. It also means you are vulnerable to security exploits. <strong>Microsoft will no longer support Internet Explorer from August 17th 2021.</strong></p>
-      <p>We recommend that you use a modern up to date and secure browser to view this and all other websites. Download and install a new browser:</p>
-      <ul>
-        <li><a href="https://www.microsoft.com/en-us/edge" title="Download and install Edge">Microsoft Edge</a></li>
-        <li><a href="https://www.google.co.uk/chrome/" title="Download and install Chrome">Google Chrome</a></li>
-        <li><a href="https://www.mozilla.org/en-GB/firefox/new/" title="Download and install Firefox">Mozilla Firefox</a></li>
-        <li><a href="https://www.apple.com/uk/safari/" title="Download and install Safari">Apple Safari</a></li>
-      </ul>
-    </AlertBannerService></MaxWidthContainer></PageMain>;
+const Template: Story<AlertBannerServiceProps> = (args) => (
+  <PageMain>
+    <MaxWidthContainer>
+      <AlertBannerService {...args}>
+        <p>Children of the page container goes here</p>
+        <p>
+          There should probably be some sort of <a href="#">Call to action</a>
+        </p>
+      </AlertBannerService>
+    </MaxWidthContainer>
+  </PageMain>
+);
+const TemplateIE: Story<AlertBannerServiceProps> = (args) => (
+  <PageMain>
+    <MaxWidthContainer>
+      <AlertBannerService {...args}>
+        <p>
+          It looks like you are using an out of date version of Internet Explorer. Using this browser will mean that
+          certain features of this website will not work. It also means you are vulnerable to security exploits.{' '}
+          <strong>Microsoft will no longer support Internet Explorer from August 17th 2021.</strong>
+        </p>
+        <p>
+          We recommend that you use a modern up to date and secure browser to view this and all other websites. Download
+          and install a new browser:
+        </p>
+        <ul>
+          <li>
+            <a href="https://www.microsoft.com/en-us/edge" title="Download and install Edge">
+              Microsoft Edge
+            </a>
+          </li>
+          <li>
+            <a href="https://www.google.co.uk/chrome/" title="Download and install Chrome">
+              Google Chrome
+            </a>
+          </li>
+          <li>
+            <a href="https://www.mozilla.org/en-GB/firefox/new/" title="Download and install Firefox">
+              Mozilla Firefox
+            </a>
+          </li>
+          <li>
+            <a href="https://www.apple.com/uk/safari/" title="Download and install Safari">
+              Apple Safari
+            </a>
+          </li>
+        </ul>
+      </AlertBannerService>
+    </MaxWidthContainer>
+  </PageMain>
+);
 
 export const ExampleAlert = Template.bind({});
 ExampleAlert.args = {
   title: 'Title of alert',
+};
+
+export const ExampleAlertWithoutTitle = Template.bind({});
+ExampleAlertWithoutTitle.args = {
+  title: '',
 };
 
 export const ExampleIEWarning = TemplateIE.bind({});
@@ -41,17 +85,17 @@ ExampleIEWarning.args = {
 export const ExampleWarning = Template.bind({});
 ExampleWarning.args = {
   title: 'Title of alert',
-  alertType: "warning"
+  alertType: 'warning',
 };
 
 export const ExamplePositive = Template.bind({});
 ExamplePositive.args = {
   title: 'Title of alert',
-  alertType: "positive"
+  alertType: 'positive',
 };
 
 export const ExampleMemorial = Template.bind({});
 ExampleMemorial.args = {
   title: 'Title of alert',
-  alertType: "london_bridge"
+  alertType: 'london_bridge',
 };

--- a/src/library/structure/AlertBannerService/AlertBannerService.test.tsx
+++ b/src/library/structure/AlertBannerService/AlertBannerService.test.tsx
@@ -66,4 +66,19 @@ describe('Alert Service Banner', () => {
 
     expect(getByTestId('AlertBannerService')).toHaveStyle(`border-color: ${west_theme.theme_vars.colours.black}`);
   });
+
+  it('should not add a heading if title is empty', () => {
+    const renderComponent = () =>
+      render(
+        <ThemeProvider theme={west_theme}>
+          <AlertBannerService title="">
+            <p>This is some content.</p>
+          </AlertBannerService>
+        </ThemeProvider>
+      );
+
+    const { queryByRole } = renderComponent();
+
+    expect(queryByRole('heading')).toBeNull();
+  });
 });

--- a/src/library/structure/AlertBannerService/AlertBannerService.test.tsx
+++ b/src/library/structure/AlertBannerService/AlertBannerService.test.tsx
@@ -67,11 +67,26 @@ describe('Alert Service Banner', () => {
     expect(getByTestId('AlertBannerService')).toHaveStyle(`border-color: ${west_theme.theme_vars.colours.black}`);
   });
 
-  it('should not add a heading if title is empty', () => {
+  it('should not add a heading if title is empty string', () => {
     const renderComponent = () =>
       render(
         <ThemeProvider theme={west_theme}>
-          <AlertBannerService title="">
+          <AlertBannerService title="  ">
+            <p>This is some content.</p>
+          </AlertBannerService>
+        </ThemeProvider>
+      );
+
+    const { queryByRole } = renderComponent();
+
+    expect(queryByRole('heading')).toBeNull();
+  });
+
+  it('should not add a heading if title is not provided', () => {
+    const renderComponent = () =>
+      render(
+        <ThemeProvider theme={west_theme}>
+          <AlertBannerService>
             <p>This is some content.</p>
           </AlertBannerService>
         </ThemeProvider>

--- a/src/library/structure/AlertBannerService/AlertBannerService.tsx
+++ b/src/library/structure/AlertBannerService/AlertBannerService.tsx
@@ -13,7 +13,7 @@ const AlertBannerService: React.FunctionComponent<AlertBannerServiceProps> = ({
 }) => (
   <Styles.Container alertType={alertType} data-testid="AlertBannerService">
     <Styles.InnerContainer data-testid="AlertBannerServiceInner">
-      <Heading text={title} />
+      {title && <Heading text={title} />}
       {children}
     </Styles.InnerContainer>
   </Styles.Container>

--- a/src/library/structure/AlertBannerService/AlertBannerService.tsx
+++ b/src/library/structure/AlertBannerService/AlertBannerService.tsx
@@ -13,7 +13,7 @@ const AlertBannerService: React.FunctionComponent<AlertBannerServiceProps> = ({
 }) => (
   <Styles.Container alertType={alertType} data-testid="AlertBannerService">
     <Styles.InnerContainer data-testid="AlertBannerServiceInner">
-      {title && <Heading text={title} />}
+      {title?.trim() && <Heading text={title} />}
       {children}
     </Styles.InnerContainer>
   </Styles.Container>

--- a/src/library/structure/AlertBannerService/AlertBannerService.types.ts
+++ b/src/library/structure/AlertBannerService/AlertBannerService.types.ts
@@ -1,14 +1,16 @@
 export interface AlertBannerServiceProps {
   /**
-   * The title of this alert
+   * The optional title of this alert
    */
-  title: string;
-      /**
+  title?: string;
+
+  /**
    * The type of alert
    */
-  alertType?: "alert" | "warning" | "positive" | "london_bridge";  
+  alertType?: 'alert' | 'warning' | 'positive' | 'london_bridge';
+
   /**
-  * All children content for the banner
-  */
-   children: React.ReactNode
+   * All children content for the banner
+   */
+  children: React.ReactNode;
 }


### PR DESCRIPTION
If the title is not set, then it will not include the heading.

- Added story for alert without a title
- Added test to ensure heading is not included when title is empty

To test, run `npm run test AlertBannerService`