### PR TITLE
Added imageOverrideLogo to HomeHero, tests

### DIFF
--- a/src/library/structure/HomeHero/HomeHero.stories.tsx
+++ b/src/library/structure/HomeHero/HomeHero.stories.tsx
@@ -1,118 +1,74 @@
-import React from "react";
-import HomeHero from "./HomeHero";
-import { HomeHeroProps } from "./HomeHero.types";
+import React from 'react';
+import HomeHero from './HomeHero';
+import { HomeHeroProps } from './HomeHero.types';
 import { Story } from '@storybook/react/types-6-0';
+import { HomeHeroCommon, HomeHeroPromotedLinks } from './HomeHero.storydata';
 
 export default {
-    title: 'Library/structure/Home Hero',
-    component: HomeHero,
-    parameters: {
-      status: {
-        type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      }
+  title: 'Library/structure/Home Hero',
+  component: HomeHero,
+  parameters: {
+    status: {
+      type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
     },
+  },
+  argTypes: {
+    topline: {
+      table: { category: 'Banner area' },
+    },
+    imageOverrideLogo: {
+      table: { category: 'Banner area' },
+    },
+    strapline: {
+      table: { category: 'Banner area' },
+    },
+    imagesArray: {
+      table: { category: 'Hero images' },
+    },
+    promotedLinksArray: {
+      table: { category: 'Hero buttons' },
+    },
+    searchSuggestions: {
+      table: { category: 'Search' },
+    },
+  },
 };
 
 const Template: Story<HomeHeroProps> = (args) => <HomeHero {...args}></HomeHero>;
 
-export const HomeHeroExample = Template.bind({});
-
-const CommonArgs = {
-    searchSuggestions: ['Apple', 'Orange', 'Lemon', 'Pear', 'Peach', 'Kiwifruit is a hairy little fruit from China and this expands nicely to fit on other lines', 
-    'Killer tomato', 'Kinetic energy weapon', 'Kid gloves', 'Kiora', 'Kidderminster'],
-    imagesArray: [
-        {
-            image1440x810: "http://placehold.it/1440x810",
-            image144x81: "http://placehold.it/144x81"
-        },
-        {
-            image1440x810: "http://placehold.it/1340x810",
-            image144x81: "http://placehold.it/134x81"
-        },
-        {
-            image1440x810: "http://placehold.it/1240x810",
-            image144x81: "http://placehold.it/124x81"
-        },
-        {
-            image1440x810: "http://placehold.it/1140x810",
-            image144x81: "http://placehold.it/114x81"
-        }
-    ]
-}
-
-
-HomeHeroExample.args = {
-    promotedLinksArray: [
-        {
-            title: "Make a payment",
-            url: "/"
-        },
-        {
-            title: "Contact the council",
-            url: "/"
-        },
-        {
-            title: "About our new website",
-            url: "/"
-        }
-    ],
-    ...CommonArgs
+export const HomeHeroExample0Links = Template.bind({});
+HomeHeroExample0Links.args = {
+  promotedLinksArray: [],
+  ...HomeHeroCommon,
 };
-
 
 export const HomeHeroExample1Link = Template.bind({});
 HomeHeroExample1Link.args = {
-    promotedLinksArray: [
-        {
-            title: "Make a payment",
-            url: "/"
-        }
-    ],
-    ...CommonArgs
+  promotedLinksArray: HomeHeroPromotedLinks.slice(0, 1),
+  ...HomeHeroCommon,
 };
 
 export const HomeHeroExample2Links = Template.bind({});
 HomeHeroExample2Links.args = {
-    promotedLinksArray: [
-        {
-            title: "Coronavirus (COVID-19)",
-            url: "/"
-        },
-        {
-            title: "Make a payment",
-            url: "/"
-        }
-    ],
-    ...CommonArgs
+  promotedLinksArray: HomeHeroPromotedLinks.slice(0, 2),
+  ...HomeHeroCommon,
+};
+
+export const HomeHeroExample3Links = Template.bind({});
+HomeHeroExample3Links.args = {
+  promotedLinksArray: HomeHeroPromotedLinks.slice(0, 3),
+  ...HomeHeroCommon,
 };
 
 export const HomeHeroExample4Links = Template.bind({});
 HomeHeroExample4Links.args = {
-    promotedLinksArray: [
-        {
-            title: "Coronavirus (COVID-19)",
-            url: "/"
-        },
-        {
-            title: "Make a payment",
-            url: "/"
-        },
-        {
-            title: "Contact the council",
-            url: "/"
-        },
-        {
-            title: "About our new website",
-            url: "/"
-        }
-    ],
-    ...CommonArgs
+  promotedLinksArray: HomeHeroPromotedLinks.slice(0, 4),
+  ...HomeHeroCommon,
 };
 
-
-export const HomeHeroExample0Links = Template.bind({});
-HomeHeroExample0Links.args = {
-    promotedLinksArray: [
-    ],
-    ...CommonArgs
+export const HomeHeroExampleOverriddenLogo = Template.bind({});
+HomeHeroExampleOverriddenLogo.args = {
+  promotedLinksArray: HomeHeroPromotedLinks.slice(0, 4),
+  ...HomeHeroCommon,
+  imageOverrideLogo: 'http://placehold.it/520x150',
 };

--- a/src/library/structure/HomeHero/HomeHero.stories.tsx
+++ b/src/library/structure/HomeHero/HomeHero.stories.tsx
@@ -19,6 +19,9 @@ export default {
     imageOverrideLogo: {
       table: { category: 'Banner area' },
     },
+    imageOverrideLogoAltText: {
+      table: { category: 'Banner area' },
+    },
     strapline: {
       table: { category: 'Banner area' },
     },
@@ -71,4 +74,5 @@ HomeHeroExampleOverriddenLogo.args = {
   promotedLinksArray: HomeHeroPromotedLinks.slice(0, 4),
   ...HomeHeroCommon,
   imageOverrideLogo: 'http://placehold.it/520x150',
+  imageOverrideLogoAltText: 'My logo',
 };

--- a/src/library/structure/HomeHero/HomeHero.storydata.ts
+++ b/src/library/structure/HomeHero/HomeHero.storydata.ts
@@ -1,0 +1,56 @@
+/**
+ * Example data for the HomeHero stories
+ */
+
+export const HomeHeroCommon = {
+  searchSuggestions: [
+    'Apple',
+    'Orange',
+    'Lemon',
+    'Pear',
+    'Peach',
+    'Kiwifruit is a hairy little fruit from China and this expands nicely to fit on other lines',
+    'Killer tomato',
+    'Kinetic energy weapon',
+    'Kid gloves',
+    'Kiora',
+    'Kidderminster',
+  ],
+  imagesArray: [
+    {
+      image1440x810: 'http://placehold.it/1440x810',
+      image144x81: 'http://placehold.it/144x81',
+    },
+    {
+      image1440x810: 'http://placehold.it/1340x810',
+      image144x81: 'http://placehold.it/134x81',
+    },
+    {
+      image1440x810: 'http://placehold.it/1240x810',
+      image144x81: 'http://placehold.it/124x81',
+    },
+    {
+      image1440x810: 'http://placehold.it/1140x810',
+      image144x81: 'http://placehold.it/114x81',
+    },
+  ],
+};
+
+export const HomeHeroPromotedLinks = [
+  {
+    title: 'Covid-19',
+    url: '/',
+  },
+  {
+    title: 'Make a payment',
+    url: '/',
+  },
+  {
+    title: 'Contact the council',
+    url: '/',
+  },
+  {
+    title: 'About our new website',
+    url: '/',
+  },
+];

--- a/src/library/structure/HomeHero/HomeHero.styles.js
+++ b/src/library/structure/HomeHero/HomeHero.styles.js
@@ -1,19 +1,23 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Wrapper = styled.header`
-    background: ${props => props.noBackground ? "transparent" : 
-        props.theme.cardinal_name === "north" ?  (props.theme.theme_vars.colours.grey_light+"7a") : props.theme.theme_vars.colours.white};
-`
+  background: ${(props) =>
+    props.noBackground
+      ? 'transparent'
+      : props.theme.cardinal_name === 'north'
+      ? props.theme.theme_vars.colours.grey_light + '7a'
+      : props.theme.theme_vars.colours.white};
+`;
 
 export const Container = styled.div`
-    font-family: ${props => props.theme.theme_vars.fontstack};
+    font-family: ${(props) => props.theme.theme_vars.fontstack};
     overflow: hidden;
-    background: ${props => props.theme.theme_vars.colours.action}5A;
+    background: ${(props) => props.theme.theme_vars.colours.action}5A;
     padding: 30px 0;
     padding-bottom: 15px;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.s}){
-        background-image: url("${props => props.image}");
+    @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}){
+        background-image: url("${(props) => props.image}");
         background-size: cover;
         background-repeat: no-repeat;
         background-position: center;
@@ -22,73 +26,81 @@ export const Container = styled.div`
             background-image: none;
         }
     }
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.s}){
+    @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}){
         padding: 60px 0;
     }
-    @media screen and (min-width: calc(${props => props.theme.theme_vars.breakpoints.l} + 60px)){
+    @media screen and (min-width: calc(${(props) => props.theme.theme_vars.breakpoints.l} + 60px)){
         margin-right: auto;
         margin-left: auto;
         padding: 90px 0;
         max-width: 1680px;
     }
-`
+`;
 
 export const StyledMaxWidthContainer = styled.div`
-    ${props => props.theme.fontStyles}
+    ${(props) => props.theme.fontStyles}
     margin-right: 15px;
     margin-left: 15px;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
+    @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}){
         margin-right: 30px;
         margin-left: 30px;
     }
 
