### PR TITLE
Fix Google Maps accessibility warnings

### DIFF
--- a/src/library/slices/GoogleMap/GoogleMap.styles.js
+++ b/src/library/slices/GoogleMap/GoogleMap.styles.js
@@ -1,6 +1,12 @@
 import styled from 'styled-components';
 
 /**
+ * A div to workaround a bug in styled components that results in no or wrong class and
+ * therefore styling being applied in some circumstances. Wrapped around anything affected.
+ */
+export const ProtectiveContainer = styled.div``;
+
+/**
  * Description text above map embed/link
  */
 export const MapDescription = styled.div`
@@ -71,4 +77,8 @@ export const MapLink = styled.a`
   &:active {
     ${(props) => props.theme.linkStylesActive};
   }
+`;
+
+export const AccessibleMapLink = styled(MapLink)`
+  ${(props) => props.theme.visuallyHidden};
 `;

--- a/src/library/slices/GoogleMap/GoogleMap.tsx
+++ b/src/library/slices/GoogleMap/GoogleMap.tsx
@@ -21,7 +21,7 @@ const GoogleMap: React.FunctionComponent<GoogleMapProps> = ({
 
   /* We extract the iframe source URL and check it actually goes to www.google.com/maps */
   const src_matches = iframe_html.match(/src="([^"]+)"/gi);
-  let embed_url = src_matches?.length == 1 ? src_matches[0].replace("src=\"", "") : '';
+  let embed_url = src_matches?.length == 1 ? src_matches[0].replace('src="', '') : '';
   if (embed_url) {
     const map_matches = embed_url.match(/^https:\/\/www.google.com\/maps/gi);
     embed_url = map_matches?.length == 1 ? embed_url : '';
@@ -35,31 +35,45 @@ const GoogleMap: React.FunctionComponent<GoogleMapProps> = ({
 
   return (
     <>
-      {title && <Heading level={3} text={title} />}
-      {description && (
-        <Styles.MapDescription
-          dangerouslySetInnerHTML={{
-            __html: sanitizeHtml(description),
-          }}
-        />
-      )}
-      {(!link_url || !embed_url) && (
-        <AlertBannerService alertType={'warning'} title={'Invalid map'}>
-          Embedded map contains invalid {!link_url && 'link'}
-          {!link_url && !embed_url && ' and '}
-          {!embed_url && 'iframe data'}; please report this to the content editor
-        </AlertBannerService>
-      )}
-      {cookiesAccepted && embed_url && (
-        <Styles.MapEmbed data-testid="GoogleMapContainer">
-          <Styles.MapEmbedIFrame src={embed_url} allow="fullscreen" data-testid="GoogleMapIframe" />
-        </Styles.MapEmbed>
-      )}
-      {!cookiesAccepted && link_url && (
-        <Styles.MapLink href={link_url}>
-          {link_title ? link_title : 'Google Maps link'}
-        </Styles.MapLink>
-      )}
+      <Styles.ProtectiveContainer>
+        {title && <Heading level={3} text={title} />}
+        {description && (
+          <Styles.MapDescription
+            dangerouslySetInnerHTML={{
+              __html: sanitizeHtml(description),
+            }}
+          />
+        )}
+        {(!link_url || !embed_url) && (
+          <AlertBannerService alertType={'warning'} title={'Invalid map'}>
+            Embedded map contains invalid {!link_url && 'link'}
+            {!link_url && !embed_url && ' and '}
+            {!embed_url && 'iframe data'}; please report this to the content editor
+          </AlertBannerService>
+        )}
+        {cookiesAccepted && embed_url && (
+          <Styles.MapEmbed data-testid="GoogleMapContainer">
+            <Styles.MapEmbedIFrame
+              src={embed_url}
+              data-testid="GoogleMapIframe"
+              title={title ? title : 'Embedded map'}
+              aria-hidden="true"
+            />
+          </Styles.MapEmbed>
+        )}
+        {cookiesAccepted &&
+          link_url && ( // visually hidden link for screen readers etc. as the embed isn't very accessible so hidden from them
+            <Styles.ProtectiveContainer>
+              <Styles.AccessibleMapLink href={link_url}>
+                {link_title ? link_title : 'Google Maps link'}
+              </Styles.AccessibleMapLink>
+            </Styles.ProtectiveContainer>
+          )}
+        {!cookiesAccepted &&
+          link_url && ( // visible link for all if cookies not accepted
+            <Styles.MapLink href={link_url}>{link_title ? link_title : 'Google Maps link'}</Styles.MapLink>
+          )}
+      </Styles.ProtectiveContainer>
     </>
   );
 };


### PR DESCRIPTION
### Testing

- Pull this design system version in via yalc to the front end
- View any page with a map embedded, run axe test (e.g. Firefox Axe Devtools extension)
- Marvel at lack of errors
- Inspect the page and find the iframe for the embed now has a title attribute and a visually hidden link below the iframe (if cookies accepted)