### PR TITLE
Heading inside div instead of span

### DIFF
--- a/src/library/components/HeadingWithIcon/HeadingWithIcon.styles.js
+++ b/src/library/components/HeadingWithIcon/HeadingWithIcon.styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const HeadingWrapper = styled.span`
+export const HeadingWrapper = styled.div`
   display: flex;
   -webkit-flex-direction: row;
   -moz-flex-direction: row;


### PR DESCRIPTION
HeadingWithIcon was set to be contained in a span to resolve an earlier issue with HTML validation. The homepage ServiceLinksBoxed has been refactored to no longer use the HeadingWithIcon so it can be reverted to div for the container. 

https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.westnorthants.gov.uk%2Fbusiness-and-licensing 

## Testing
- Checkout this branch and `npm run dev` 
- Validate the HTML in the Service Page Example to test it no longer shows the error