### PR TITLE
Add bundle-analyzer to rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react": "~17",
         "react-dom": "~17",
         "rollup": "~2.74",
+        "rollup-plugin-analyzer": "^4.0.0",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
@@ -18726,14 +18727,14 @@
       }
     },
     "node_modules/html-react-parser": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.12.tgz",
-      "integrity": "sha512-nqYQzr4uXh67G9ejAG7djupTHmQvSTgjY83zbXLRfKHJ0F06751jXx6WKSFARDdXxCngo2/7H4Rwtfeowql4gQ==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.14.tgz",
+      "integrity": "sha512-pxhNWGie8Y+DGDpSh8cTa0k3g8PsDcwlfolA+XxYo1AGDeB6e2rdlyv4ptU9bOTiZ2i3fID+6kyqs86MN0FYZQ==",
       "dependencies": {
         "domhandler": "4.3.1",
         "html-dom-parser": "1.2.0",
         "react-property": "2.0.0",
-        "style-to-js": "1.1.0"
+        "style-to-js": "1.1.1"
       },
       "peerDependencies": {
         "react": "0.14 || 15 || 16 || 17 || 18"
@@ -27607,6 +27608,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-analyzer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz",
+      "integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/rollup-plugin-copy": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
@@ -29775,9 +29785,9 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
-      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.1.tgz",
+      "integrity": "sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==",
       "dependencies": {
         "style-to-object": "0.3.0"
       }
@@ -46680,14 +46690,14 @@
       }
     },
     "html-react-parser": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.12.tgz",
-      "integrity": "sha512-nqYQzr4uXh67G9ejAG7djupTHmQvSTgjY83zbXLRfKHJ0F06751jXx6WKSFARDdXxCngo2/7H4Rwtfeowql4gQ==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.14.tgz",
+      "integrity": "sha512-pxhNWGie8Y+DGDpSh8cTa0k3g8PsDcwlfolA+XxYo1AGDeB6e2rdlyv4ptU9bOTiZ2i3fID+6kyqs86MN0FYZQ==",
       "requires": {
         "domhandler": "4.3.1",
         "html-dom-parser": "1.2.0",
         "react-property": "2.0.0",
-        "style-to-js": "1.1.0"
+        "style-to-js": "1.1.1"
       }
     },
     "html-tags": {
@@ -53417,6 +53427,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rollup-plugin-analyzer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz",
+      "integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==",
+      "dev": true
+    },
     "rollup-plugin-copy": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
@@ -55159,9 +55175,9 @@
       }
     },
     "style-to-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
-      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.1.tgz",
+      "integrity": "sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==",
       "requires": {
         "style-to-object": "0.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react": "~17",
     "react-dom": "~17",
     "rollup": "~2.74",
+    "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import svg from 'rollup-plugin-svg';
 import json from '@rollup/plugin-json';
+import analyze from 'rollup-plugin-analyzer';
 
 const packageJson = require('./package.json');
 
@@ -27,12 +28,10 @@ export default {
     peerDepsExternal(),
     resolve({
       extensions: extensions,
+      preferBuiltins: true,
     }),
     commonjs({
       include: 'node_modules/**',
-      namedExports: {
-        'react-is': ['isForwardRef'],
-      },
     }),
     svg(),
     typescript({ useTsconfigDeclarationDir: true }),
@@ -55,6 +54,11 @@ export default {
 
       // generate a named export for every property of the JSON object
       namedExports: true, // Default: true
+    }),
+    analyze({
+      limit: 10,
+      summaryOnly: true,
+      hideDeps: true,
     }),
   ],
 };


### PR DESCRIPTION
Not sure if we need to include this in the actual design system, but found it useful to show the largest files exported from our design system so we can discuss what to improve. 

Running `npm run build` will provide analysis. For more details, change the `summaryOnly` to false in the rollup.config.js file. 