### PR TITLE
Update PostCodeSearch placeholder

### DIFF
--- a/src/library/components/FormWithLine/FormWithLine.tsx
+++ b/src/library/components/FormWithLine/FormWithLine.tsx
@@ -1,39 +1,44 @@
+import React from 'react';
 
-import React from "react";
-
-import { FormWithLineProps } from "./FormWithLine.types";
-import * as Styles from "./FormWithLine.styles";
+import { FormWithLineProps } from './FormWithLine.types';
+import * as Styles from './FormWithLine.styles';
 
 /**
  * Form element - a container with a line on the left
  */
 const FormWithLine: React.FC<FormWithLineProps> = ({
-  lineColour = "#C6C6C6",
-  hideLine = false, 
+  lineColour = '#C6C6C6',
+  hideLine = false,
   formRole,
   formMethod,
   formURL,
   isError = false,
   errorSummary,
   onSubmit,
-  children
-  }) => {
-    return (
-      <Styles.Container>
-        <Styles.Line lineColour={lineColour} hideLine={hideLine} isError={isError} />
-        <Styles.Form onSubmit={onSubmit} hideLine={hideLine} role={formRole} method={formMethod} url={formURL}>
-          {errorSummary && <Styles.ErrorSummary>{errorSummary}</Styles.ErrorSummary>}
-          {children}
-        </Styles.Form>
-      </Styles.Container>
-    );
-  };
-  
+  children,
+}) => {
+  return (
+    <Styles.Container>
+      <Styles.Line lineColour={lineColour} hideLine={hideLine} isError={isError} />
+      <Styles.Form
+        onSubmit={onSubmit}
+        hideLine={hideLine}
+        role={formRole}
+        method={formMethod}
+        url={formURL}
+        data-testid="FormWithLine"
+      >
+        {errorSummary && <Styles.ErrorSummary>{errorSummary}</Styles.ErrorSummary>}
+        {children}
+      </Styles.Form>
+    </Styles.Container>
+  );
+};
 
 export default FormWithLine;
 
-
-{/* <form  class="form form--area-search"  data-area-search="">
+{
+  /* <form  class="form form--area-search"  data-area-search="">
                         <div data-form-title class="area-search__title">Enter your postcode</div>
                         <div data-form-info class="area-search__info">For example HP20 1UY</div>
                         <div data-response-text class="area-search__response-text"></div>
@@ -47,4 +52,5 @@ export default FormWithLine;
                         <button data-find-another-button type="button" class="button button--link hide">
                             Find another postcode
                         </button>
-                    </form> */}
+                    </form> */
+}

--- a/src/library/components/Input/Input.tsx
+++ b/src/library/components/Input/Input.tsx
@@ -1,27 +1,17 @@
-
-import React from "react";
-
-import { InputProps } from "./Input.types";
-import * as Styles from "./Input.styles";
+import React from 'react';
+import { InputProps } from './Input.types';
+import * as Styles from './Input.styles';
 
 /**
  * Primary UI component for user interaction
  */
-const Input: React.FC<InputProps> = ({
-    type = "text",
-    placeholder = "",
-    isErrored = false,
-    errorText,
-    name
-  }) => {
-    return (
-      <>
+const Input: React.FC<InputProps> = ({ type = 'text', placeholder = '', isErrored = false, errorText, name }) => {
+  return (
+    <>
       {errorText && <Styles.ErrorText>{errorText}</Styles.ErrorText>}
-      <Styles.StyledInput type={type} placeholder={isErrored ? "Enter a postcode" : placeholder} name={name} isErrored={isErrored} />
-      </>
-    );
-  };
-  
+      <Styles.StyledInput type={type} placeholder={placeholder} name={name} isErrored={isErrored} />
+    </>
+  );
+};
 
 export default Input;
-

