### PR TITLE
Remove titles from links in HomeUnitarySection

### DIFF
--- a/src/library/structure/HomeUnitarySection/HomeUnitarySection.test.tsx
+++ b/src/library/structure/HomeUnitarySection/HomeUnitarySection.test.tsx
@@ -37,12 +37,12 @@ describe('Home Unitary Section', () => {
 
     expect(links[0]).toHaveStyle(`color: ${west_theme.theme_vars.colours.action}`);
     expect(links[0]).toHaveTextContent('westnorthants.gov.uk');
-    expect(links[0]).toHaveAttribute('title', 'westnorthants.gov.uk');
+    expect(links[0]).not.toHaveAttribute('title');
     expect(links[0]).toHaveAttribute('href', west_theme.theme_vars.council_link);
 
     expect(links[1]).toHaveStyle(`color: ${west_theme.theme_vars.other_council_action}`);
     expect(links[1]).toHaveTextContent('northnorthants.gov.uk');
-    expect(links[1]).toHaveAttribute('title', 'northnorthants.gov.uk');
+    expect(links[1]).not.toHaveAttribute('title');
     expect(links[1]).toHaveAttribute('href', west_theme.theme_vars.other_council_link);
   });
 });

--- a/src/library/structure/HomeUnitarySection/HomeUnitarySection.test.tsx
+++ b/src/library/structure/HomeUnitarySection/HomeUnitarySection.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import HomeUnitarySection from './HomeUnitarySection';
+import { HomeUnitarySectionProps } from './HomeUnitarySection.types';
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
+
+describe('Home Unitary Section', () => {
+  const props: HomeUnitarySectionProps = {
+    title: 'Northamptonshire’s two new unitary councils',
+    postcodeText: 'Not sure which you live in? Enter your postcode to find out',
+    firstLine:
+      'There are now two new unitary councils for Northamptonshire – North and West. They’ll help us provide better services and information for residents and businesses.',
+    westText: 'Covering the local areas of Daventry, Northampton Borough and South Northamptonshire',
+    northText: 'Covering the local areas of Corby, East Northamptonshire, Kettering and Wellingborough',
+  };
+
+  it('should render the home unitary section including links', () => {
+    const renderComponent = () =>
+      render(
+        <ThemeProvider theme={west_theme}>
+          <HomeUnitarySection {...props} />
+        </ThemeProvider>
+      );
+
+    const { getByRole, getAllByRole, getByTestId } = renderComponent();
+    const component = getByTestId('HomeUnitarySection');
+
+    expect(getByRole('heading')).toHaveTextContent(props.title);
+
+    expect(component).toHaveTextContent(props.firstLine);
+    expect(component).toHaveTextContent(props.westText);
+    expect(component).toHaveTextContent(props.northText);
+
+    const links = getAllByRole('link');
+    expect(links).toHaveLength(2);
+
+    expect(links[0]).toHaveStyle(`color: ${west_theme.theme_vars.colours.action}`);
+    expect(links[0]).toHaveTextContent('westnorthants.gov.uk');
+    expect(links[0]).toHaveAttribute('title', 'westnorthants.gov.uk');
+    expect(links[0]).toHaveAttribute('href', west_theme.theme_vars.council_link);
+
+    expect(links[1]).toHaveStyle(`color: ${west_theme.theme_vars.other_council_action}`);
+    expect(links[1]).toHaveTextContent('northnorthants.gov.uk');
+    expect(links[1]).toHaveAttribute('title', 'northnorthants.gov.uk');
+    expect(links[1]).toHaveAttribute('href', west_theme.theme_vars.other_council_link);
+  });
+});

--- a/src/library/structure/HomeUnitarySection/HomeUnitarySection.tsx
+++ b/src/library/structure/HomeUnitarySection/HomeUnitarySection.tsx
@@ -1,50 +1,74 @@
-import React from "react";
+import React from 'react';
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
+import { HomeUnitarySectionProps } from './HomeUnitarySection.types';
+import * as Styles from './HomeUnitarySection.styles';
+import PostCodeSearch from '../../components/PostCodeSearch/PostCodeSearch';
+import Heading from '../../components/Heading/Heading';
+import NorthColoured from '../../components/logos/NorthColouredLogo/logo';
+import WestColoured from '../../components/logos/WestColouredLogo/logo';
+import MapImage from './assets/map';
 
