### PR TITLE
Fix/warning text disclaimer link title

### DIFF
--- a/src/library/slices/WarningText/WarningText.stories.tsx
+++ b/src/library/slices/WarningText/WarningText.stories.tsx
@@ -1,8 +1,7 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import WarningText from "./WarningText";
-import { WarningTextProps } from "./WarningText.types";
+import WarningText from './WarningText';
+import { WarningTextProps } from './WarningText.types';
 import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
 
 export default {
@@ -11,22 +10,36 @@ export default {
   parameters: {
     status: {
       type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-    }
+    },
   },
 };
 
-const Template: Story<WarningTextProps> = (args) => <MaxWidthContainer noBackground><WarningText {...args}>Aenean lacinia bibendum nulla sed consectetur. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec id elit non mi porta gravida at eget metus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</WarningText></MaxWidthContainer>;
-const Template2: Story<WarningTextProps> = (args) => <MaxWidthContainer noBackground><WarningText {...args}>We are in the process of adding information to this new unitary council website. Some pages will give you a link back to a previous council website to help you find what you need. <a href="/">Read more about the changes</a>.</WarningText></MaxWidthContainer>;
+const Template: Story<WarningTextProps> = (args) => (
+  <MaxWidthContainer noBackground>
+    <WarningText {...args}>
+      Aenean lacinia bibendum nulla sed consectetur. Integer posuere erat a ante venenatis dapibus posuere velit
+      aliquet. Donec id elit non mi porta gravida at eget metus. Integer posuere erat a ante venenatis dapibus posuere
+      velit aliquet.
+    </WarningText>
+  </MaxWidthContainer>
+);
+const Template2: Story<WarningTextProps> = (args) => (
+  <MaxWidthContainer noBackground>
+    <WarningText {...args}>
+      We are in the process of adding information to this new unitary council website. Some pages will give you a link
+      back to a previous council website to help you find what you need. <a href="/">Read more about the changes</a>.
+    </WarningText>
+  </MaxWidthContainer>
+);
 
-
-export const ExampleHighlightText = Template.bind({});    
+export const ExampleHighlightText = Template.bind({});
 ExampleHighlightText.args = {
-  title: "Highlight this text",
-  isWarning: false
+  title: 'Highlight this text',
+  isWarning: false,
 };
 
-export const ExampleDisclaimerText = Template2.bind({});    
+export const ExampleDisclaimerText = Template2.bind({});
 ExampleDisclaimerText.args = {
-  title: "Why information is on a different website",
-  isWarning: true
+  title: 'Why information is on a different website',
+  isWarning: true,
 };