--- a/src/library/components/PostCodeSearch/PostCodeSearch.stories.tsx
+++ b/src/library/components/PostCodeSearch/PostCodeSearch.stories.tsx
@@ -1,22 +1,27 @@
-import React from "react";
-import PostCodeSearch from "./PostCodeSearch";
-import { PostCodeSearchProps } from "./PostCodeSearch.types";
+import React from 'react';
+import PostCodeSearch from './PostCodeSearch';
+import { PostCodeSearchProps } from './PostCodeSearch.types';
 import { Story } from '@storybook/react/types-6-0';
 import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 
 export default {
-    title: 'Library/Components/Post Code Search',
-    component: PostCodeSearch,
-    parameters: {
-      status: {
-        type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      }
+  title: 'Library/Components/Postcode Search',
+  component: PostCodeSearch,
+  parameters: {
+    status: {
+      type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
     },
+  },
 };
 
-const Template: Story<PostCodeSearchProps> = (args) => <SBPadding><MaxWidthContainer><PostCodeSearch {...args} /></MaxWidthContainer></SBPadding>;
+const Template: Story<PostCodeSearchProps> = (args) => (
+  <SBPadding>
+    <MaxWidthContainer>
+      <PostCodeSearch {...args} />
+    </MaxWidthContainer>
+  </SBPadding>
+);
 
 export const Example = Template.bind({});
-Example.args = {
-};
+Example.args = {};

--- a/src/library/components/PostCodeSearch/PostCodeSearch.styles.js
+++ b/src/library/components/PostCodeSearch/PostCodeSearch.styles.js
@@ -1,115 +1,119 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Container = styled.div`
-    strong {
-        font-weight: bold;
-    }
+  strong {
+    font-weight: bold;
+  }
 
-    p {
-        margin-bottom: 15px;
-    }
-`
+  p {
+    margin-bottom: 15px;
+  }
+`;
 export const IconWrapper = styled.span`
-    display: inline-block;
-    margin-right: 15px;
-    padding-left: 3px;
-`
+  display: inline-block;
+  margin-right: 15px;
+  padding-left: 3px;
+`;
 export const DropDownButton = styled.button`
-    background: transparent;
-    border: 0;    
-    ${props => props.theme.linkStyles}
-    font-weight: 400;
-    padding-left: 0;
-    color: ${props => props.theme.theme_vars.colours.black};
-    text-align: left;
-    
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
+  background: transparent;
+  border: 0;
+  ${(props) => props.theme.linkStyles}
+  font-weight: 400;
+  padding-left: 0;
+  color: ${(props) => props.theme.theme_vars.colours.black};
+  text-align: left;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.45;
-    }
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
 
-    &:hover{
-        ${props => props.theme.linkStylesHover}
-        cursor: pointer;
-    }
-    &:focus{
-        ${props => props.theme.linkStylesFocus}
-    }
-    &:active{
-        ${props => props.theme.linkStylesActive}
-    }
-`
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.45;
+  }
+
+  &:hover {
+    ${(props) => props.theme.linkStylesHover}
+    cursor: pointer;
+  }
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus}
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
+  }
+`;
 
 export const DropDownContent = styled.div`
-    margin-top: 10px;
-    
-    input {
-        margin-top: 15px;
-        margin-bottom: 15px;
-    }
-`
+  margin-top: 10px;
+
+  input {
+    margin-top: 15px;
+    margin-bottom: 15px;
+  }
+`;
 
 export const Label = styled.label`
-    margin-bottom: 5px;
-    display: block;
-`
+  margin-bottom: 5px;
+  display: block;
+`;
 
 export const PostcodeResult = styled.div`
-    margin-top: 15px;
+  margin-top: 15px;
 
-    display: flex;
-    -webkit-flex-direction: row;
-    -moz-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-    align-items: flex-start;
+  display: flex;
+  -webkit-flex-direction: row;
+  -moz-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  align-items: flex-start;
 
-    .result {
-        padding-left: 15px;
-        padding-top: 10px;
-        padding-bottom: 12px;
-        max-width: calc(100% - 30px);
-    }
-`
+  .result {
+    padding-left: 15px;
+    padding-top: 10px;
+    padding-bottom: 12px;
+    max-width: calc(100% - 30px);
+  }
+`;
 export const Line = styled.div`
-    background: ${props => props.theme.theme_vars.colours.grey_dark};
-    width: 5px;
-    border-radius: 2px;
-`
+  background: ${(props) => props.theme.theme_vars.colours.grey_dark};
+  width: 5px;
+  border-radius: 2px;
+`;
 
 export const StartAgain = styled.button`
