### PR TITLE
Make contents a h2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "northants-design-system",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "northants-design-system",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "northants-design-system",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": false,
   "description": "Design system for West & North Northamptonshire Councils, two unitary councils encompassing Wellingborough, Corby, Daventry, East Northants, Kettering, Northampton, Northamptonshire County and South Northants.",
   "main": "build/index.js",

--- a/src/library/structure/Contents/Contents.tsx
+++ b/src/library/structure/Contents/Contents.tsx
@@ -9,7 +9,7 @@ const Contents: React.FunctionComponent<ContentsProps> = ({
   title = 'Contents',
 }) => (
   <Styles.Container data-testid="Contents">
-    <Heading text={title} level={4} />
+    <Heading text={title} level={2} />
     <Styles.List>
       {contents.map((content, index) => (
         <Styles.ListItem key={index}>


### PR DESCRIPTION
Make contents a H2 so it doesn't jump from H1 to H4 when included in the Service Page in the frontend. 

Also version bump as it seems I forgot to commit it when I last published. 