### PR TITLE
Remove mobile breadcrumbs 

### DIFF
--- a/src/library/structure/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -3,6 +3,7 @@ import { Story } from '@storybook/react/types-6-0';
 import Breadcrumbs from './Breadcrumbs';
 import { BreadcrumbsProps } from './Breadcrumbs.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
+import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
 
 export default {
   title: 'library/Structure/Breadcrumbs',
@@ -15,7 +16,9 @@ export default {
 
 const Template: Story<BreadcrumbsProps> = (args) => (
   <SBPadding>
-    <Breadcrumbs {...args} />
+    <MaxWidthContainer>
+      <Breadcrumbs {...args} />
+    </MaxWidthContainer>
   </SBPadding>
 );
 

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.styles.js
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.styles.js
@@ -15,9 +15,19 @@ export const List = styled.ol`
 `;
 
 export const Crumb = styled.li`
-  display: inline-block;
   margin-right: ${(props) => props.theme.theme_vars.spacingSizes.small};
   margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  display: none;
+
+  &:first-of-type,
+  &:last-of-type {
+    display: inline-block;
+  }
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    display: inline-block;
+  }
+
   &:last-of-type svg {
     display: none;
   }

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.styles.js
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.styles.js
@@ -3,50 +3,36 @@ import styled from 'styled-components';
 export const Container = styled.div`
   padding-top: 20px;
   border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey}80;
-  margin-bottom: ${(props) => (props.hasMargin ? '30px' : 0)};
+  margin-bottom: ${(props) => (props.hasMargin ? props.theme.theme_vars.spacingSizes.large : 0)};
 `;
 
 export const List = styled.ol`
   list-style: none;
   padding-left: 0px;
   margin-top: 0;
-  display: none;
-  margin-bottom: 20px;
-
-  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
-    display: block;
-  }
+  display: block;
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
 `;
 
 export const Crumb = styled.li`
-  display: inline;
-  margin-right: 10px;
+  display: inline-block;
+  margin-right: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
   &:last-of-type svg {
     display: none;
   }
 `;
+
 export const IconWrapper = styled.div`
   display: inline-block;
-  margin-left: 10px;
+  margin-left: ${(props) => props.theme.theme_vars.spacingSizes.small};
   vertical-align: middle;
 `;
-export const MobileCrumb = styled.div`
-  display: block;
-  padding: 15px 0;
-  margin-top: -15px;
 
-  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
-    display: none;
-  }
-`;
-export const BackIconWrapper = styled.div`
-  display: inline-block;
-  margin-right: 10px;
-  vertical-align: middle;
-`;
 export const BreadcrumbLink = styled.a`
   ${(props) => props.theme.linkStyles}
   font-weight: 400;
+  display: inline-block;
 
   svg {
     fill: ${(props) => props.theme.theme_vars.colours.action};

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.test.tsx
@@ -27,9 +27,9 @@ describe('Breadcrumbs', () => {
       </ThemeProvider>
     );
 
-  const { queryAllByRole, getByTestId } = renderComponent();
-
   it('should render the breadcrumb links', () => {
+    const { queryAllByRole, getByTestId } = renderComponent();
+
     // Include hidden as jest renders mobile first
     const links = queryAllByRole('link', { hidden: true });
 
@@ -42,5 +42,38 @@ describe('Breadcrumbs', () => {
     expect(links[1]).toHaveTextContent('Service landing page');
 
     expect(getByTestId('Breadcrumbs')).toHaveStyle(`margin-bottom: ${west_theme.theme_vars.spacingSizes.large}`);
+  });
+
+  it('should only show the first and last breadcrumb on mobile', () => {
+    props.breadcrumbsArray = [
+      {
+        title: 'Home',
+        url: '/',
+      },
+      {
+        title: 'Service landing page',
+        url: '/service-landing-page',
+      },
+      {
+        title: 'Service page',
+        url: '/service-landing-page/service-page',
+      },
+    ];
+
+    const { queryAllByRole } = renderComponent();
+
+    const links = queryAllByRole('link', { hidden: true });
+
+    expect(links.length).toBe(3);
+
+    expect(links[0]).toBeVisible();
+    expect(links[0]).toHaveAttribute('href', '/');
+    expect(links[0]).toHaveTextContent('Home');
+
+    expect(links[1]).not.toBeVisible();
+
+    expect(links[2]).toBeVisible();
+    expect(links[2]).toHaveAttribute('href', '/service-landing-page/service-page');
+    expect(links[2]).toHaveTextContent('Service page');
   });
 });

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.test.tsx
@@ -33,7 +33,7 @@ describe('Breadcrumbs', () => {
     // Include hidden as jest renders mobile first
     const links = queryAllByRole('link', { hidden: true });
 
-    expect(links.length).toBe(3);
+    expect(links.length).toBe(2);
 
     expect(links[0]).toHaveAttribute('href', '/');
     expect(links[0]).toHaveTextContent('Home');
@@ -41,10 +41,6 @@ describe('Breadcrumbs', () => {
     expect(links[1]).toHaveAttribute('href', '/service-landing-page');
     expect(links[1]).toHaveTextContent('Service landing page');
 
-    // Lastly, a mobile only 'Back' link
-    expect(links[2]).toHaveAttribute('href', '/service-landing-page');
-    expect(links[2]).toHaveTextContent('Back');
-
-    expect(getByTestId('Breadcrumbs')).toHaveStyle('margin-bottom: 30px');
+    expect(getByTestId('Breadcrumbs')).toHaveStyle(`margin-bottom: ${west_theme.theme_vars.spacingSizes.large}`);
   });
 });

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.tsx
@@ -21,17 +21,6 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ breadcrumbsArr
         </Styles.Crumb>
       ))}
     </Styles.List>
-    <Styles.MobileCrumb>
-      <Styles.BreadcrumbLink
-        href={breadcrumbsArray[breadcrumbsArray.length - 1].url}
-        title={'Go back to previous page'}
-      >
-        <Styles.BackIconWrapper>
-          <ChevronIcon direction={'left'} />
-        </Styles.BackIconWrapper>
-        Back
-      </Styles.BreadcrumbLink>
-    </Styles.MobileCrumb>
   </Styles.Container>
 );
 


### PR DESCRIPTION
- Remove the mobile breadcrumbs
- Adjust spacing so that it has even spacing when breadcrumbs wrap on small screens
- Replace px sizes with theme spacingSizes
- Update test as no longer has mobile back link
- Wrap stories in MaxWidthContainer so styles better represent theme styles