### PR TITLE
Add optional breadcrumb to HeroImage

### DIFF
--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
@@ -71,7 +71,7 @@ export const MicroSiteExample = Template.bind({});
 MicroSiteExample.args = {
   title: 'Northamptonshire Country Parks',
   heroImage: HeroImageExampleMicroSiteData, // empty headline in this overriden by title above
-  breadcrumbsArray: micrositeBreadcrumbs,
+  breadcrumbsArray: null,
   bodyText: ' ',
   sections: sections.slice(0, 1),
   footerLinks,
@@ -84,7 +84,7 @@ export const MicroSiteWithTopServicesExample = Template.bind({});
 MicroSiteWithTopServicesExample.args = {
   title: 'Northamptonshire Country Parks',
   heroImage: HeroImageExampleMicroSiteData, // empty headline in this overriden by title above
-  breadcrumbsArray: micrositeBreadcrumbs,
+  breadcrumbsArray: null,
   bodyText: ' ',
   sections: sections.slice(0, 1),
   footerLinks,
@@ -121,7 +121,7 @@ export const MicroSiteWithAlertExample = Template.bind({});
 MicroSiteWithAlertExample.args = {
   title: 'Northamptonshire Country Parks',
   heroImage: HeroImageExampleMicroSiteData, // empty headline in this overriden by title above
-  breadcrumbsArray: breadcrumbs,
+  breadcrumbsArray: null,
   bodyText: ' ',
   sections: sections.slice(0, 1),
   footerLinks,

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
@@ -3,12 +3,16 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { ServiceLandingPageExample } from './ServiceLandingPageExample';
 import { ServiceLandingPageExampleProps } from './ServiceLandingPageExample.types';
-import { HeroImageExampleMicroSiteData } from '../../structure/HeroImage/HeroImage.storydata';
+import {
+  HeroImageExampleMicroSiteData,
+  HeroImageExampleBoxedWithBreadcrumbData,
+} from '../../structure/HeroImage/HeroImage.storydata';
 import {
   threeTopServicesData,
   sixTopServicesData,
   sections,
   breadcrumbs,
+  micrositeBreadcrumbs,
   footerLinks,
   serviceAlert,
 } from './ServiceLandingPageExample.storydata';
@@ -67,7 +71,7 @@ export const MicroSiteExample = Template.bind({});
 MicroSiteExample.args = {
   title: 'Northamptonshire Country Parks',
   heroImage: HeroImageExampleMicroSiteData, // empty headline in this overriden by title above
-  breadcrumbsArray: breadcrumbs,
+  breadcrumbsArray: micrositeBreadcrumbs,
   bodyText: ' ',
   sections: sections.slice(0, 1),
   footerLinks,
@@ -80,7 +84,7 @@ export const MicroSiteWithTopServicesExample = Template.bind({});
 MicroSiteWithTopServicesExample.args = {
   title: 'Northamptonshire Country Parks',
   heroImage: HeroImageExampleMicroSiteData, // empty headline in this overriden by title above
-  breadcrumbsArray: breadcrumbs,
+  breadcrumbsArray: micrositeBreadcrumbs,
   bodyText: ' ',
   sections: sections.slice(0, 1),
   footerLinks,
@@ -93,14 +97,8 @@ MicroSiteWithTopServicesExample.args = {
 export const MicroSiteBoxedExample = Template.bind({});
 MicroSiteBoxedExample.args = {
   title: 'Northamptonshire Country Parks',
-  heroImage: {
-    ...HeroImageExampleMicroSiteData,
-    callToActionText: '...google It!',
-    callToActionURL: 'https://www.google.com',
-    content: "<p>They're wicked innit, don't just believe us...</p>",
-    backgroundBox: true,
-  }, // empty headline in this overriden by title above
-  breadcrumbsArray: breadcrumbs,
+  heroImage: HeroImageExampleBoxedWithBreadcrumbData, // empty headline in this overriden by title above
+  breadcrumbsArray: micrositeBreadcrumbs,
   bodyText: ' ',
   sections: sections.slice(0, 1),
   footerLinks,

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.storydata.ts
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.storydata.ts
@@ -175,6 +175,17 @@ export const breadcrumbs: BreadcrumbProp[] = [
   },
 ];
 
+export const micrositeBreadcrumbs: BreadcrumbProp[] = [
+  {
+    title: 'Home',
+    url: '/',
+  },
+  {
+    title: 'Country Parks',
+    url: '/country-parks',
+  },
+];
+
 export const serviceAlert: AlertBannerServiceProps = {
   children: 'This is the alert text.',
   title: 'An example service alert',

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
@@ -32,8 +32,7 @@ export const ServiceLandingPageExample: React.FunctionComponent<ServiceLandingPa
           imageSmall={heroImage.imageSmall}
           imageAltText={heroImage.imageAltText}
           backgroundBox={heroImage.backgroundBox}
-          showBreadcrumb={heroImage.showBreadcrumb}
-          breadcrumbsArray={breadcrumbsArray}
+          breadcrumb={breadcrumbsArray?.[breadcrumbsArray.length - 1]}
         />
 
         {serviceAlert?.alertType && (

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
@@ -32,6 +32,8 @@ export const ServiceLandingPageExample: React.FunctionComponent<ServiceLandingPa
           imageSmall={heroImage.imageSmall}
           imageAltText={heroImage.imageAltText}
           backgroundBox={heroImage.backgroundBox}
+          showBreadcrumb={heroImage.showBreadcrumb}
+          breadcrumbsArray={breadcrumbsArray}
         />
 
         {serviceAlert?.alertType && (

--- a/src/library/structure/HeroImage/HeroImage.stories.tsx
+++ b/src/library/structure/HeroImage/HeroImage.stories.tsx
@@ -6,6 +6,7 @@ import {
   HeroImageExampleGradientData,
   HeroImageExampleBoxedData,
   HeroImageExampleMicroSiteData,
+  HeroImageExampleBoxedWithBreadcrumbData,
 } from './HeroImage.storydata';
 
 export default {
@@ -57,3 +58,6 @@ HeroImageExampleGradientTitleOnly.args = {
   headline: 'Example Microsite Title',
   ...HeroImageExampleMicroSiteData,
 };
+
+export const HeroImageWithBreadcrumb = Template.bind({});
+HeroImageWithBreadcrumb.args = HeroImageExampleBoxedWithBreadcrumbData;

--- a/src/library/structure/HeroImage/HeroImage.storydata.ts
+++ b/src/library/structure/HeroImage/HeroImage.storydata.ts
@@ -36,3 +36,18 @@ export const HeroImageExampleMicroSiteData: HeroImageProps = {
   imageAltText: 'Lush green parkland',
   backgroundBox: false,
 };
+
+export const HeroImageExampleBoxedWithBreadcrumbData: HeroImageProps = {
+  showBreadcrumb: true,
+  breadcrumbsArray: [
+    {
+      title: 'Home',
+      url: '/',
+    },
+    {
+      title: 'Country Parks',
+      url: '/country-parks',
+    },
+  ],
+  ...HeroImageExampleBoxedData,
+};

--- a/src/library/structure/HeroImage/HeroImage.storydata.ts
+++ b/src/library/structure/HeroImage/HeroImage.storydata.ts
@@ -38,16 +38,9 @@ export const HeroImageExampleMicroSiteData: HeroImageProps = {
 };
 
 export const HeroImageExampleBoxedWithBreadcrumbData: HeroImageProps = {
-  showBreadcrumb: true,
-  breadcrumbsArray: [
-    {
-      title: 'Home',
-      url: '/',
-    },
-    {
-      title: 'Country Parks',
-      url: '/country-parks',
-    },
-  ],
+  breadcrumb: {
+    title: 'Home',
+    url: '/',
+  },
   ...HeroImageExampleBoxedData,
 };

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -140,10 +140,18 @@ export const CallToActionLink = styled.a`
 export const BreadcrumbLink = styled.a`
   ${(props) => props.theme.fontStyles}
   ${(props) => props.theme.linkStyles}
+  color: ${(props) =>
+    props.backgroundBox ? props.theme.theme_vars.colours.action : props.theme.theme_vars.colours.white};
   margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
   display: block;
 
-  &:hover {
+  &:hover,
+  &:focus {
     text-decoration-style: dashed;
+    text-shadow: ${(props) =>
+      props.backgroundBox
+        ? 'none'
+        : `2px 2px 4px rgba(150, 150, 150, 0.5), -2px 2px 4px rgba(150, 150, 150, 0.5),
+      2px -2px 4px rgba(150, 150, 150, 0.5), -2px -2px 4px rgba(150, 150, 150, 0.5)`};
   }
 `;

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -1,5 +1,5 @@
-import styled from "styled-components";
-import Heading from "../../components/Heading/Heading";
+import styled from 'styled-components';
+import Heading from '../../components/Heading/Heading';
 
 /**
  * Hero image container with optional dark gradient for non-box mode
@@ -7,21 +7,38 @@ import Heading from "../../components/Heading/Heading";
  */
 export const Container = styled.div`
   background-image: ${(props) =>
-    !props.backgroundBox
-      ? `linear-gradient(to bottom left, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75)),`
-      : ``} url("${(props) => props.image}");
-  
-  /* phones */
-  padding-top: 90%;
-  /* everything else */
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.s}){
-    padding-top: 31.25%;
-  }
+      !props.backgroundBox ? `linear-gradient(to bottom left, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75)),` : ``}
+    url('${(props) => props.image}');
+
   padding-bottom: 10px;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
-  position: relative;
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  align-items: flex-end;
+
+  &::before {
+    content: '';
+    /* phones */
+    padding-top: 90%;
+    /* everything else */
+    @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+      padding-top: 31.25%;
+    }
+  }
+`;
+
+export const InnerContainer = styled.div`
+  max-width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  flex-grow: 1;
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
+    max-width: ${(props) => props.theme.theme_vars.breakpoints.l};
+  }
 `;
 
 /**
@@ -30,18 +47,13 @@ export const Container = styled.div`
 export const Overlay = styled.div`
   ${(props) => props.theme.fontStyles}
   text-align: left;
-  position: absolute;
-  bottom: 14%;
-  left: 8%;
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.x_large};
+  margin-left: 15px;
   padding: 25px 25px 0 25px;
   color: ${(props) =>
-    props.backgroundBox
-      ? props.theme.theme_vars.colours.black
-      : props.theme.theme_vars.colours.white};
+    props.backgroundBox ? props.theme.theme_vars.colours.black : props.theme.theme_vars.colours.white};
   background-color: ${(props) =>
-    props.backgroundBox
-      ? props.theme.theme_vars.colours.grey_light + "F2"
-      : `transparent`};
+    props.backgroundBox ? props.theme.theme_vars.colours.grey_light + 'F2' : `transparent`};
   box-shadow: ${(props) =>
     props.backgroundBox
       ? `0px -4px 0px 0px ` + props.theme.theme_vars.colours.action + ` inset, 0px 4px 15px rgba(0, 0, 0, 0.11)`
@@ -50,43 +62,44 @@ export const Overlay = styled.div`
   border-radius: 5px;
 
   /* default - phones */
-  max-width: 70%;
+  max-width: 80%;
 
   /* tablets */
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-    max-width: 50%;
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    max-width: 60%;
+    margin-left: ${(props) => props.theme.theme_vars.spacingSizes.large};
   }
 
   /* desktop */
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.l}){
-    max-width: 35%;
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
+    max-width: 50%;
+    margin-left: 0;
   }
 `;
 
 export const Headline = styled(Heading)`
   margin: 0;
   color: ${(props) =>
-    props.backgroundBox
-      ? props.theme.theme_vars.colours.black
-      : props.theme.theme_vars.colours.white};
-  
+    props.backgroundBox ? props.theme.theme_vars.colours.black : props.theme.theme_vars.colours.white};
+
   /* default - phones */
   font-size: 22px;
 
   /* tablets */
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     font-size: 32px;
   }
 
   /* desktop */
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.l}){
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
     font-size: 44px;
   }
 `;
 
 export const Content = styled.div`
   margin-top: 10px;
-  p, div {
+  p,
+  div {
     margin-bottom: 10px;
   }
 `;
@@ -107,12 +120,21 @@ export const CallToActionLink = styled.a`
   &:hover,
   &:focus {
     text-decoration-style: dotted;
-    text-shadow: 2px 2px 4px rgba(150, 150, 150, 0.5),
-      -2px 2px 4px rgba(150, 150, 150, 0.5),
-      2px -2px 4px rgba(150, 150, 150, 0.5),
-      -2px -2px 4px rgba(150, 150, 150, 0.5);
+    text-shadow: 2px 2px 4px rgba(150, 150, 150, 0.5), -2px 2px 4px rgba(150, 150, 150, 0.5),
+      2px -2px 4px rgba(150, 150, 150, 0.5), -2px -2px 4px rgba(150, 150, 150, 0.5);
   }
   &:active {
     transform: translate(3px);
+  }
+`;
+
+export const BreadcrumbLink = styled.a`
+  ${(props) => props.theme.fontStyles}
+  ${(props) => props.theme.linkStyles}
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  display: block;
+
+  &:hover {
+    text-decoration-style: dashed;
   }
 `;

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -23,8 +23,12 @@ export const Container = styled.div`
     content: '';
     /* phones */
     padding-top: 90%;
-    /* everything else */
+    /* tablet */
     @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+      padding-top: 40%;
+    }
+    /* everything else */
+    @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
       padding-top: 31.25%;
     }
   }