-    @media screen and (min-width: calc(${props => props.theme.theme_vars.breakpoints.l} + 60px)){
+    @media screen and (min-width: calc(${(props) => props.theme.theme_vars.breakpoints.l} + 60px)){
         margin-right: auto;
         margin-left: auto;
-        max-width: ${props => props.theme.theme_vars.breakpoints.l};
+        max-width: ${(props) => props.theme.theme_vars.breakpoints.l};
     }
-`
+`;
 export const HiddenH1 = styled.h1`
-    visibility: hidden;
-`
+  visibility: hidden;
+`;
 
 export const MainBox = styled.div`
-    padding: 30px;
-    background: ${props => props.theme.theme_vars.colours.white};
-    background: ${props => props.theme.theme_vars.colours.white}F2;
-    box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.11);
-    -webkit-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.11);
-    -moz-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.11);
-    border-radius: 5px;
+  padding: 30px;
+  background: ${(props) => props.theme.theme_vars.colours.white};
+  background: ${(props) => props.theme.theme_vars.colours.white}F2;
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.11);
+  -webkit-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.11);
+  -moz-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.11);
+  border-radius: 5px;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-        max-width: calc(50% - 60px);
-    }
-`
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    max-width: calc(50% - 60px);
+  }
+`;
 
 export const Topline = styled.p`
-    color: ${props => props.theme.theme_vars.colours.grey_dark};
-`
+  color: ${(props) => props.theme.theme_vars.colours.grey_dark};
+`;
 
 export const LogoColoured = styled.div`
