### PR TITLE
Full width container & accordion changes

### DIFF
--- a/src/library/slices/Accordion/Accordion.stories.tsx
+++ b/src/library/slices/Accordion/Accordion.stories.tsx
@@ -45,9 +45,9 @@ ExampleAccordion.args = {
   ],
 };
 
-export const AccordionWithoutReadMore = Template.bind({});
-AccordionWithoutReadMore.args = {
-  withReadMore: false,
+export const AccordionWithReadMore = Template.bind({});
+AccordionWithReadMore.args = {
+  withReadMore: true,
   sections: [
     {
       title: 'Tortor Magna',

--- a/src/library/slices/Accordion/Accordion.tsx
+++ b/src/library/slices/Accordion/Accordion.tsx
@@ -1,14 +1,10 @@
-import React, { useState, useEffect } from "react";
-import { AccordionProps } from "./Accordion.types";
-import * as Styles from "./Accordion.styles";
-import AccordionSection from "./AccordionSection";
-import { uniqueID } from "./../../helpers/helpers";
+import React, { useState, useEffect } from 'react';
+import { AccordionProps } from './Accordion.types';
+import * as Styles from './Accordion.styles';
+import AccordionSection from './AccordionSection';
+import { uniqueID } from './../../helpers/helpers';
 
-const Accordion: React.FunctionComponent<AccordionProps> = ({
-  sections,
-  isFilter = false,
-  withReadMore = true,
-}) => {
+const Accordion: React.FunctionComponent<AccordionProps> = ({ sections, isFilter = false, withReadMore = false }) => {
   sections.map((section, i) => {
     section.accordionSectionId = i;
   });
@@ -18,9 +14,7 @@ const Accordion: React.FunctionComponent<AccordionProps> = ({
   const [accordionStates, setAccordionStates] = useState(sections);
 
   useEffect(() => {
-    const anyOpen = accordionStates.find(
-      (accordionState) => accordionState.isExpanded === true
-    );
+    const anyOpen = accordionStates.find((accordionState) => accordionState.isExpanded === true);
     anyOpen ? setOpenAll(false) : setOpenAll(true);
     setShowControls(true);
   });
@@ -54,12 +48,8 @@ const Accordion: React.FunctionComponent<AccordionProps> = ({
     <Styles.Container data-testid="Accordion" id={accordionId}>
       {showControls && sections.length > 1 && (
         <Styles.AccordionControls>
-          <Styles.OpenAllButton
-            onClick={toggleAll}
-            type="button"
-            aria-expanded={!openAll}
-          >
-            {openAll ? "Open all" : "Close all"}
+          <Styles.OpenAllButton onClick={toggleAll} type="button" aria-expanded={!openAll}>
+            {openAll ? 'Open all' : 'Close all'}
             <Styles.VisuallyHidden> sections</Styles.VisuallyHidden>
           </Styles.OpenAllButton>
         </Styles.AccordionControls>

--- a/src/library/structure/FullWidthContainer/FullWidthContainer.styles.js
+++ b/src/library/structure/FullWidthContainer/FullWidthContainer.styles.js
@@ -2,5 +2,5 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   background: ${(props) => (props.hasBackground ? props.theme.theme_vars.colours.grey_light : 'transparent')};
-  padding: ${(props) => (props.hasPadding ? '50px 0' : '0')};
+  padding: ${(props) => (props.hasPadding ? '50px 0 20px' : '0')};
 `;

--- a/src/library/structure/FullWidthContainer/FullWidthContainer.test.tsx
+++ b/src/library/structure/FullWidthContainer/FullWidthContainer.test.tsx
@@ -21,7 +21,7 @@ describe('Full Width Container', () => {
     const { getByTestId } = renderComponent();
 
     const fullWidthContainer = getByTestId('FullWidthContainer');
-    expect(fullWidthContainer).toHaveStyle('padding: 50px 0');
+    expect(fullWidthContainer).toHaveStyle('padding: 50px 0 20px');
     expect(fullWidthContainer).toHaveStyle(`background: ${west_theme.theme_vars.colours.grey_light}`);
   });
 


### PR DESCRIPTION
A couple of small changes from discussion with Lawrence last week. 

- Reduce the bottom padding of the full width container. Content inside usually has it's own bottom margin.
- Remove the 'Read more' links in the accordions by default
- Updated Accordion story to show with 'Read more' as it's now hidden by default