### PR TITLE
Fix alert banner width being overwritten

### DIFF
--- a/src/library/structure/AlertBanner/AlertBanner.styles.js
+++ b/src/library/structure/AlertBanner/AlertBanner.styles.js
@@ -78,7 +78,7 @@ export const BannerTitle = styled.p`
 
 export const BannerContent = styled.div`
   p {
-    max-width: 100%;
+    max-width: 100% !important;
   }
 `;
 


### PR DESCRIPTION
It seems styled components overwrite nested styles so have to use !important to ensure the style is not overwritten. 