--- a/src/library/slices/WarningText/WarningText.test.tsx
+++ b/src/library/slices/WarningText/WarningText.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import WarningText from './WarningText';
+import { WarningTextProps } from './WarningText.types';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+
+describe('WarningText', () => {
+  let props: WarningTextProps;
+
+  beforeEach(() => {
+    props = {
+      title: 'The warning title',
+      isWarning: true,
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <WarningText {...props}>The warning text body</WarningText>
+      </ThemeProvider>
+    );
+
+  it('should render the warning text', () => {
+    const { getByTestId } = renderComponent();
+    const component = getByTestId('WarningText');
+
+    expect(component).toBeVisible();
+    expect(component).toHaveStyle(`background: ${west_theme.theme_vars.colours.focus}80}`);
+    expect(component).toHaveTextContent(props.title);
+    expect(component).toHaveTextContent('The warning text body');
+  });
+
+  it('should not be a warning', () => {
+    props.isWarning = false;
+
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId('WarningText')).toHaveStyle(`background: ${west_theme.theme_vars.colours.secondary}80}`);
+  });
+});

--- a/src/library/slices/WarningText/WarningText.tsx
+++ b/src/library/slices/WarningText/WarningText.tsx
@@ -1,17 +1,18 @@
+import React from 'react';
+import parse from 'html-react-parser';
+import { WarningTextProps } from './WarningText.types';
+import * as Styles from './WarningText.styles';
 
-import React from "react";
-import parse from "html-react-parser"
+// @TODO this needs to fit within the content border
 
-import { WarningTextProps } from "./WarningText.types";
-import * as Styles from "./WarningText.styles";
-
-// @TODO this needs to fit within the content border 
-
+/**
+ * Display text as a highlight or warning with a title
+ */
 const WarningText: React.FC<WarningTextProps> = ({ title, isWarning = false, children }) => (
-    <Styles.WarningText isWarning={isWarning}>
-        <Styles.Title isWarning={isWarning}>{title}</Styles.Title>
-        <Styles.Content>{children}</Styles.Content>
-    </Styles.WarningText>
+  <Styles.WarningText isWarning={isWarning} data-testid="WarningText">
+    <Styles.Title isWarning={isWarning}>{title}</Styles.Title>
+    <Styles.Content>{children}</Styles.Content>
+  </Styles.WarningText>
 );
 
 export default WarningText;

--- a/src/library/slices/WarningText/WarningText.tsx
+++ b/src/library/slices/WarningText/WarningText.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import parse from 'html-react-parser';
 import { WarningTextProps } from './WarningText.types';
 import * as Styles from './WarningText.styles';
-
-// @TODO this needs to fit within the content border
 
 /**
  * Display text as a highlight or warning with a title

--- a/src/library/slices/WarningText/WarningText.tsx
+++ b/src/library/slices/WarningText/WarningText.tsx
@@ -8,7 +8,7 @@ import * as Styles from './WarningText.styles';
 /**
  * Display text as a highlight or warning with a title
  */
-const WarningText: React.FC<WarningTextProps> = ({ title, isWarning = false, children }) => (
+const WarningText: React.FunctionComponent<WarningTextProps> = ({ title, isWarning = false, children }) => (
   <Styles.WarningText isWarning={isWarning} data-testid="WarningText">
     <Styles.Title isWarning={isWarning}>{title}</Styles.Title>
     <Styles.Content>{children}</Styles.Content>

--- a/src/library/slices/WarningText/WarningText.types.ts
+++ b/src/library/slices/WarningText/WarningText.types.ts
@@ -1,9 +1,9 @@
-
 export interface WarningTextProps {
   /**
    * 	The title of the warning
    */
   title: string;
+
   /**
    * 	Optional to change the colour from a secondary colour to warning
    */

--- a/src/library/slices/WarningTextDisclaimer/WarningTextDisclaimer.stories.tsx
+++ b/src/library/slices/WarningTextDisclaimer/WarningTextDisclaimer.stories.tsx
@@ -1,8 +1,7 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import WarningTextDisclaimer from "./WarningTextDisclaimer";
-import { WarningTextDisclaimerProps } from "./WarningTextDisclaimer.types";
+import WarningTextDisclaimer from './WarningTextDisclaimer';
+import { WarningTextDisclaimerProps } from './WarningTextDisclaimer.types';
 import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
 
 export default {
@@ -11,11 +10,18 @@ export default {
   parameters: {
     status: {
       type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-    }
+    },
   },
 };
 
-const Template: Story<WarningTextDisclaimerProps> = (args) => <MaxWidthContainer><WarningTextDisclaimer {...args}>Aenean lacinia bibendum nulla sed consectetur. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec id elit non mi porta gravida at eget metus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</WarningTextDisclaimer></MaxWidthContainer>;
+const Template: Story<WarningTextDisclaimerProps> = (args) => (
+  <MaxWidthContainer>
+    <WarningTextDisclaimer {...args}>
+      Aenean lacinia bibendum nulla sed consectetur. Integer posuere erat a ante venenatis dapibus posuere velit
+      aliquet. Donec id elit non mi porta gravida at eget metus. Integer posuere erat a ante venenatis dapibus posuere
+      velit aliquet.
+    </WarningTextDisclaimer>
+  </MaxWidthContainer>
+);
 
-
-export const ExampleWarningTextDisclaimer = Template.bind({});    
+export const ExampleWarningTextDisclaimer = Template.bind({});

--- a/src/library/slices/WarningTextDisclaimer/WarningTextDisclaimer.tsx
+++ b/src/library/slices/WarningTextDisclaimer/WarningTextDisclaimer.tsx
@@ -1,15 +1,15 @@
+import React from 'react';
+import { WarningTextDisclaimerProps } from './WarningTextDisclaimer.types';
+import WarningText from '../WarningText/WarningText';
 
-import React from "react";
-
-import { WarningTextDisclaimerProps } from "./WarningTextDisclaimer.types";
-import WarningText from "../WarningText/WarningText";
-
-const WarningTextDisclaimer: React.FC<WarningTextDisclaimerProps> = () => {
-    return(
-        <WarningText title="Why information is on a different website" isWarning>
-            We are in the process of adding information to this new unitary council website. Some pages will give you a link back to a previous council website to help you find what you need. <a href={"/your-council/about-website"} title="Read the article">Read more about the changes</a>.
-        </WarningText>
-    );
-}
+const WarningTextDisclaimer: React.FunctionComponent<WarningTextDisclaimerProps> = () => {
+  return (
+    <WarningText title="Why information is on a different website" isWarning>
+      We are in the process of adding information to this new unitary council website. Some pages will give you a link
+      back to a previous council website to help you find what you need.{' '}
+      <a href={'/your-council/about-website'}>Read more about the council changes</a>.
+    </WarningText>
+  );
+};
 
 export default WarningTextDisclaimer;

--- a/src/library/slices/WarningTextDisclaimer/WarningTextDisclaimer.types.ts
+++ b/src/library/slices/WarningTextDisclaimer/WarningTextDisclaimer.types.ts
@@ -1,4 +1,1 @@
-
-export interface WarningTextDisclaimerProps {
-
-}
+export interface WarningTextDisclaimerProps {}


### PR DESCRIPTION
Update the WarningTextDisclaimer link text and [remove the title](https://www.a11yproject.com/posts/creating-valid-and-accessible-links/#what-about-the-title-attribute%3F). 

Added test for the parent WarningText component and updated the files with prettier for consistency. 