### PR TITLE
Bugfix/google map styles overwritten

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+      "version": "7.17.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+      "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
@@ -11595,9 +11595,9 @@
       "dev": true
     },
     "node_modules/@types/styled-components": {
-      "version": "5.1.22",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.22.tgz",
-      "integrity": "sha512-zQzf/0aGtgFDjB942f8IaKA6UilFziDza9wXkAX5mpiSWA/FBZBU6yUavvczulTvoR6759h6CH8HuuIcJDBgZA==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.23.tgz",
+      "integrity": "sha512-zt8oQGU6XB4LH1Xpq169YnAVmt22+swzHJvyKMyTZu/z8+afvgKjjg0s79aAodgNSf36ZOEG6DyVAW/JhLH2Nw==",
       "dev": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "*",
@@ -29031,9 +29031,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.67.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
-      "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
+      "version": "2.67.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.3.tgz",
+      "integrity": "sha512-G/x1vUwbGtP6O5ZM8/sWr8+p7YfZhI18pPqMRtMYMWSbHjKZ/ajHGiM+GWNTlWyOR0EHIdT8LHU+Z4ciIZ1oBw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -33059,9 +33059,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.0.tgz",
-      "integrity": "sha512-E5Fqu89Gu8fR6vejRqu26h8ld/k6/dCVbeGUcuZjc+goQHDfCPU9rER71JmdtBYGmci7Ec2aFEATQ2IVXKy2wg==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -33073,7 +33073,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.0",
+        "enhanced-resolve": "^5.8.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -33741,9 +33741,9 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+      "version": "7.17.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+      "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
@@ -42304,9 +42304,9 @@
       "dev": true
     },
     "@types/styled-components": {
-      "version": "5.1.22",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.22.tgz",
-      "integrity": "sha512-zQzf/0aGtgFDjB942f8IaKA6UilFziDza9wXkAX5mpiSWA/FBZBU6yUavvczulTvoR6759h6CH8HuuIcJDBgZA==",
+      "version": "5.1.23",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.23.tgz",
+      "integrity": "sha512-zt8oQGU6XB4LH1Xpq169YnAVmt22+swzHJvyKMyTZu/z8+afvgKjjg0s79aAodgNSf36ZOEG6DyVAW/JhLH2Nw==",
       "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "*",
@@ -55870,9 +55870,9 @@
       }
     },
     "rollup": {
-      "version": "2.67.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
-      "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
+      "version": "2.67.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.3.tgz",
+      "integrity": "sha512-G/x1vUwbGtP6O5ZM8/sWr8+p7YfZhI18pPqMRtMYMWSbHjKZ/ajHGiM+GWNTlWyOR0EHIdT8LHU+Z4ciIZ1oBw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -59030,9 +59030,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.0.tgz",
-      "integrity": "sha512-E5Fqu89Gu8fR6vejRqu26h8ld/k6/dCVbeGUcuZjc+goQHDfCPU9rER71JmdtBYGmci7Ec2aFEATQ2IVXKy2wg==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -59044,7 +59044,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.0",
+        "enhanced-resolve": "^5.8.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15071,9 +15071,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-      "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -16957,9 +16957,9 @@
       }
     },
     "node_modules/eslint-plugin-storybook": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.6.tgz",
-      "integrity": "sha512-hxeydYXi0DZC80kV9wPz9pA9oG9GVdfNg9iXR/KhqnMdqZWCGQKsex05k4VlX52no7mm/sICjW/iKYtRqVkaaw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.7.tgz",
+      "integrity": "sha512-rko/QUHa3/hrC3W5RmPrukKawCyGeVqSuwzyLZO6aV/neyOPrgkL/LED8u6NQJSaT1qZFT+7iLQ1eE8Ce7G+aA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.0.1",
@@ -45074,9 +45074,9 @@
       }
     },
     "core-js": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-      "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ=="
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
     },
     "core-js-compat": {
       "version": "3.20.3",
@@ -46792,9 +46792,9 @@
       "requires": {}
     },
     "eslint-plugin-storybook": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.6.tgz",