-    background: transparent;
-    border: 0;    
-    margin-top: 15px;
-    margin-left: -6px;
-    ${props => props.theme.linkStyles}
-    &:hover{
-        ${props => props.theme.linkStylesHover}
-        cursor: pointer;
-    }
-    &:focus{
-        ${props => props.theme.linkStylesFocus}
-    }
-    &:active{
-        ${props => props.theme.linkStylesActive}
-    }
+  background: transparent;
+  border: 0;
+  margin-top: 15px;
+  margin-left: -6px;
+  ${(props) => props.theme.linkStyles}
+  &:hover {
+    ${(props) => props.theme.linkStylesHover}
+    cursor: pointer;
+  }
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus}
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
+  }
 
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.45;
-    }
-`
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.45;
+  }
+`;
 
 export const LoadingContainer = styled.div`
-    padding-left: 30px;
-`
+  padding-left: 30px;
+`;
+
+export const FormContainer = styled.div`
+  display: ${(props) => (props.isLoading ? `none` : 'block')};
+`;

--- a/src/library/components/PostCodeSearch/PostCodeSearch.test.tsx
+++ b/src/library/components/PostCodeSearch/PostCodeSearch.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import PostCodeSearch from './PostCodeSearch';
+import { PostCodeSearchProps } from './PostCodeSearch.types';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+import axios from 'axios';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.MockedFunction<typeof axios>;
+
+describe('PostCodeSearch', () => {
+  let props: PostCodeSearchProps;
+
+  beforeEach(() => {
+    props = {
+      title: 'Enter your postcode to find your area',
+      otherCouncilLink: 'https://www.northnorthants.gov.uk',
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <PostCodeSearch {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render the component and open the search', () => {
+    const { getByTestId, queryByPlaceholderText, getByText } = renderComponent();
+
+    const component = getByTestId('PostCodeSearch');
+    const searchInput = queryByPlaceholderText('Search postcode');
+    const expandButton = getByText(props.title);
+
+    expect(component).toBeVisible();
+    expect(expandButton).toBeVisible();
+    expect(searchInput).toBeNull();
+
+    fireEvent.click(expandButton);
+
+    expect(queryByPlaceholderText('Search postcode')).toBeVisible();
+  });
+
+  it('should error with empty postcode', () => {
+    const { getByTestId, getByPlaceholderText, getByText, getByRole } = renderComponent();
+    const component = getByTestId('PostCodeSearch');
+    const expandButton = getByText(props.title);
+
+    fireEvent.click(expandButton);
+    const searchInput = getByPlaceholderText('Search postcode');
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    fireEvent.submit(getByTestId('FormWithLine'));
+
+    expect(component).toHaveTextContent('You need to enter a postcode');
+  });
+
+  it('should display an error for incorrect postcode', async () => {
+    mockedAxios.mockResolvedValue({
+      status: 200,
+      data: 'Incorrect postcode',
+      statusText: 'Ok',
+      headers: {},
+      config: {},
+    });
+
+    const { getByTestId, getByPlaceholderText, getByText, getByRole } = renderComponent();
+    const component = getByTestId('PostCodeSearch');
+    const expandButton = getByText(props.title);
+
+    fireEvent.click(expandButton);
+    const searchInput = getByPlaceholderText('Search postcode');
+
+    fireEvent.change(searchInput, { target: { value: 'FAKE POSTCODE' } });
+
+    fireEvent.submit(getByTestId('FormWithLine'));
+
+    await waitFor(() => {
+      expect(component).toHaveTextContent(
+        'There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new post codes.'
+      );
+    });
+  });
+
+  it('should find a postcode', async () => {
+    mockedAxios.mockResolvedValue({
+      statusText: 'Ok',
+      headers: {},
+      config: {},
+      status: 200,
+      data: {
+        numOfSovereign: 1,
+        sovereign: [
+          {
+            sovereignName: 'Kettering',
+            sovereignCode: 4,
+          },
+        ],
+        numOfUnitary: 1,
+        unitary: [
+          {
+            unitary: 'North',
+            unitaryCode: 1,
+          },
+        ],
+        addresses: [
+          {
+            DPA: {
+              ADDRESS: '123, EXAMPLE ROAD, KETTERING, NORTH POSTCODE',
+              SOVEREIGN_COUNCIL_CODE: 4,
+              SOVEREIGN_COUNCIL_NAME: 'Kettering',
+              UNITARY_COUNCIL_NAME: 'North',
+              UPRN: '12345678910',
+            },
+          },
+        ],
+      },
+    });
+
+    const { getByTestId, getByPlaceholderText, getByText, getByRole } = renderComponent();
+    const component = getByTestId('PostCodeSearch');
+    const expandButton = getByText(props.title);
+
+    fireEvent.click(expandButton);
+    const searchInput = getByPlaceholderText('Search postcode');
+
+    fireEvent.change(searchInput, { target: { value: 'NORTH POSTCODE' } });
+
+    fireEvent.submit(getByTestId('FormWithLine'));
+
+    await waitFor(() => {
+      expect(component).toHaveTextContent(
+        'This postcode NORTH POSTCODE is in North Northamptonshire, in the Kettering area.'
+      );
+      expect(component).toHaveTextContent(
+        'In order to find the right information for you, please visit the North Northamptonshire website and find your local area (Kettering) for this service'
+      );
+
+      const councilLink = getByRole('link');
+
+      expect(councilLink).toHaveAttribute('href', west_theme.theme_vars.other_council_link);
+      expect(councilLink).toHaveTextContent("Go to North Northamptonshire's website");
+    });
+  });
+});

--- a/src/library/components/PostCodeSearch/PostCodeSearch.test.tsx
+++ b/src/library/components/PostCodeSearch/PostCodeSearch.test.tsx
@@ -40,7 +40,7 @@ describe('PostCodeSearch', () => {
 
     fireEvent.click(expandButton);
 
-    expect(queryByPlaceholderText('Search postcode')).toBeVisible();
+    expect(queryByPlaceholderText('Enter a postcode')).toBeVisible();
   });
 
   it('should error with empty postcode', () => {
@@ -49,7 +49,7 @@ describe('PostCodeSearch', () => {
     const expandButton = getByText(props.title);
 
     fireEvent.click(expandButton);
-    const searchInput = getByPlaceholderText('Search postcode');
+    const searchInput = getByPlaceholderText('Enter a postcode');
 
     fireEvent.change(searchInput, { target: { value: '' } });
 
@@ -72,7 +72,7 @@ describe('PostCodeSearch', () => {
     const expandButton = getByText(props.title);
 
     fireEvent.click(expandButton);
-    const searchInput = getByPlaceholderText('Search postcode');
+    const searchInput = getByPlaceholderText('Enter a postcode');
 
     fireEvent.change(searchInput, { target: { value: 'FAKE POSTCODE' } });
 
@@ -80,7 +80,7 @@ describe('PostCodeSearch', () => {
 
     await waitFor(() => {
       expect(component).toHaveTextContent(
-        'There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new post codes.'
+        'There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new postcodes.'
       );
     });
   });
@@ -125,7 +125,7 @@ describe('PostCodeSearch', () => {
     const expandButton = getByText(props.title);
 
     fireEvent.click(expandButton);
-    const searchInput = getByPlaceholderText('Search postcode');
+    const searchInput = getByPlaceholderText('Enter a postcode');
 
     fireEvent.change(searchInput, { target: { value: 'NORTH POSTCODE' } });
 

--- a/src/library/components/PostCodeSearch/PostCodeSearch.tsx
+++ b/src/library/components/PostCodeSearch/PostCodeSearch.tsx
@@ -63,8 +63,8 @@ const PostCodeSearch: React.FunctionComponent<PostCodeSearchProps> = ({
   };
 
   const handleSubmit = (e) => {
-    const enteredPostcode = e.target.elements.postcode.value;
     e.preventDefault();
+    const enteredPostcode = e.target.elements.postcode.value;
     setCurrentPostcode(enteredPostcode);
     if (enteredPostcode === '') {
       handleError(true, 'You need to enter a postcode');
@@ -98,7 +98,7 @@ const PostCodeSearch: React.FunctionComponent<PostCodeSearchProps> = ({
 
   const handleError = (
     error,
-    errorMsg = 'There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new post codes.'
+    errorMsg = 'There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new postcodes.'
   ) => {
     setErrorText(errorMsg);
     setisError(error);
@@ -177,30 +177,30 @@ const PostCodeSearch: React.FunctionComponent<PostCodeSearchProps> = ({
               isError={isError}
               lineColour={themeContext.theme_vars.colours.grey_dark}
             >
-              {isLoading ? (
+              {isLoading && (
                 <Styles.LoadingContainer>
                   <LoadingSpinner />
                   <p>Loading...</p>
                 </Styles.LoadingContainer>
-              ) : (
-                <>
-                  <Styles.Label htmlFor="postcode">
-                    Enter your postcode
-                    <HintText
-                      text={themeContext.cardinal_name === 'north' ? 'For example NN16 0AP' : 'For example NN1 1DE'}
-                    />
-                    <Input
-                      type="text"
-                      placeholder="Search postcode"
-                      name="postcode"
-                      errorText={errorText}
-                      isErrored={isError}
-                    />
-                  </Styles.Label>
-
-                  <FormButton type="submit" aria-label="Submit" text="Find" />
-                </>
               )}
+
+              <Styles.FormContainer isLoading={isLoading}>
+                <Styles.Label htmlFor="postcode">
+                  Enter your postcode
+                  <HintText
+                    text={themeContext.cardinal_name === 'north' ? 'For example NN16 0AP' : 'For example NN1 1DE'}
+                  />
+                  <Input
+                    type="text"
+                    placeholder="Enter a postcode"
+                    name="postcode"
+                    errorText={errorText}
+                    isErrored={isError}
+                  />
+                </Styles.Label>
+
+                <FormButton type="submit" aria-label="Submit" text="Find" />
+              </Styles.FormContainer>
             </FormWithLine>
           ) : (
             <Styles.PostcodeResult>
@@ -229,7 +229,7 @@ const PostCodeSearch: React.FunctionComponent<PostCodeSearchProps> = ({
                   {themeContext.theme_vars.cardinal_name !== responseData.unitary[0].unitary.toLowerCase() ? (
                     <p>
                       In order to find the right information for you, please visit the{' '}
-                      <a href={themeContext.theme_vars.other_council_link} title="Go to the other council">
+                      <a href={themeContext.theme_vars.other_council_link}>
                         {responseData.unitary[0].unitary} Northamptonshire website.
                       </a>
                     </p>

--- a/src/library/components/PostCodeSearch/PostCodeSearch.tsx
+++ b/src/library/components/PostCodeSearch/PostCodeSearch.tsx
@@ -1,87 +1,89 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from 'react';
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
-import axios from 'axios'
-
-import { PostCodeSearchProps } from "./PostCodeSearch.types";
-import * as Styles from "./PostCodeSearch.styles";
-
-import HintText from "../HintText/HintText";
-import FormWithLine from "../FormWithLine/FormWithLine";
-import Input from "../Input/Input";
-import FormButton from "../FormButton/FormButton";
-
+import axios from 'axios';
+import { PostCodeSearchProps } from './PostCodeSearch.types';
+import * as Styles from './PostCodeSearch.styles';
+import HintText from '../HintText/HintText';
+import FormWithLine from '../FormWithLine/FormWithLine';
+import Input from '../Input/Input';
+import FormButton from '../FormButton/FormButton';
 import ChevronIcon from '../../components/icons/ChevronIcon/ChevronIcon';
-import Button from "../Button/Button";
-import { SignpostLinks } from "../../structure/PageStructures";
-import DropDownSelect from "../DropDownSelect/DropDownSelect";
-import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
+import Button from '../Button/Button';
+import { SignpostLinks } from '../../structure/PageStructures';
+import DropDownSelect from '../DropDownSelect/DropDownSelect';
+import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 
 // PostCodeSearchApiKey
-import {PostCodeSearchApiUrl} from '../../helpers/api-helpers';
+import { PostCodeSearchApiUrl } from '../../helpers/api-helpers';
 
 /**
  * The functionality for searching for a postcode
  */
-const PostCodeSearch: React.FC<PostCodeSearchProps> = ({
-    title = "Enter your postcode to find your area",
-    formError = false,
-    otherCouncilLink,
-    signPostLinks,
-    isUnitary = false
-  }) => {
-    const themeContext = useContext(ThemeContext);
-    const [open, setOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-    const [isError, setisError] = useState(formError);
-    const [errorText, setErrorText] = useState("");
-    const [currentPostcode, setCurrentPostcode] = useState("");
-    const [isMultiple, setIsMultiple] = useState(false);
-    const [addressArray, setAddressArray] = useState([]);
+const PostCodeSearch: React.FunctionComponent<PostCodeSearchProps> = ({
+  title = 'Enter your postcode to find your area',
+  formError = false,
+  otherCouncilLink,
+  signPostLinks,
+  isUnitary = false,
+}) => {
+  const themeContext = useContext(ThemeContext);
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setisError] = useState(formError);
+  const [errorText, setErrorText] = useState('');
+  const [currentPostcode, setCurrentPostcode] = useState('');
+  const [isMultiple, setIsMultiple] = useState(false);
+  const [addressArray, setAddressArray] = useState([]);
 
-    const defaultArray = { 
-      numOfSovereign: 0,
-      sovereign: [{
-        sovereignName: "",
-        sovereignCode: 0 
-      }],
-      numOfUnitary: 0,
-      unitary: [{
-        unitary: "",
-        unitaryCode: 0
-      }],
-      addresses: []
+  const defaultArray = {
+    numOfSovereign: 0,
+    sovereign: [
+      {
+        sovereignName: '',
+        sovereignCode: 0,
+      },
+    ],
+    numOfUnitary: 0,
+    unitary: [
+      {
+        unitary: '',
+        unitaryCode: 0,
+      },
+    ],
+    addresses: [],
+  };
+
+  const [responseData, setResponseData] = useState(defaultArray);
+
+  const clearData = () => {
+    setResponseData(defaultArray);
+    setCurrentPostcode('');
+    setAddressArray([]);
+  };
+
+  const handleSubmit = (e) => {
+    const enteredPostcode = e.target.elements.postcode.value;
+    e.preventDefault();
+    setCurrentPostcode(enteredPostcode);
+    if (enteredPostcode === '') {
+      handleError(true, 'You need to enter a postcode');
+    } else {
+      setIsLoading(true);
+      checkPostcode(enteredPostcode);
     }
+  };
 
-    const [responseData, setResponseData] =  useState(defaultArray);
-
-    const clearData = () => {
-      setResponseData(defaultArray)
-      setCurrentPostcode("")
-      setAddressArray([])
-    }
-
-    const handleSubmit= (e) => {
-      e.preventDefault();
-      setCurrentPostcode(e.target.postcode.value)
-      if(e.target.postcode.value === "") {
-        setIsLoading(true);
-        handleError(true, "You need to enter a postcode");
-      } else {
-        checkPostcode(e.target.postcode.value);
-      }
-    }
-
-    const checkPostcode = async (postcode) => {
-      axios({
-        method: "GET",
-        url: `${PostCodeSearchApiUrl}${postcode.replace(/ /g,'')}`
-        // headers: { 'x-api-key': `${PostCodeSearchApiKey}` }
-      })
+  const checkPostcode = async (postcode) => {
+    axios({
+      method: 'GET',
+      url: `${PostCodeSearchApiUrl}${postcode.replace(/ /g, '')}`,
+      // headers: { 'x-api-key': `${PostCodeSearchApiKey}` }
+    })
       .then((response) => {
         setIsLoading(false);
         if (response.data.numOfUnitary > 0) {
-          setResponseData(response.data)
+          setResponseData(response.data);
         } else {
           // console.log(response)
           handleError(true);
@@ -90,136 +92,204 @@ const PostCodeSearch: React.FC<PostCodeSearchProps> = ({
       .catch((error) => {
         setIsLoading(false);
         handleError(true);
-        console.log(error)
-      })
-    }
-
-    const handleError = (error, errorMsg = "There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new post codes.") => {
-      setErrorText(errorMsg)
-      setisError(error)
-    }
-
-    useEffect(() => {
-      if(responseData.numOfUnitary > 0) {
-        if(isError) {
-          handleError(false, "");
-        }
-        if(responseData.numOfUnitary > 1) {
-          setIsMultiple(true);
-          responseData.addresses.map(address => {
-            setAddressArray(addressArray => [...addressArray, {
-              title: address.DPA.ADDRESS.split(',')[0].toLowerCase().replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase()))) + ", " + address.DPA.ADDRESS.split(',')[1].toLowerCase().replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase()))),
-              value: address.DPA.UPRN,
-              info: [{
-                numOfSovereign: 1,
-                sovereign: [{
-                  sovereignName: address.DPA.SOVEREIGN_COUNCIL_NAME,
-                  sovereignCode: address.DPA.SOVEREIGN_COUNCIL_CODE, 
-                }],
-                numOfUnitary: 1,
-                unitary: [{
-                  unitary: address.DPA.UNITARY_COUNCIL_NAME,
-                  unitaryCode: address.DPA.UNITARY_COUNCIL_CODE
-                }],
-                addresses: []                
-              }] 
-            }])
-          })
-        }
-      }
-    }, [responseData]);
-
-
-    function handleAddressChange(e){
-      if(e.target.value !== "") {
-        const singleAddress = addressArray.find(address => address.value === e.target.value);
-        setIsMultiple(false);
-        setResponseData(singleAddress.info[0]);
-        setCurrentPostcode(currentPostcode + " ("+singleAddress.title+")")
-      }
-    }
-
-    return(
-      <Styles.Container>
-        <Styles.DropDownButton onClick={() => setOpen(open ? false : true)}>
-          <Styles.IconWrapper>
-            <ChevronIcon direction={open ? "down" : "right"} colourFill={themeContext.theme_vars.colours.black} />
-          </Styles.IconWrapper>
-          {title}
-        </Styles.DropDownButton>
-        {open && 
-          <Styles.DropDownContent>
-            {responseData.numOfUnitary === 0 ?
-              <FormWithLine onSubmit={e => { handleSubmit(e) }} isError={isError} lineColour={themeContext.theme_vars.colours.grey_dark}>
-                {isLoading ?
-                  <Styles.LoadingContainer>
-                    <LoadingSpinner />
-                    <p>Loading...</p>
-                  </Styles.LoadingContainer>
-                  
-                :
-                <>
-                <Styles.Label htmlFor="postcode">
-                  Enter your postcode
-                  <HintText text={themeContext.cardinal_name === "north" ? "For example NN16 0AP" : "For example NN1 1DE"} />
-                  
-                  <Input type="text" placeholder="Search" name="postcode" errorText={errorText} isErrored={isError} />
-                </Styles.Label>
-
-                <FormButton type="submit" aria-label="Submit" text="Find" />
-                </>
-                }
-              </FormWithLine>
-              :
-              <Styles.PostcodeResult>
-                <Styles.Line />
-                {
-                isMultiple ?
-                <div className="result"> 
-                  <p>This postcode <strong>{currentPostcode}</strong> includes addresses that are in multiple areas, please select your address so that we can tell you which area you are in.</p>
-                  <DropDownSelect onChange={handleAddressChange} id="address" label="Select your address" options={[...[{ title: "Select an address to continue", value: "" }], ...addressArray]}  />
-                </div>
-                :
-                isUnitary ? 
-                  <div className="result">
-                      <p>This postcode <strong>{currentPostcode}</strong> is in <strong>{responseData.unitary[0].unitary} Northamptonshire</strong>, in the <strong>{responseData.sovereign[0].sovereignName}</strong> area.</p>
-                      
-                      {themeContext.theme_vars.cardinal_name !== responseData.unitary[0].unitary.toLowerCase() ?
-                        <p>In order to find the right information for you, please visit the <a href={themeContext.theme_vars.other_council_link} title="Go to the other council">{responseData.unitary[0].unitary} Northamptonshire website.</a></p>
-                        :
-                        <p>You are on the <strong>correct website for this postcode</strong>.</p>
-                      }
-
-                    <Styles.StartAgain onClick={() => clearData()}>Check another postcode</Styles.StartAgain>
-                  </div>
-                  :
-                  themeContext.theme_vars.cardinal_name !== responseData.unitary[0].unitary.toLowerCase() ?
-                    <div className="result"> 
-                      <p>This postcode <strong>{currentPostcode}</strong> is in <strong>{responseData.unitary[0].unitary} Northamptonshire</strong>, in the <strong>{responseData.sovereign[0].sovereignName}</strong> area.</p>
-                      <p>In order to find the right information for you, please visit the {responseData.unitary[0].unitary} Northamptonshire website and find your local area ({responseData.sovereign[0].sovereignName}) for this service.</p>
-
-                      <Button size="large" colourOverride={themeContext.theme_vars.other_council_action} text={"Go to " + (responseData.unitary[0].unitary) + " Northamptonshire's website"} url={otherCouncilLink} isExternal={true} />
-                      <br />
-                      <Styles.StartAgain onClick={() => clearData()}>Check another postcode</Styles.StartAgain>
-                    </div>
-                    :
-                    <div className="result">
-                      <p>The postcode <strong>{currentPostcode}</strong> is in the <strong>{responseData.sovereign[0].sovereignName}</strong> area.</p>
-                      
-                      { signPostLinks.find(link => link.sovereignCode === responseData.sovereign[0].sovereignCode) && 
-                        <Button size="large" text={"Go to " + responseData.sovereign[0].sovereignName} url={signPostLinks.find(link => link.sovereignCode === responseData.sovereign[0].sovereignCode).url} />
-                      }<br />
-                      <Styles.StartAgain onClick={() => clearData()}>Check another postcode</Styles.StartAgain>
-                    </div>
-                }
-              </Styles.PostcodeResult>
-            }
-          </Styles.DropDownContent>
-        }
-      </Styles.Container>
-    );
+        console.log(error);
+      });
   };
-  
+
+  const handleError = (
+    error,
+    errorMsg = 'There is an issue with the postcode you entered, it may not be in Northamptonshire, or if your property is new there may be a 6 week delay for new post codes.'
+  ) => {
+    setErrorText(errorMsg);
+    setisError(error);
+  };
+
+  useEffect(() => {
+    if (responseData.numOfUnitary > 0) {
+      if (isError) {
+        handleError(false, '');
+      }
+      if (responseData.numOfUnitary > 1) {
+        setIsMultiple(true);
+        responseData.addresses.map((address) => {
+          setAddressArray((addressArray) => [
+            ...addressArray,
+            {
+              title:
+                address.DPA.ADDRESS.split(',')[0]
+                  .toLowerCase()
+                  .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase())) +
+                ', ' +
+                address.DPA.ADDRESS.split(',')[1]
+                  .toLowerCase()
+                  .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase())),
+              value: address.DPA.UPRN,
+              info: [
+                {
+                  numOfSovereign: 1,
+                  sovereign: [
+                    {
+                      sovereignName: address.DPA.SOVEREIGN_COUNCIL_NAME,
+                      sovereignCode: address.DPA.SOVEREIGN_COUNCIL_CODE,
+                    },
+                  ],
+                  numOfUnitary: 1,
+                  unitary: [
+                    {
+                      unitary: address.DPA.UNITARY_COUNCIL_NAME,
+                      unitaryCode: address.DPA.UNITARY_COUNCIL_CODE,
+                    },
+                  ],
+                  addresses: [],
+                },
+              ],
+            },
+          ]);
+        });
+      }
+    }
+  }, [responseData]);
+
+  function handleAddressChange(e) {
+    if (e.target.value !== '') {
+      const singleAddress = addressArray.find((address) => address.value === e.target.value);
+      setIsMultiple(false);
+      setResponseData(singleAddress.info[0]);
+      setCurrentPostcode(currentPostcode + ' (' + singleAddress.title + ')');
+    }
+  }
+
+  return (
+    <Styles.Container data-testid="PostCodeSearch">
+      <Styles.DropDownButton onClick={() => setOpen(open ? false : true)}>
+        <Styles.IconWrapper>
+          <ChevronIcon direction={open ? 'down' : 'right'} colourFill={themeContext.theme_vars.colours.black} />
+        </Styles.IconWrapper>
+        {title}
+      </Styles.DropDownButton>
+      {open && (
+        <Styles.DropDownContent>
+          {responseData.numOfUnitary === 0 ? (
+            <FormWithLine
+              onSubmit={(e) => {
+                handleSubmit(e);
+              }}
+              isError={isError}
+              lineColour={themeContext.theme_vars.colours.grey_dark}
+            >
+              {isLoading ? (
+                <Styles.LoadingContainer>
+                  <LoadingSpinner />
+                  <p>Loading...</p>
+                </Styles.LoadingContainer>
+              ) : (
+                <>
+                  <Styles.Label htmlFor="postcode">
+                    Enter your postcode
+                    <HintText
+                      text={themeContext.cardinal_name === 'north' ? 'For example NN16 0AP' : 'For example NN1 1DE'}
+                    />
+                    <Input
+                      type="text"
+                      placeholder="Search postcode"
+                      name="postcode"
+                      errorText={errorText}
+                      isErrored={isError}
+                    />
+                  </Styles.Label>
+
+                  <FormButton type="submit" aria-label="Submit" text="Find" />
+                </>
+              )}
+            </FormWithLine>
+          ) : (
+            <Styles.PostcodeResult>
+              <Styles.Line />
+              {isMultiple ? (
+                <div className="result">
+                  <p>
+                    This postcode <strong>{currentPostcode}</strong> includes addresses that are in multiple areas,
+                    please select your address so that we can tell you which area you are in.
+                  </p>
+                  <DropDownSelect
+                    onChange={handleAddressChange}
+                    id="address"
+                    label="Select your address"
+                    options={[...[{ title: 'Select an address to continue', value: '' }], ...addressArray]}
+                  />
+                </div>
+              ) : isUnitary ? (
+                <div className="result">
+                  <p>
+                    This postcode <strong>{currentPostcode}</strong> is in{' '}
+                    <strong>{responseData.unitary[0].unitary} Northamptonshire</strong>, in the{' '}
+                    <strong>{responseData.sovereign[0].sovereignName}</strong> area.
+                  </p>
+
+                  {themeContext.theme_vars.cardinal_name !== responseData.unitary[0].unitary.toLowerCase() ? (
+                    <p>
+                      In order to find the right information for you, please visit the{' '}
+                      <a href={themeContext.theme_vars.other_council_link} title="Go to the other council">
+                        {responseData.unitary[0].unitary} Northamptonshire website.
+                      </a>
+                    </p>
+                  ) : (
+                    <p>
+                      You are on the <strong>correct website for this postcode</strong>.
+                    </p>
+                  )}
+
+                  <Styles.StartAgain onClick={() => clearData()}>Check another postcode</Styles.StartAgain>
+                </div>
+              ) : themeContext.theme_vars.cardinal_name !== responseData.unitary[0].unitary.toLowerCase() ? (
+                <div className="result">
+                  <p>
+                    This postcode <strong>{currentPostcode}</strong> is in{' '}
+                    <strong>{responseData.unitary[0].unitary} Northamptonshire</strong>, in the{' '}
+                    <strong>{responseData.sovereign[0].sovereignName}</strong> area.
+                  </p>
+                  <p>
+                    In order to find the right information for you, please visit the {responseData.unitary[0].unitary}{' '}
+                    Northamptonshire website and find your local area ({responseData.sovereign[0].sovereignName}) for
+                    this service.
+                  </p>
+
+                  <Button
+                    size="large"
+                    colourOverride={themeContext.theme_vars.other_council_action}
+                    text={'Go to ' + responseData.unitary[0].unitary + " Northamptonshire's website"}
+                    url={otherCouncilLink}
+                    isExternal={true}
+                  />
+                  <br />
+                  <Styles.StartAgain onClick={() => clearData()}>Check another postcode</Styles.StartAgain>
+                </div>
+              ) : (
+                <div className="result">
+                  <p>
+                    The postcode <strong>{currentPostcode}</strong> is in the{' '}
+                    <strong>{responseData.sovereign[0].sovereignName}</strong> area.
+                  </p>
+
+                  {signPostLinks?.find((link) => link.sovereignCode === responseData.sovereign[0].sovereignCode) && (
+                    <Button
+                      size="large"
+                      text={'Go to ' + responseData.sovereign[0].sovereignName}
+                      url={
+                        signPostLinks.find((link) => link.sovereignCode === responseData.sovereign[0].sovereignCode).url
+                      }
+                    />
+                  )}
+                  <br />
+                  <Styles.StartAgain onClick={() => clearData()}>Check another postcode</Styles.StartAgain>
+                </div>
+              )}
+            </Styles.PostcodeResult>
+          )}
+        </Styles.DropDownContent>
+      )}
+    </Styles.Container>
+  );
+};
 
 export default PostCodeSearch;
-


### PR DESCRIPTION
Lots of changes for a placeholder text change... 

Managed to figure out how to mock axios (after many hours trawling stack overflow) so the tests shouldn't need access to the real api to run. This allows us to control the response. 

The tests wouldn't work with `e.target.postcode.value` in handleSubmit so I updated it to use `e.target.elements.postcode.value`. 

There was also a bug where it activated the loading state when the postcode was empty so it never displayed the error message. 