### PR TITLE
Remove All services title in header

### DIFF
--- a/src/library/structure/Header/Header.test.tsx
+++ b/src/library/structure/Header/Header.test.tsx
@@ -39,7 +39,7 @@ describe('Header', () => {
     expect(links[0]).toHaveAttribute('title', 'Home');
 
     expect(links[1]).toHaveAttribute('href', `${props.allServicesLink}#all-services`);
-    expect(links[1]).toHaveAttribute('title', 'All services');
+    expect(links[1]).not.toHaveAttribute('title');
 
     expect(search).toBeVisible();
   });

--- a/src/library/structure/Header/Header.test.tsx
+++ b/src/library/structure/Header/Header.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Header from './Header';
+import { HeaderProps } from './Header.types';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+
+describe('Header', () => {
+  let props: HeaderProps;
+
+  beforeEach(() => {
+    props = {
+      homeLink: '/',
+      allServicesLink: '/all-services',
+      isHomepage: false,
+      hideSearchBar: false,
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <Header {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render the header', () => {
+    const { getByTestId, getAllByRole, getByPlaceholderText } = renderComponent();
+    const component = getByTestId('Header');
+    const links = getAllByRole('link');
+    const search = getByPlaceholderText('Search');
+
+    expect(component).toBeVisible();
+
+    // Home & All Services links
+    expect(links).toHaveLength(2);
+
+    expect(links[0]).toHaveAttribute('href', props.homeLink);
+    expect(links[0]).toHaveAttribute('title', 'Home');
+
+    expect(links[1]).toHaveAttribute('href', `${props.allServicesLink}#all-services`);
+    expect(links[1]).toHaveAttribute('title', 'All services');
+
+    expect(search).toBeVisible();
+  });
+
+  it('should hide all services link', () => {
+    props.allServicesLink = null;
+
+    const { getAllByRole, getByTestId } = renderComponent();
+
+    expect(getByTestId('Header')).not.toHaveTextContent('All services');
+    expect(getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('should hide the search bar', () => {
+    props.hideSearchBar = true;
+
+    const { queryByPlaceholderText } = renderComponent();
+
+    expect(queryByPlaceholderText('Search')).toBeNull();
+  });
+});

--- a/src/library/structure/Header/Header.tsx
+++ b/src/library/structure/Header/Header.tsx
@@ -89,10 +89,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
             </Styles.HomeLink>
           </Styles.LogoWrapper>
           {allServicesLink && (
-            <Styles.AllServicesLink
-              href={isHomepage ? '#all-services' : allServicesLink + '#all-services'}
-              title="All services"
-            >
+            <Styles.AllServicesLink href={isHomepage ? '#all-services' : allServicesLink + '#all-services'}>
               All services
             </Styles.AllServicesLink>
           )}

--- a/src/library/structure/Header/Header.tsx
+++ b/src/library/structure/Header/Header.tsx
@@ -1,13 +1,13 @@
-import React from "react";
+import React from 'react';
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
-import { HeaderProps } from "./Header.types";
-import * as Styles from "./Header.styles";
-import GDSLogo from "../../components/logos/GDSLogo/logo";
-import NorthColoured from "../../components/logos/NorthColouredLogo/logo";
-import NorthWhite from "../../components/logos/NorthWhiteLogo/logo";
-import WestWhite from "../../components/logos/WestWhiteLogo/logo";
-import Searchbar from "../Searchbar/Searchbar";
+import { HeaderProps } from './Header.types';
+import * as Styles from './Header.styles';
+import GDSLogo from '../../components/logos/GDSLogo/logo';
+import NorthColoured from '../../components/logos/NorthColouredLogo/logo';
+import NorthWhite from '../../components/logos/NorthWhiteLogo/logo';
+import WestWhite from '../../components/logos/WestWhiteLogo/logo';
+import Searchbar from '../Searchbar/Searchbar';
 
 /**
  * The header that should appear at the top of every page.
@@ -15,8 +15,8 @@ import Searchbar from "../Searchbar/Searchbar";
 const Header: React.FunctionComponent<HeaderProps> = ({
   children,
   hideSearchBar = false,
-  homeLink = "/",
-  allServicesLink = "/",
+  homeLink = '/',
+  allServicesLink = '/',
   isHomepage = false,
   searchSuggestions = [],
   ...props
@@ -34,62 +34,86 @@ const Header: React.FunctionComponent<HeaderProps> = ({
       memorial west homepage  - dark grey header / white logo / has search
   */
   const themeLogos = (cardinal_name, is_memorial) => {
-
-    if(is_memorial === true ) {
-      switch(cardinal_name) {
-        case "north":
-          return <Styles.LogoWhite><NorthWhite /></Styles.LogoWhite>;
-        case "west":
-          return  <Styles.LogoWhite><WestWhite /></Styles.LogoWhite>;
+    if (is_memorial === true) {
+      switch (cardinal_name) {
+        case 'north':
+          return (
+            <Styles.LogoWhite>
+              <NorthWhite />
+            </Styles.LogoWhite>
+          );
+        case 'west':
+          return (
+            <Styles.LogoWhite>
+              <WestWhite />
+            </Styles.LogoWhite>
+          );
         default:
-          return <Styles.LogoWhite><GDSLogo /></Styles.LogoWhite>;
+          return (
+            <Styles.LogoWhite>
+              <GDSLogo />
+            </Styles.LogoWhite>
+          );
       }
     } else {
-      switch(cardinal_name) {
-        case "north":
-          return <Styles.LogoColoured><NorthColoured /></Styles.LogoColoured>; 
-        case "west":
-          return <Styles.LogoWhite><WestWhite /></Styles.LogoWhite>;
+      switch (cardinal_name) {
+        case 'north':
+          return (
+            <Styles.LogoColoured>
+              <NorthColoured />
+            </Styles.LogoColoured>
+          );
+        case 'west':
+          return (
+            <Styles.LogoWhite>
+              <WestWhite />
+            </Styles.LogoWhite>
+          );
         default:
-          return <Styles.LogoColoured className="black_logo"><GDSLogo /></Styles.LogoColoured>;
+          return (
+            <Styles.LogoColoured className="black_logo">
+              <GDSLogo />
+            </Styles.LogoColoured>
+          );
       }
     }
-  }
+  };
 
-  return(
+  return (
     <>
-      <Styles.Container
-        {...props}
-      >
+      <Styles.Container {...props} data-testid="Header">
         <Styles.StyledMaxWidthContainer noBackground>
           <Styles.LogoWrapper>
             <Styles.HomeLink href={homeLink} title="Home" id="logo">
               {themeLogos(themeContext.cardinal_name, themeContext.is_memorial)}
             </Styles.HomeLink>
           </Styles.LogoWrapper>
-          {allServicesLink &&
-            <Styles.AllServicesLink href={isHomepage ? "#all-services" : allServicesLink + "#all-services"} title="See all services">
+          {allServicesLink && (
+            <Styles.AllServicesLink
+              href={isHomepage ? '#all-services' : allServicesLink + '#all-services'}
+              title="All services"
+            >
               All services
             </Styles.AllServicesLink>
-          }
-          {!hideSearchBar &&
+          )}
+          {!hideSearchBar && (
             <Styles.SearchWrapper>
-                <Searchbar 
-                  isLight={themeContext.cardinal_name === "north" ? true : false} 
-                  submitInfo={{
-                    postTo: "/search",
-                    params: {
-                        type: "search"
-                    }
-                  }}
-                  suggestions={searchSuggestions}
-                />
+              <Searchbar
+                isLight={themeContext.cardinal_name === 'north' ? true : false}
+                submitInfo={{
+                  postTo: '/search',
+                  params: {
+                    type: 'search',
+                  },
+                }}
+                suggestions={searchSuggestions}
+              />
             </Styles.SearchWrapper>
-          }
-
+          )}
         </Styles.StyledMaxWidthContainer>
       </Styles.Container>
     </>
-)};
+  );
+};
 
 export default Header;


### PR DESCRIPTION
Remove the title for the 'All services' link in the header for [accessibility advisory](https://www.a11yproject.com/checklist/#remove-title-attribute-tooltips). Added test. 