### PR TITLE
Clicking link in alert banner dismisses banner

### DIFF
--- a/src/library/structure/AlertBanner/AlertBanner.stories.tsx
+++ b/src/library/structure/AlertBanner/AlertBanner.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
 import AlertBanner from './AlertBanner';
 import { AlertBannerProps } from './AlertBanner.types';
+import Button from '../../components/Button/Button';
 import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
 
 export default {
@@ -20,6 +21,11 @@ const childrenMessage = (
   </p>
 );
 
+const resetAlert = (event) => {
+    window.localStorage.clear();
+    window.location.reload();
+};
+
 const Template: Story<AlertBannerProps> = (args) => (
   <>
     <AlertBanner {...args} />
@@ -28,6 +34,8 @@ const Template: Story<AlertBannerProps> = (args) => (
       <br />
       <br />
       <p>Once this unique alert has been hidden it will not be shown again on this device.</p>
+      <br />
+      <Button url={null} onClick={resetAlert}>Click to reset</Button>
     </MaxWidthContainer>
   </>
 );

--- a/src/library/structure/AlertBanner/AlertBanner.stories.tsx
+++ b/src/library/structure/AlertBanner/AlertBanner.stories.tsx
@@ -17,13 +17,13 @@ export default {
 
 const childrenMessage = (
   <p>
-    Coronavirus | National lockdown: stay at home. <a href="/">Learn what this means for residents and workers here</a>
+    Coronavirus | National lockdown: stay at home. <a href="javascript:;">Learn what this means for residents and workers here</a>
   </p>
 );
 
 const resetAlert = (event) => {
     window.localStorage.clear();
-    window.location.reload();
+    window.location.replace(window.location.href.split('&')[0]);
 };
 
 const Template: Story<AlertBannerProps> = (args) => (

--- a/src/library/structure/AlertBanner/AlertBanner.tsx
+++ b/src/library/structure/AlertBanner/AlertBanner.tsx
@@ -11,14 +11,16 @@ import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
  */
 const AlertBanner: React.FunctionComponent<AlertBannerProps> = ({ uid, title, alertType = 'alert', children }) => {
   const themeContext = useContext(ThemeContext);
-  const [hideAlert, setHideAlert] = useLocalStorage('alert_' + uid, true);
+  const [showAlert, setShowAlert] = useLocalStorage('alert_' + uid, true);
 
   const hideClickHandler = () => {
-    setHideAlert(false);
+    setShowAlert(false);
   };
 
+  const notServer = typeof(window) !== 'undefined';
+
   return (
-    hideAlert && (
+    showAlert && notServer && (
       <Styles.Container alertType={alertType} data-testid="AlertBanner">
         <MaxWidthContainer noBackground>
           <Styles.InnerContainer>

--- a/src/library/structure/AlertBanner/AlertBanner.tsx
+++ b/src/library/structure/AlertBanner/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { AlertBannerProps } from './AlertBanner.types';
@@ -11,22 +11,34 @@ import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
  */
 const AlertBanner: React.FunctionComponent<AlertBannerProps> = ({ uid, title, alertType = 'alert', children }) => {
   const themeContext = useContext(ThemeContext);
+  const elementRef = useRef(null);
   const [showAlert, setShowAlert] = useLocalStorage('alert_' + uid, true);
+  useEffect(() => {
+    elementRef?.current?.addEventListener('click', embeddedLinkCLickHandler);
+  }, [elementRef]);
 
+  /* A click on any link within the alert text dismisses the banner too */
+  const embeddedLinkCLickHandler = (event) => {
+    if (event?.target?.tagName === 'A') {
+      hideClickHandler();
+    }
+  };
   const hideClickHandler = () => {
     setShowAlert(false);
   };
 
-  const notServer = typeof(window) !== 'undefined';
+  /* Stop flash of banner on page load when previously dismissed */
+  const notServer = typeof window !== 'undefined';
 
   return (
-    showAlert && notServer && (
+    showAlert &&
+    notServer && (
       <Styles.Container alertType={alertType} data-testid="AlertBanner">
         <MaxWidthContainer noBackground>
           <Styles.InnerContainer>
             <Styles.BannerContentContainer>
               <Styles.BannerTitle>{title}</Styles.BannerTitle>
-              <Styles.BannerContent>{children}</Styles.BannerContent>
+              <Styles.BannerContent ref={elementRef}>{children}</Styles.BannerContent>
             </Styles.BannerContentContainer>
 
             <Styles.HideLink


### PR DESCRIPTION
## Testing
* In Storybook you can play with the AlertBanner structure to verify that clicking a link within a banner also dismisses it
* Also fixed the bug whereby a dismissed site alert still flashes up briefly on initial page load in production build; `yalc publish` this branch and on the frontend `yalc add northants-design-system && yarn install && yarn bs`, set a sitewide alert in the CMS, load homepage in frontend, dismiss it, reload page, verify no banner flash.