### PR TITLE
Fix for search suggestions in the header

### DIFF
--- a/src/library/structure/Header/Header.styles.js
+++ b/src/library/structure/Header/Header.styles.js
@@ -39,6 +39,7 @@ export const Container = styled.header`
 `;
 
 export const StyledMaxWidthContainer = styled(MaxWidthContainer)`
+  overflow: visible; // Fix for search suggestions
   display: grid;
   align-items: center;
   grid-template-areas: 'headerlogo headerlinks headersearch';


### PR DESCRIPTION
- Checkout this branch
- `npm run dev`
- View the Structure/Header component and search for 'co' and the search suggestions should no longer be cropped
- `yalc publish` then in frontend `yalc add northants-design-system && yarn install && yarn dev`
- Test the search suggestions display correctly in the frontend 