### PR TITLE
Add url and cookie helper tests

### DIFF
--- a/__tests__/CookieHelper.test.ts
+++ b/__tests__/CookieHelper.test.ts
@@ -1,0 +1,46 @@
+import { cookieName, getCookie, wereCookiesAccepted } from '../src/library/helpers/cookies';
+
+describe('cookie helper', () => {
+  describe('cookieName', () => {
+    it('gets the cookie name', () => {
+      expect(cookieName).toEqual('fn-cookie');
+    });
+  });
+
+  describe('getCookie', () => {
+    it('gets the cookie', () => {
+      const cookie = {
+        cookiesAccepted: true,
+      };
+      document.cookie = `${cookieName}=${JSON.stringify(cookie)};path=/`;
+
+      expect(getCookie(cookieName)).toEqual(`{"cookiesAccepted":true}`);
+    });
+  });
+
+  describe('wereCookiesAccepted', () => {
+    it('returns false if no cookie or override set for cookie check', () => {
+      // Expire any previous cookie set
+      document.cookie = cookieName + '=; Max-Age=0;';
+      expect(wereCookiesAccepted(null)).toEqual(false);
+    });
+
+    it('checks if cookies were accepted', () => {
+      const cookie = {
+        cookiesAccepted: true,
+      };
+      document.cookie = `${cookieName}=${JSON.stringify(cookie)};path=/`;
+
+      expect(wereCookiesAccepted(null)).toEqual(true);
+    });
+
+    it('returns the override when boolean for cookie check', () => {
+      const cookie = {
+        cookiesAccepted: true,
+      };
+      document.cookie = `${cookieName}=${JSON.stringify(cookie)};path=/`;
+
+      expect(wereCookiesAccepted(false)).toEqual(false);
+    });
+  });
+});

--- a/__tests__/UrlHelpers.test.ts
+++ b/__tests__/UrlHelpers.test.ts
@@ -1,0 +1,157 @@
+import {
+  handleParams,
+  removeParams,
+  removeValueFromParam,
+  countParams,
+  getParamValue,
+  getDropDownValues,
+  getCheckboxValues,
+  deSlug,
+} from '../src/library/helpers/url-helpers';
+
+describe('Url Helpers', () => {
+  beforeEach(() => {
+    // Mock window.location
+    delete global.window.location;
+    global.window = Object.create(window);
+    global.window.location = {
+      ancestorOrigins: null,
+      hash: null,
+      host: 'dummy.com',
+      port: '123',
+      protocol: 'http:',
+      hostname: 'dummy.com',
+      href: 'http://dummy.com?page=1&name=testing',
+      origin: 'http://dummy.com',
+      pathname: null,
+      search: null,
+      assign: null,
+      reload: null,
+      replace: null,
+      toString: () => {
+        return global.window.location.href;
+      },
+    };
+  });
+
+  describe('handleParams', () => {
+    it('adds a param to the url', () => {
+      const newParams = [
+        {
+          key: 'services',
+          value: 'business-services',
+        },
+      ];
+      handleParams('test-path', newParams);
+
+      expect(window.location.href).toEqual('http://dummy.com/test-path?page=1&name=testing&services=business-services');
+    });
+
+    it('adds multiple params to the url', () => {
+      const newParams = [
+        {
+          key: 'services',
+          value: 'business-services',
+        },
+        {
+          key: 'type',
+          value: 'article',
+        },
+      ];
+      handleParams('test-path', newParams);
+
+      expect(window.location.href).toEqual(
+        'http://dummy.com/test-path?page=1&name=testing&services=business-services&type=article'
+      );
+    });
+
+    it('removes a param from the url', () => {
+      handleParams('test-path', [], ['page']);
+
+      expect(window.location.href).toEqual('http://dummy.com/test-path?name=testing');
+    });
+  });
+
+  describe('removeParams', () => {
+    it('removes the page parameter', () => {
+      removeParams(['page']);
+
+      expect(window.location.href).toEqual('http://dummy.com/?name=testing');
+    });
+
+    it('removes the name parameter', () => {
+      removeParams(['name']);
+
+      expect(window.location.href).toEqual('http://dummy.com/?page=1');
+    });
+  });
+
+  /**
+   * Uses ASCI code `%2C` instead of `,` to separate multiple params
+   */
+  describe('removeValueFromParam', () => {
+    it('removes a specific value from a given param', () => {
+      window.location.href = 'http://dummy.com/?page=1&name=testing%2Ctest%2Ctest2';
+
+      removeValueFromParam('name', 'testing');
+
+      expect(window.location.href).toEqual('http://dummy.com/?page=1&name=test%2Ctest2');
+    });
+  });
+
+  describe('countParams', () => {
+    it('counts the parameter', () => {
+      expect(countParams(['page'])).toEqual(1);
+    });
+
+    it('counts the parameters', () => {
+      expect(countParams(['page', 'name'])).toEqual(2);
+    });
+
+    it('only counts the matching parameters', () => {
+      expect(countParams(['page', 'not-in-url'])).toEqual(1);
+    });
+  });
+
+  describe('getParamValue', () => {
+    it('gets a parameter value', () => {
+      expect(getParamValue('name')).toEqual(['testing']);
+    });
+
+    it('returns empty for no match', () => {
+      expect(getParamValue('not-in-url')).toEqual([]);
+    });
+  });
+
+  describe('getDropDownValues', () => {
+    it('gets the drop down values', () => {
+      expect(getDropDownValues('name')).toEqual(['testing']);
+    });
+
+    it('gets multiple drop down values as csv', () => {
+      window.location.href = 'http://dummy.com/?page=1&name=testing%2Ctest%2Ctest2';
+      expect(getDropDownValues('name')).toEqual(['testing,test,test2']);
+    });
+  });
+
+  describe('getCheckboxValues', () => {
+    it('gets the checkbox values', () => {
+      expect(getCheckboxValues('name')).toEqual(['testing']);
+    });
+
+    it('gets multiple checkbox values as array', () => {
+      window.location.href = 'http://dummy.com/?page=1&name=testing%2Ctest%2Ctest2';
+      expect(getCheckboxValues('name')).toEqual(['testing', 'test', 'test2']);
+    });
+  });
+
+  describe('deSlug', () => {
+    it('deslugs a string', () => {
+      expect(deSlug('business-services-and-accounts')).toBe('Business Services And Accounts');
+    });
+
+    it('uppercases the first letter of each word', () => {
+      expect(deSlug('this-will-be-title-formatted')).toBe('This Will Be Title Formatted');
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  roots: ['src'],
+  roots: ['__tests__', 'src'],
   setupFilesAfterEnv: ['./jest.setup.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testPathIgnorePatterns: ['node_modules/'],


### PR DESCRIPTION
Added tests for the cookie and url helpers so that we can document what they do in case we need to refactor them in future. 

I put the tests in the `__tests__` directory as I didn't want to clutter up the `helpers` directory and it gives us a location to write other non component tests in future. 