### PR TITLE
Fix SectionLinks alt attribute

### DIFF
--- a/src/library/structure/SectionLinks/SectionLinks.styles.js
+++ b/src/library/structure/SectionLinks/SectionLinks.styles.js
@@ -101,7 +101,7 @@ export const Summary = styled.p`
   font-weight: 400;
 `;
 
-export const ImageContainer = styled.figure`
+export const ImageContainer = styled.span`
   position: relative;
   padding-top: 56.25%;
   width: 100%;

--- a/src/library/structure/SectionLinks/SectionLinks.test.tsx
+++ b/src/library/structure/SectionLinks/SectionLinks.test.tsx
@@ -110,9 +110,9 @@ describe('Section Links', () => {
     expect(images).toHaveLength(2);
 
     expect(images[0]).toHaveStyle('background: url("/small-image-1.jpg") center center / cover no-repeat;');
-    expect(images[0]).toHaveAttribute('alt', 'The first image alt text');
+    expect(images[0]).toHaveAttribute('aria-label', 'The first image alt text');
 
     expect(images[1]).toHaveStyle('background: url("/small-image-2.jpg") center center / cover no-repeat;');
-    expect(images[1]).toHaveAttribute('alt', 'The second image alt text');
+    expect(images[1]).toHaveAttribute('aria-label', 'The second image alt text');
   });
 });

--- a/src/library/structure/SectionLinks/SectionLinks.tsx
+++ b/src/library/structure/SectionLinks/SectionLinks.tsx
@@ -31,7 +31,6 @@ const SectionLinks: React.FunctionComponent<SectionLinksProps> = ({
                   {(src) => (
                     <Styles.ImageContainer
                       image={src}
-                      alt={link.imageAltText}
                       role="img"
                       aria-label={link.imageAltText}
                     ></Styles.ImageContainer>


### PR DESCRIPTION
Removing the alt text as it is invalid on non img elements. Updated tests to look for aria-label instead of alt attributes. 

Using span instead of figure and following these guidelines https://www.davidmacd.com/blog/alternate-text-for-css-background-images.html 