@@ -47,8 +51,9 @@ export const InnerContainer = styled.div`
 export const Overlay = styled.div`
   ${(props) => props.theme.fontStyles}
   text-align: left;
-  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.x_large};
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
   margin-left: 15px;
+  margin-right: 15px;
   padding: 25px 25px 0 25px;
   color: ${(props) =>
     props.backgroundBox ? props.theme.theme_vars.colours.black : props.theme.theme_vars.colours.white};
@@ -60,20 +65,24 @@ export const Overlay = styled.div`
       : `none`};
 
   border-radius: 5px;
+  overflow: hidden;
 
   /* default - phones */
-  max-width: 80%;
+  max-width: calc(100% - 30px);
 
   /* tablets */
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
-    max-width: 60%;
+    max-width: 65%;
     margin-left: ${(props) => props.theme.theme_vars.spacingSizes.large};
+    margin-right: 0;
+    margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.medium};
   }
 
   /* desktop */
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
     max-width: 50%;
     margin-left: 0;
+    margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.x_large};
   }
 `;
 

--- a/src/library/structure/HeroImage/HeroImage.test.tsx
+++ b/src/library/structure/HeroImage/HeroImage.test.tsx
@@ -4,6 +4,7 @@ import HeroImage from './HeroImage';
 import { HeroImageProps } from './HeroImage.types';
 import { west_theme } from '../../../themes/theme_generator';
 import { ThemeProvider } from 'styled-components';