-import { HomeUnitarySectionProps } from "./HomeUnitarySection.types";
-import * as Styles from "./HomeUnitarySection.styles";
-import PostCodeSearch from "../../components/PostCodeSearch/PostCodeSearch";
-import Heading from "../../components/Heading/Heading";
-
-import NorthColoured from "../../components/logos/NorthColouredLogo/logo";
-import WestColoured from "../../components/logos/WestColouredLogo/logo";
-import MapImage from "./assets/map";
-
-const HomeUnitarySection: React.FC<HomeUnitarySectionProps> = ({ 
-    title="Northamptonshire’s two new unitary councils",
-    postcodeText="Not sure which you live in? Enter your postcode to find out",
-    firstLine="There are now two new unitary councils for Northamptonshire – North and West. They’ll help us provide better services and information for residents and businesses.",
-    westText="Covering the local areas of Daventry, Northampton Borough and South Northamptonshire",
-    northText="Covering the local areas of Corby, East Northamptonshire, Kettering and Wellingborough"
+const HomeUnitarySection: React.FunctionComponent<HomeUnitarySectionProps> = ({
+  title = 'Northamptonshire’s two new unitary councils',
+  postcodeText = 'Not sure which you live in? Enter your postcode to find out',
+  firstLine = 'There are now two new unitary councils for Northamptonshire – North and West. They’ll help us provide better services and information for residents and businesses.',
+  westText = 'Covering the local areas of Daventry, Northampton Borough and South Northamptonshire',
+  northText = 'Covering the local areas of Corby, East Northamptonshire, Kettering and Wellingborough',
 }) => {
-    const themeContext = useContext(ThemeContext);
-    const northLink = themeContext.cardinal_name === "north" ? themeContext.theme_vars.council_link : themeContext.theme_vars.other_council_link
-    const westLink = themeContext.cardinal_name === "west" ? themeContext.theme_vars.council_link : themeContext.theme_vars.other_council_link
-    
-    return(
-        <Styles.Container>
-            <Heading text={title} />
-            <p>{firstLine}</p>
-            <PostCodeSearch isUnitary title={postcodeText} />
+  const themeContext = useContext(ThemeContext);
+  const northLink =
+    themeContext.cardinal_name === 'north'
+      ? themeContext.theme_vars.council_link
+      : themeContext.theme_vars.other_council_link;
+  const westLink =
+    themeContext.cardinal_name === 'west'
+      ? themeContext.theme_vars.council_link
+      : themeContext.theme_vars.other_council_link;
 
-            <Styles.MapSection>
-                <Styles.West>
-                    <WestColoured />
-                    <p>{westText}</p>
-                    <Styles.CouncilLink colour={themeContext.cardinal_name === "north" ? themeContext.theme_vars.other_council_action : themeContext.theme_vars.colours.action} href={westLink} title="Go to the West's website">westnorthants.gov.uk</Styles.CouncilLink>
-                </Styles.West>
-                <Styles.Map>
-                    <MapImage />
-                </Styles.Map>
-                <Styles.North>
-                    <NorthColoured />
-                    <p>{northText}</p>
-                    <Styles.CouncilLink colour={themeContext.cardinal_name === "west" ? themeContext.theme_vars.other_council_action : themeContext.theme_vars.colours.action} href={northLink} title="Go to the North's website">northnorthants.gov.uk</Styles.CouncilLink>
-                </Styles.North>
-            </Styles.MapSection>
-        </Styles.Container>
-    )
+  return (
+    <Styles.Container data-testid="HomeUnitarySection">
+      <Heading text={title} />
+      <p>{firstLine}</p>
+      <PostCodeSearch isUnitary title={postcodeText} />
+
+      <Styles.MapSection>
+        <Styles.West>
+          <WestColoured />
+          <p>{westText}</p>
+          <Styles.CouncilLink
+            colour={
+              themeContext.cardinal_name === 'north'
+                ? themeContext.theme_vars.other_council_action
+                : themeContext.theme_vars.colours.action
+            }
+            href={westLink}
+            title="westnorthants.gov.uk"
+          >
+            westnorthants.gov.uk
+          </Styles.CouncilLink>
+        </Styles.West>
+        <Styles.Map>
+          <MapImage />
+        </Styles.Map>
+        <Styles.North>
+          <NorthColoured />
+          <p>{northText}</p>
+          <Styles.CouncilLink
+            colour={
+              themeContext.cardinal_name === 'west'
+                ? themeContext.theme_vars.other_council_action
+                : themeContext.theme_vars.colours.action
+            }
+            href={northLink}
+            title="northnorthants.gov.uk"
+          >
+            northnorthants.gov.uk
+          </Styles.CouncilLink>
+        </Styles.North>
+      </Styles.MapSection>
+    </Styles.Container>
+  );
 };
 
 export default HomeUnitarySection;

--- a/src/library/structure/HomeUnitarySection/HomeUnitarySection.tsx
+++ b/src/library/structure/HomeUnitarySection/HomeUnitarySection.tsx
@@ -43,7 +43,6 @@ const HomeUnitarySection: React.FunctionComponent<HomeUnitarySectionProps> = ({
                 : themeContext.theme_vars.colours.action
             }
             href={westLink}
-            title="westnorthants.gov.uk"
           >
             westnorthants.gov.uk
           </Styles.CouncilLink>
@@ -61,7 +60,6 @@ const HomeUnitarySection: React.FunctionComponent<HomeUnitarySectionProps> = ({
                 : themeContext.theme_vars.colours.action
             }
             href={northLink}
-            title="northnorthants.gov.uk"
           >
             northnorthants.gov.uk
           </Styles.CouncilLink>


### PR DESCRIPTION
Remove link titles as per [Accessibility advisory](https://www.a11yproject.com/checklist/#remove-title-attribute-tooltips). Mainly prettier changes to formatting. Also added test. 