### PR TITLE
Remove loading attribute from HeroImage

### DIFF
--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -29,13 +29,8 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
           partialVisibility: true,
         }}
       >
-        {(src, loading) => (
-          <Styles.Container
-            image={src}
-            loading={loading.toString()}
-            backgroundBox={backgroundBox}
-            data-testid="HeroImage"
-          >
+        {(src) => (
+          <Styles.Container image={src} backgroundBox={backgroundBox} data-testid="HeroImage">
             <Styles.InnerContainer>
               <Styles.Overlay backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
                 {breadcrumb && (


### PR DESCRIPTION
Fixes this HTML validation issue by removing the loading attribute from the div.
<img width="752" alt="Screenshot 2022-06-09 at 11 07 30" src="https://user-images.githubusercontent.com/4160546/172822626-decf7dc9-a1b4-4436-9cfe-a1d24cb27138.png">