+  svg {
+    margin-top: -45px;
+    max-width: 450px;
+    width: 95%;
+    height: auto;
+  }
+  &.black_logo {
     svg {
-        margin-top: -45px;
-        max-width: 450px;
-        width: 95%;
-        height: auto;
+      fill: black !important;
+      path {
+        fill: black !important;
+      }
     }
-    &.black_logo {
-        svg {
-            fill: black !important;
-            path {
-                fill: black !important;
-            }
-        }
-    }
-`
+  }
+`;
+
+export const LogoOverride = styled.div`
+  img {
+    margin-top: -45px;
+    max-width: 520px;
+    height: auto;
+  }
+`;
 
 export const Strapline = styled.p`
-    margin-bottom: 20px;
-    margin-top: -10px;
-`
+  margin-bottom: 20px;
+  margin-top: -10px;
+`;

--- a/src/library/structure/HomeHero/HomeHero.styles.js
+++ b/src/library/structure/HomeHero/HomeHero.styles.js
@@ -96,6 +96,7 @@ export const LogoOverride = styled.div`
   img {
     margin-top: -45px;
     max-width: 520px;
+    width: 100%;
     height: auto;
   }
 `;

--- a/src/library/structure/HomeHero/HomeHero.test.tsx
+++ b/src/library/structure/HomeHero/HomeHero.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { fireEvent, render, RenderResult } from '@testing-library/react';
+import HomeHero from './HomeHero';
+import { HomeHeroProps } from './HomeHero.types';
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
+import { HomeHeroCommon, HomeHeroPromotedLinks } from './HomeHero.storydata';
+
+describe('HomeHero common usage', () => {
+  const props: HomeHeroProps = {
+    promotedLinksArray: HomeHeroPromotedLinks.slice(0, 3),
+    ...HomeHeroCommon,
+  };
+
+  let rendered: RenderResult;
+
+  // run before each it() function, as otherwise things are cleaned up and subsequent it() calls go wrong
+  beforeEach(() => {
+    rendered = render(
+      <ThemeProvider theme={west_theme}>
+        <HomeHero {...props} />
+      </ThemeProvider>
+    );
+  });
+
+  it('should render 3 promoted links', () => {
+      console.log(typeof rendered);
+    const links = rendered.queryAllByRole('link');
+    expect(links).toHaveLength(3);
+
+    expect(links[0]).toHaveTextContent(HomeHeroPromotedLinks[0].title);
+    expect(links[0]).toHaveAttribute('href', HomeHeroPromotedLinks[0].url);
+    expect(links[1]).toHaveTextContent(HomeHeroPromotedLinks[1].title);
+    expect(links[1]).toHaveAttribute('href', HomeHeroPromotedLinks[1].url);
+    expect(links[2]).toHaveTextContent(HomeHeroPromotedLinks[2].title);
+    expect(links[2]).toHaveAttribute('href', HomeHeroPromotedLinks[2].url);
+  });
+
+  it('should include a search box with autocomplete and a search button', () => {
+    const search = rendered.getByRole('textbox');
+    expect(search).toHaveProperty('placeholder', 'Search the site');
+
+    const searchbutton = rendered.getByRole('button');
+    expect(searchbutton).toHaveValue('Search');
+
+    fireEvent.change(search, { target: { value: 'oran' } });
+    const listbox = rendered.getByRole('listbox');
+    expect(listbox).toBeVisible();
+    expect(listbox.children.length).toBe(1);
+  });
+
+  it('should not render an image tag', () => {
+    const images = rendered.queryAllByRole('img');
+    expect(images).toHaveLength(0);
+  });
+});
+
+describe('HomeHero unusual usage', () => {
+  const props: HomeHeroProps = {
+    imageOverrideLogo: 'http://placehold.it/520x150',
+    topline: 'To be on top',
+    strapline: 'Strap in',
+    promotedLinksArray: [],
+    ...HomeHeroCommon,
+  };
+
+  let rendered: RenderResult;
+
+  beforeEach(() => {
+    rendered = render(
+      <ThemeProvider theme={west_theme}>
+        <HomeHero {...props} />
+      </ThemeProvider>
+    );
+  });
+
+  it('should render 0 links', () => {
+    const links = rendered.queryAllByRole('link');
+    expect(links).toHaveLength(0);
+  });
+
+  it('should render a topline', () => {
+    rendered.getByText('To be on top');
+  });
+
+  it('should render a strapline', () => {
+    rendered.getByText('Strap in');
+  });
+
+  it('should render an overriden logo image', () => {
+    const img = rendered.getByRole('img');
+    expect(img).toBeVisible();
+    expect(img).toHaveProperty('src', 'http://placehold.it/520x150');
+  });
+});

--- a/src/library/structure/HomeHero/HomeHero.test.tsx
+++ b/src/library/structure/HomeHero/HomeHero.test.tsx
@@ -24,7 +24,6 @@ describe('HomeHero common usage', () => {
   });
 
   it('should render 3 promoted links', () => {
-      console.log(typeof rendered);
     const links = rendered.queryAllByRole('link');
     expect(links).toHaveLength(3);
 
@@ -58,6 +57,7 @@ describe('HomeHero common usage', () => {
 describe('HomeHero unusual usage', () => {
   const props: HomeHeroProps = {
     imageOverrideLogo: 'http://placehold.it/520x150',
+    imageOverrideLogoAltText: 'My alt text',
     topline: 'To be on top',
     strapline: 'Strap in',
     promotedLinksArray: [],
@@ -91,5 +91,6 @@ describe('HomeHero unusual usage', () => {
     const img = rendered.getByRole('img');
     expect(img).toBeVisible();
     expect(img).toHaveProperty('src', 'http://placehold.it/520x150');
+    expect(img).toHaveProperty('alt', 'My alt text');
   });
 });

--- a/src/library/structure/HomeHero/HomeHero.tsx
+++ b/src/library/structure/HomeHero/HomeHero.tsx
@@ -1,14 +1,14 @@
-import React, {useEffect, useRef, useState} from "react";
+import React, { useEffect, useState } from 'react';
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
-import { HomeHeroProps } from "./HomeHero.types";
-import * as Styles from "./HomeHero.styles";
-import GDSLogo from "../../components/logos/GDSLogo/logo";
-import NorthColoured from "../../components/logos/NorthColouredLogo/logo";
-import WestColoured from "../../components/logos/WestColouredLogo/logo";
-import LazyImage from "react-lazy-progressive-image";
-import Searchbar from "../Searchbar/Searchbar";
-import PromotedLinks from "../../components/PromotedLinks/PromotedLinks";
+import { HomeHeroProps } from './HomeHero.types';
+import * as Styles from './HomeHero.styles';
+import GDSLogo from '../../components/logos/GDSLogo/logo';
+import NorthColoured from '../../components/logos/NorthColouredLogo/logo';
+import WestColoured from '../../components/logos/WestColouredLogo/logo';
+import LazyImage from 'react-lazy-progressive-image';
+import Searchbar from '../Searchbar/Searchbar';
+import PromotedLinks from '../../components/PromotedLinks/PromotedLinks';
 
 /**
  * The Hero that should appear at the top of the home page.
@@ -18,62 +18,78 @@ const HomeHero: React.FunctionComponent<HomeHeroProps> = ({
   strapline,
   imagesArray,
   promotedLinksArray,
-  searchSuggestions = []
+  searchSuggestions = [],
+  imageOverrideLogo,
 }) => {
   const themeContext = useContext(ThemeContext);
   const [random, setRandom] = useState(999);
+  const usingMemorialTheme =
+    themeContext.theme_vars.theme_name === 'Memorial theme North' ||
+    themeContext.theme_vars.theme_name === 'Memorial theme West';
 
   useEffect(() => {
     setRandom(Math.floor(Math.random() * imagesArray.length));
-  }, []);  
+  }, []);
 
-  return(
+  return (
     <>
       <Styles.Wrapper>
         <LazyImage
-            src={random !== 999 && imagesArray[random].image1440x810 ? imagesArray[random].image1440x810 : ''}
-            placeholder={random !== 999 && imagesArray[random].image144x81 ? imagesArray[random].image144x81 : ''}
-            visibilitySensorProps={{
-                partialVisibility: true
-            }}
+          src={random !== 999 && imagesArray[random].image1440x810 ? imagesArray[random].image1440x810 : ''}
+          placeholder={random !== 999 && imagesArray[random].image144x81 ? imagesArray[random].image144x81 : ''}
+          visibilitySensorProps={{
+            partialVisibility: true,
+          }}
         >
-          {src => 
-            <Styles.Container className={random !== 999 ? "loaded" : "loading"} image={src} title={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ""}>
+          {(src) => (
+            <Styles.Container
+              className={random !== 999 ? 'loaded' : 'loading'}
+              image={src}
+              title={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ''}
+            >
               <Styles.StyledMaxWidthContainer>
                 <Styles.MainBox>
-                  {topline &&
-                    <Styles.Topline>{topline}</Styles.Topline>
-                  }
+                  {topline && <Styles.Topline>{topline}</Styles.Topline>}
                   <Styles.HiddenH1>{themeContext.full_name} Council</Styles.HiddenH1>
-                  <Styles.LogoColoured className={themeContext.theme_vars.theme_name === "Memorial theme North" || themeContext.theme_vars.theme_name === "Memorial theme West" ? "black_logo" : ""}>
-                    {themeContext.cardinal_name === "north" ? <NorthColoured /> : (themeContext.cardinal_name === "west" ? <WestColoured /> : <GDSLogo />)}
-                  </Styles.LogoColoured>   
-                  {strapline && 
-                    <Styles.Strapline>{strapline}</Styles.Strapline>
-                  }
-                  <Searchbar 
+                  {imageOverrideLogo && !usingMemorialTheme && (
+                    <Styles.LogoOverride>
+                      <img src={imageOverrideLogo} width="520" height="150" alt="Logo" />
+                    </Styles.LogoOverride>
+                  )}
+                  {(!imageOverrideLogo || usingMemorialTheme) && (
+                    <Styles.LogoColoured className={usingMemorialTheme ? 'black_logo' : ''}>
+                      {themeContext.cardinal_name === 'north' ? (
+                        <NorthColoured />
+                      ) : themeContext.cardinal_name === 'west' ? (
+                        <WestColoured />
+                      ) : (
+                        <GDSLogo />
+                      )}
+                    </Styles.LogoColoured>
+                  )}
+                  {strapline && <Styles.Strapline>{strapline}</Styles.Strapline>}
+                  <Searchbar
                     isLight
-                    isLarge 
+                    isLarge
                     placeholder="Search the site"
                     submitInfo={{
-                      postTo: "/search",
+                      postTo: '/search',
                       params: {
-                          type: "search"
-                      }
+                        type: 'search',
+                      },
                     }}
                     suggestions={searchSuggestions}
                     maximumMatchesShown={4}
                   />
                 </Styles.MainBox>
-                {promotedLinksArray.length > 0 && 
-                  <PromotedLinks promotedLinksArray={promotedLinksArray}/>
-                 }
+                {promotedLinksArray.length > 0 && <PromotedLinks promotedLinksArray={promotedLinksArray} />}
               </Styles.StyledMaxWidthContainer>
             </Styles.Container>
-          }
+          )}
         </LazyImage>
       </Styles.Wrapper>
     </>
-)};
+  );
+};
 
 export default HomeHero;

--- a/src/library/structure/HomeHero/HomeHero.tsx
+++ b/src/library/structure/HomeHero/HomeHero.tsx
@@ -20,6 +20,7 @@ const HomeHero: React.FunctionComponent<HomeHeroProps> = ({
   promotedLinksArray,
   searchSuggestions = [],
   imageOverrideLogo,
+  imageOverrideLogoAltText,
 }) => {
   const themeContext = useContext(ThemeContext);
   const [random, setRandom] = useState(999);
@@ -53,7 +54,7 @@ const HomeHero: React.FunctionComponent<HomeHeroProps> = ({
                   <Styles.HiddenH1>{themeContext.full_name} Council</Styles.HiddenH1>
                   {imageOverrideLogo && !usingMemorialTheme && (
                     <Styles.LogoOverride>
-                      <img src={imageOverrideLogo} width="520" height="150" alt="Logo" />
+                      <img src={imageOverrideLogo} width="520" height="150" alt={imageOverrideLogoAltText?.trim() ? imageOverrideLogoAltText : "Logo"} />
                     </Styles.LogoOverride>
                   )}
                   {(!imageOverrideLogo || usingMemorialTheme) && (

--- a/src/library/structure/HomeHero/HomeHero.types.ts
+++ b/src/library/structure/HomeHero/HomeHero.types.ts
@@ -10,6 +10,11 @@ export interface HomeHeroProps {
   imageOverrideLogo?: string;
 
   /**
+   * Alt text for overridden logo
+   */
+  imageOverrideLogoAltText?: string;
+
+   /**
    * The line of text after the logo
    */
   strapline?: string;

--- a/src/library/structure/HomeHero/HomeHero.types.ts
+++ b/src/library/structure/HomeHero/HomeHero.types.ts
@@ -1,19 +1,24 @@
 export interface HomeHeroProps {
-   /**
+  /**
    * The line of text before the logo
    */
   topline?: string;
-  
+
+  /**
+   * URL of an alternative logo to override the preset ones (520 x 150 px)
+   */
+  imageOverrideLogo?: string;
+
   /**
    * The line of text after the logo
    */
   strapline?: string;
-  
+
   /**
    * The images for the hero, minimum of one
    */
   imagesArray: Array<HeroImageProp>;
-  
+
   /**
    * The main promoted links, an array that should be from 1-4, preferably 3
    */
@@ -26,20 +31,20 @@ export interface HomeHeroProps {
 }
 
 export interface HeroImageProp {
-    /**
-     * The url of the image
-     */
-    image1440x810: string;
+  /**
+   * The url of the image
+   */
+  image1440x810: string;
 
-    /**
-     * The url of the image in 10x smaller for lazy loading
-     */
-    image144x81: string;
+  /**
+   * The url of the image in 10x smaller for lazy loading
+   */
+  image144x81: string;
 
-    /**
-     * Optional alt text for the image - this should only be included if the image contains content that is important to users and not purely decorative
-     */
-    imageAltText?: string;
+  /**
+   * Optional alt text for the image - this should only be included if the image contains content that is important to users and not purely decorative
+   */
+  imageAltText?: string;
 }
 
 export interface PromotedLinkProp {


### PR DESCRIPTION
### Testing

1. `npm test HomeHero`
2. Take a look at the HomeHero structure, there is a new story showing the overridden logo set to a simple placeholder image. Image is intended to be 520x150 pixels, and will be enforced as such in the CMS.
3. Verify that any London Bridge theme will display normal black/white logo, not the overridden logo (so, e.g., a temporary logo for a particular month won't override the memorial theme logo).