-      "integrity": "sha512-hxeydYXi0DZC80kV9wPz9pA9oG9GVdfNg9iXR/KhqnMdqZWCGQKsex05k4VlX52no7mm/sICjW/iKYtRqVkaaw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.7.tgz",
+      "integrity": "sha512-rko/QUHa3/hrC3W5RmPrukKawCyGeVqSuwzyLZO6aV/neyOPrgkL/LED8u6NQJSaT1qZFT+7iLQ1eE8Ce7G+aA==",
       "dev": true,
       "requires": {
         "@storybook/csf": "^0.0.1",

--- a/src/library/pages/ContentPage/ContentPage.storydata.ts
+++ b/src/library/pages/ContentPage/ContentPage.storydata.ts
@@ -1,5 +1,7 @@
 /** Example story data for Content Page example */
 
+import { GoogleMapProps } from '../../slices/GoogleMap/GoogleMap.types';
+
 export const smallTable = {
   caption: 'Month you apply',
   headings: ['Date', 'Rate for vehicles', 'Rate for bicycles'],
@@ -13,4 +15,13 @@ export const smallTable = {
 export const largeTable = {
   caption: 'Example table with lots of data',
   headings: ['', 'Band A', 'Band B', 'Band C', 'Band D', 'Band E', 'Band F', 'Band G', 'Band H'],
+};
+
+export const googleMapData: GoogleMapProps = {
+  title: 'An example Google map',
+  description: 'Some description text for the map',
+  link_url: 'https://goo.gl/maps/uEQBSox9DN4z9BFy8',
+  link_title: 'View on a Map',
+  iframe_html:
+    '<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d19510.86230700187!2d-0.895762!3d52.318583!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x7967b834f2732438!2sBrixworth%20Country%20Park!5e0!3m2!1sen!2suk!4v1644496039794!5m2!1sen!2suk" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>',
 };

--- a/src/library/pages/ContentPage/ContentPage.storydata.ts
+++ b/src/library/pages/ContentPage/ContentPage.storydata.ts
@@ -1,7 +1,5 @@
 /** Example story data for Content Page example */
 
-import { GoogleMapProps } from '../../slices/GoogleMap/GoogleMap.types';
-
 export const smallTable = {
   caption: 'Month you apply',
   headings: ['Date', 'Rate for vehicles', 'Rate for bicycles'],
@@ -15,13 +13,4 @@ export const smallTable = {
 export const largeTable = {
   caption: 'Example table with lots of data',
   headings: ['', 'Band A', 'Band B', 'Band C', 'Band D', 'Band E', 'Band F', 'Band G', 'Band H'],
-};
-
-export const googleMapData: GoogleMapProps = {
-  title: 'An example Google map',
-  description: 'Some description text for the map',
-  link_url: 'https://goo.gl/maps/uEQBSox9DN4z9BFy8',
-  link_title: 'View on a Map',
-  iframe_html:
-    '<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d19510.86230700187!2d-0.895762!3d52.318583!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x7967b834f2732438!2sBrixworth%20Country%20Park!5e0!3m2!1sen!2suk!4v1644496039794!5m2!1sen!2suk" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>',
 };

--- a/src/library/pages/ContentPage/ContentPage.tsx
+++ b/src/library/pages/ContentPage/ContentPage.tsx
@@ -11,6 +11,8 @@ import Summary from '../../structure/Summary/Summary';
 import { smallTable, largeTable } from './ContentPage.storydata';
 import Promotions from '../../slices/Promotions/Promotions';
 import { PromoBlocksData } from '../../structure/PromoBlock/PromoBlock.storydata';
+import { googleMapData } from './ContentPage.storydata';
+import GoogleMap from '../../slices/GoogleMap/GoogleMap';
 
 export interface ContentPageProps {}
 
@@ -196,6 +198,7 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
           ]}
         />
         <Promotions promos={PromoBlocksData} />
+        <GoogleMap {...googleMapData} />
         <WarningTextDisclaimer />
       </PageStructures.PageMain>
     </PageStructures.MaxWidthContainer>

--- a/src/library/pages/ContentPage/ContentPage.tsx
+++ b/src/library/pages/ContentPage/ContentPage.tsx
@@ -11,7 +11,7 @@ import Summary from '../../structure/Summary/Summary';
 import { smallTable, largeTable } from './ContentPage.storydata';
 import Promotions from '../../slices/Promotions/Promotions';
 import { PromoBlocksData } from '../../structure/PromoBlock/PromoBlock.storydata';
-import { googleMapData } from './ContentPage.storydata';
+import { GoogleMapWithTitleAndDescription } from '../../slices/GoogleMap/GoogleMap.storydata';
 import GoogleMap from '../../slices/GoogleMap/GoogleMap';
 
 export interface ContentPageProps {}
@@ -198,7 +198,7 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
           ]}
         />
         <Promotions promos={PromoBlocksData} />
-        <GoogleMap {...googleMapData} />
+        <GoogleMap {...GoogleMapWithTitleAndDescription} />
         <WarningTextDisclaimer />
       </PageStructures.PageMain>
     </PageStructures.MaxWidthContainer>

--- a/src/library/slices/GoogleMap/GoogleMap.styles.js
+++ b/src/library/slices/GoogleMap/GoogleMap.styles.js
@@ -32,13 +32,13 @@ export const MapDescription = styled.div`
   }
 `;
 
-export const MapEmbed = styled.div`
+export const MapEmbed = styled.figure`
   display: block;
   position: relative;
   overflow: hidden;
   width: 100%;
   padding-top: 75%; /* 4:3 aspect ratio */
-  @media screen and (orientation:portrait) {
+  @media screen and (orientation: portrait) {
     padding-top: 133%; /* 3:4 aspect ratio for phones */
   }
   margin-bottom: 15px;


### PR DESCRIPTION
Changed to styled.figure and it seems to resolve the issue with the map going fullscreen when there is a WarningTextDisclaimer on the page. 

Added Google map to Content Page example to try and debug, but the bug doesn't occur in the design system, only the frontend.

Also updated dependencies (since yesterday's update...)

## To Test
- `yalc publish`
- cd to frontend and `yalc add northants-design-system && rm -r .next/cache && yarn install && yard dev`
- Visit page with Google Map slice and a WarningTextDisclaimer