+import { breadcrumbs } from '../../pages/ServiceLandingPageExample/ServiceLandingPageExample.storydata';
 
 describe('HeroImage slice', () => {
   it('should render text in a box when backgroundBox is true', () => {
@@ -123,5 +124,46 @@ describe('HeroImage slice', () => {
 
     const imgaltspan = queryByRole('img');
     expect(imgaltspan).toBeNull();
+  });
+
+  it('should display the parent breadcrumb in the hero image', () => {
+    let props: HeroImageProps = {
+      imageLarge:
+        'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg',
+      imageSmall:
+        'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/144/81/0/2021-12/Abington_Park_1.jpg',
+      imageAltText: 'alt text',
+      backgroundBox: true,
+      headline: 'Headline',
+      content: '<p>Hello world</p>',
+      showBreadcrumb: true,
+      breadcrumbsArray: [
+        {
+          title: 'Home',
+          url: '/',
+        },
+        {
+          title: 'Country Parks',
+          url: '/country-parks',
+        },
+      ],
+    };
+
+    const renderComponent = () =>
+      render(
+        <ThemeProvider theme={west_theme}>
+          <HeroImage {...props} />
+        </ThemeProvider>
+      );
+
+    const { getByText, queryByText } = renderComponent();
+
+    const breadcrumb = getByText('Country Parks');
+
+    expect(breadcrumb).toBeVisible();
+    expect(breadcrumb).toHaveAttribute('href', '/country-parks');
+    expect(breadcrumb).toHaveStyle(`color: ${west_theme.theme_vars.colours.action}`);
+
+    expect(queryByText('Home')).toBeNull();
   });
 });

--- a/src/library/structure/HeroImage/HeroImage.test.tsx
+++ b/src/library/structure/HeroImage/HeroImage.test.tsx
@@ -136,17 +136,10 @@ describe('HeroImage slice', () => {
       backgroundBox: true,
       headline: 'Headline',
       content: '<p>Hello world</p>',
-      showBreadcrumb: true,
-      breadcrumbsArray: [
-        {
-          title: 'Home',
-          url: '/',
-        },
-        {
-          title: 'Country Parks',
-          url: '/country-parks',
-        },
-      ],
+      breadcrumb: {
+        title: 'Country Parks',
+        url: '/country-parks',
+      },
     };
 
     const renderComponent = () =>

--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -18,7 +18,11 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
   imageLarge,
   imageSmall,
   imageAltText,
+  showBreadcrumb = false,
+  breadcrumbsArray,
 }) => {
+  const breadcrumb = breadcrumbsArray?.[breadcrumbsArray.length - 1];
+
   return (
     <>
       <LazyImage
@@ -35,17 +39,22 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
             backgroundBox={backgroundBox}
             data-testid="HeroImage"
           >
-            <Styles.Overlay backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
-              {headline && <Styles.Headline level={1} text={headline} backgroundBox={backgroundBox} />}
-              {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
-              {callToActionURL && backgroundBox && <CallToAction url={callToActionURL} text={callToActionText} />}
-              {!callToActionURL && backgroundBox && <br />}
-              {callToActionURL && !backgroundBox && (
-                <Styles.CallToActionLink href={callToActionURL}>
-                  {callToActionText ? callToActionText : 'Find out more'}
-                </Styles.CallToActionLink>
-              )}
-            </Styles.Overlay>
+            <Styles.InnerContainer>
+              <Styles.Overlay backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
+                {showBreadcrumb && breadcrumb && (
+                  <Styles.BreadcrumbLink href={breadcrumb.url}>{breadcrumb.title}</Styles.BreadcrumbLink>
+                )}
+                {headline && <Styles.Headline level={1} text={headline} backgroundBox={backgroundBox} />}
+                {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
+                {callToActionURL && backgroundBox && <CallToAction url={callToActionURL} text={callToActionText} />}
+                {!callToActionURL && backgroundBox && <br />}
+                {callToActionURL && !backgroundBox && (
+                  <Styles.CallToActionLink href={callToActionURL}>
+                    {callToActionText ? callToActionText : 'Find out more'}
+                  </Styles.CallToActionLink>
+                )}
+              </Styles.Overlay>
+            </Styles.InnerContainer>
           </Styles.Container>
         )}
       </LazyImage>

--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -18,11 +18,8 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
   imageLarge,
   imageSmall,
   imageAltText,
-  showBreadcrumb = false,
-  breadcrumbsArray,
+  breadcrumb,
 }) => {
-  const breadcrumb = breadcrumbsArray?.[breadcrumbsArray.length - 1];
-
   return (
     <>
       <LazyImage
@@ -41,9 +38,7 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
           >
             <Styles.InnerContainer>
               <Styles.Overlay backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
-                {showBreadcrumb && breadcrumb && (
-                  <Styles.BreadcrumbLink href={breadcrumb.url}>{breadcrumb.title}</Styles.BreadcrumbLink>
-                )}
+                {breadcrumb && <Styles.BreadcrumbLink href={breadcrumb.url}>{breadcrumb.title}</Styles.BreadcrumbLink>}
                 {headline && <Styles.Headline level={1} text={headline} backgroundBox={backgroundBox} />}
                 {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
                 {callToActionURL && backgroundBox && <CallToAction url={callToActionURL} text={callToActionText} />}

--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -38,7 +38,11 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
           >
             <Styles.InnerContainer>
               <Styles.Overlay backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
-                {breadcrumb && <Styles.BreadcrumbLink href={breadcrumb.url}>{breadcrumb.title}</Styles.BreadcrumbLink>}
+                {breadcrumb && (
+                  <Styles.BreadcrumbLink href={breadcrumb.url} backgroundBox={backgroundBox}>
+                    {breadcrumb.title}
+                  </Styles.BreadcrumbLink>
+                )}
                 {headline && <Styles.Headline level={1} text={headline} backgroundBox={backgroundBox} />}
                 {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
                 {callToActionURL && backgroundBox && <CallToAction url={callToActionURL} text={callToActionText} />}

--- a/src/library/structure/HeroImage/HeroImage.types.ts
+++ b/src/library/structure/HeroImage/HeroImage.types.ts
@@ -42,12 +42,7 @@ export interface HeroImageProps {
   backgroundBox: boolean;
 
   /**
-   * Should the breadcrumb be shown
+   * An optional breadcrumb. If not set then the breadcrumb is not shown
    */
-  showBreadcrumb?: boolean;
-
-  /**
-   * An optional array of breadcrumbs
-   */
-  breadcrumbsArray?: BreadcrumbProp[];
+  breadcrumb?: BreadcrumbProp;
 }

--- a/src/library/structure/HeroImage/HeroImage.types.ts
+++ b/src/library/structure/HeroImage/HeroImage.types.ts
@@ -1,3 +1,5 @@
+import { BreadcrumbProp } from '../Breadcrumbs/Breadcrumbs.types';
+
 export interface HeroImageProps {
   /**
    * Headline text, optional. Intention to use page title if missing.
@@ -38,4 +40,14 @@ export interface HeroImageProps {
    * Set to true to put the text and call to action on a white box, false to overlay on a darkened image
    */
   backgroundBox: boolean;
+
+  /**
+   * Should the breadcrumb be shown
+   */
+  showBreadcrumb?: boolean;
+
+  /**
+   * An optional array of breadcrumbs
+   */
+  breadcrumbsArray?: BreadcrumbProp[];
 }


### PR DESCRIPTION
Added the option to display the parent breadcrumb in the hero image. By default it is disabled. If set to display, it will display the breadcrumb above the title in the hero image. 

As part of this it was requested to make the hero image content the maximum width of the page. This involved more refactoring than I thought and ended up using flexbox for positioning and size, instead of position: absolute. Quite a big change for a small change. 

## To test
- `npm run test HeroImage`
- Check the HeroImage in structure, ensuring it displays as expected in different screen resolutions
- Check the HeroImage in the ServiceLandingPage examples, ensuring it displays as expected in different screen resolutions