### PR TITLE
New ImageAndText slice added

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import DownloadableFiles from './library/slices/DownloadableFiles/DownloadableFi
 import Divider from './library/slices/Divider/Divider';
 import GoogleMap from './library/slices/GoogleMap/GoogleMap';
 import Image from './library/slices/Image/Image';
+import ImageAndText from './library/slices/ImageAndText/ImageAndText';
 import Promotions from './library/slices/Promotions/Promotions';
 import Video from './library/slices/Video/Video';
 import WarningText from './library/slices/WarningText/WarningText';
@@ -46,6 +47,7 @@ export {
   DownloadableFiles,
   GoogleMap,
   Image,
+  ImageAndText,
   Promotions,
   Video,
   WarningText,

--- a/src/library/pages/ContentPage/ContentPage.tsx
+++ b/src/library/pages/ContentPage/ContentPage.tsx
@@ -13,6 +13,10 @@ import Promotions from '../../slices/Promotions/Promotions';
 import { PromoBlocksData } from '../../structure/PromoBlock/PromoBlock.storydata';
 import { GoogleMapWithTitleAndDescription } from '../../slices/GoogleMap/GoogleMap.storydata';
 import GoogleMap from '../../slices/GoogleMap/GoogleMap';
+import Image from '../../slices/Image/Image';
+import ImageAndText from '../../slices/ImageAndText/ImageAndText';
+import { ImageWithCaption } from '../../slices/Image/Image.storydata';
+import { ImageAndTextWithHeading } from '../../slices/ImageAndText/ImageAndText.storydata';
 
 export interface ContentPageProps {}
 
@@ -56,7 +60,13 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
           sem lacinia quam venenatis vestibulum. Maecenas faucibus mollis interdum.
         </p>
         <ul>
-          <li>list 1 orem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+          <li>
+            list 1 orem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </li>
           <li>list 2</li>
           <li>list 3</li>
         </ul>
@@ -205,6 +215,9 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
         />
         <Promotions promos={PromoBlocksData} />
         <GoogleMap {...GoogleMapWithTitleAndDescription} />
+        <Heading level={2} text="Full Width Image" />
+        <Image {...ImageWithCaption} />
+        <ImageAndText {...ImageAndTextWithHeading} />
         <WarningTextDisclaimer />
       </PageStructures.PageMain>
     </PageStructures.MaxWidthContainer>

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
@@ -15,6 +15,9 @@ import {
   micrositeBreadcrumbs,
   footerLinks,
   serviceAlert,
+  promoHeroImageData,
+  promoTopServicesData,
+  promoBodyText,
 } from './ServiceLandingPageExample.storydata';
 
 export default {
@@ -129,4 +132,18 @@ MicroSiteWithAlertExample.args = {
     'Explore, discover and enjoy Northamptonshire Country Parks. Woodland walks, reservoir views, play areas, cafes, each country park has its own unique character.',
   showSummary: true,
   serviceAlert,
+};
+
+export const PromoPageExample = Template.bind({});
+PromoPageExample.args = {
+  title: 'Sustainable West Northants',
+  heroImage: promoHeroImageData,
+  breadcrumbsArray: null,
+  bodyText: promoBodyText,
+  sections: [],
+  footerLinks,
+  topServices: promoTopServicesData,
+  summary:
+    'Sustainability is all about living in a way that protects our natural resources and opportunities for future generations.',
+  showSummary: true,
 };

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.storydata.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.storydata.tsx
@@ -1,8 +1,12 @@
+import React from 'react';
 import { SectionLinksProps } from '../../structure/SectionLinks/SectionLinks.types';
 import { FooterLinkProp } from '../../structure/Footer/Footer.types';
 import { BreadcrumbProp } from '../../structure/Breadcrumbs/Breadcrumbs.types';
 import { PageLinkProp, ServicesLinksListProps } from '../../structure/ServicesLinksList/ServicesLinksList.types';
 import { AlertBannerServiceProps } from '../../structure/AlertBannerService/AlertBannerService.types';
+import { CardsProps } from '../../slices/Cards/Cards.types';
+import { CallToAction, Cards, Heading, ImageAndText } from '../../..';
+import { ImageAndTextWithHeading } from '../../slices/ImageAndText/ImageAndText.storydata';
 
 const topServicesData: Array<PageLinkProp> = [
   {
@@ -191,3 +195,120 @@ export const serviceAlert: AlertBannerServiceProps = {
   title: 'An example service alert',
   alertType: 'alert',
 };
+
+/**
+ * Promo Page Storydata
+ */
+
+export const promoHeroImageData = {
+  headline: 'Sustainable West Northants',
+  content: '<p>We have collated a variety of small changes that can have a big impact for you to try today.</p>',
+  imageLarge:
+    'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg',
+  imageSmall:
+    'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/144/81/0/2021-12/Abington_Park_1.jpg',
+  imageAltText: 'Parkland',
+  backgroundBox: true,
+};
+
+export const promoTopServices: Array<PageLinkProp> = [
+  {
+    title: 'In your business',
+    url: 'in-your-business',
+    iconKey: 'births',
+    quickLinksArray: [],
+  },
+  {
+    title: 'In your home',
+    url: 'in-your-home',
+    iconKey: 'business',
+    quickLinksArray: [],
+  },
+  {
+    title: 'In your community',
+    url: 'in-your-community',
+    iconKey: 'children',
+    quickLinksArray: [],
+  },
+];
+
+export const promoTopServicesData: ServicesLinksListProps = {
+  ...topServicesCommon,
+  serviceLinksArray: promoTopServices,
+};
+
+export const cardsData: CardsProps = {
+  cards: [
+    {
+      header: 'Commitment 1',
+      content:
+        '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel mi mattis, facilisis est et, portaurna.</p>',
+    },
+    {
+      header: 'Commitment 2',
+      content:
+        '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel mi mattis, facilisis est et, portaurna.</p>',
+    },
+    {
+      header: 'Commitment 3',
+      content:
+        '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel mi mattis, facilisis est et, portaurna.</p>',
+    },
+  ],
+};
+
+export const imageCardsData: CardsProps = {
+  cards: [
+    {
+      imageLarge: 'https://via.placeholder.com/800x600?text=800+by+600+image',
+      imageSmall: 'https://via.placeholder.com/400x300?text=400+by+300+image',
+      imageAltText: 'Parkland',
+    },
+    {
+      imageLarge: 'https://via.placeholder.com/800x600?text=800+by+600+image',
+      imageSmall: 'https://via.placeholder.com/400x300?text=400+by+300+image',
+      imageAltText: 'Parkland',
+    },
+    {
+      imageLarge: 'https://via.placeholder.com/800x600?text=800+by+600+image',
+      imageSmall: 'https://via.placeholder.com/400x300?text=400+by+300+image',
+      imageAltText: 'Parkland',
+    },
+  ],
+};
+
+export const promoBodyText: React.ReactNode = (
+  <>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel mi mattis, facilisis est et, porta urna.
+      Sed porttitor neque vitae elit vehicula eleifend. Vivamus sed purus finibus, tincidunt neque quis, mollis urna.
+      Donec dapibus tellus quam, vitae fringilla mi tristique nec. Sed sit amet ligula vel ante congue gravida
+    </p>
+    <ul>
+      <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sit amet ligula vel ante congue gravida.</li>
+      <li>Phasellus vel mi mattis, facilisis est et, porta urna. Sed sit amet ligula vel ante congue gravida</li>
+      <li>Vivamus sed purus finibus, tincidunt neque quis, mollis urna. Sed sit amet ligula vel ante congue gravida</li>
+    </ul>
+    <Heading level={2} text="Our commitments" />
+    <Cards {...cardsData} />
+    <Heading level={2} text="Sustainable development goals" />
+    <Cards {...imageCardsData} />
+    <Heading level={2} text="Ideas bank" />
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel mi mattis, facilisis est et, porta urna.
+      Sed porttitor neque vitae elit vehicula eleifend. Vivamus sed purus finibus, tincidunt neque quis, mollis urna.
+      Donec dapibus tellus quam, vitae fringilla mi tristique nec. Sed sit amet ligula vel ante congue gravida
+    </p>
+    <ImageAndText {...ImageAndTextWithHeading} />
+    <ImageAndText {...ImageAndTextWithHeading} />
+    <ImageAndText {...ImageAndTextWithHeading} />
+    <Heading level={2} text="Pledge" />
+    <ul>
+      <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+      <li>Phasellus vel mi mattis, facilisis est et, porta urna.</li>
+      <li>Vivamus sed purus finibus, tincidunt neque quis, mollis urna.</li>
+    </ul>
+    <p></p>
+    <CallToAction url="/example-link" text="Share your pledge" />
+  </>
+);

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
@@ -65,14 +65,14 @@ export const ServiceLandingPageExample: React.FunctionComponent<ServiceLandingPa
     )}
 
     <PageStructures.MaxWidthContainer>
-      <PageStructures.PageMain>
+      <PageStructures.PageMain fullWidthText>
         {showSummary && summary?.trim() && (
           <Summary>
             <p>{summary}</p>
           </Summary>
         )}
 
-        <p>{bodyText ? bodyText : 'Any introductory text and slices for the landing page goes here.'}</p>
+        <>{bodyText ? bodyText : 'Any introductory text and slices for the landing page goes here.'}</>
 
         {sections.length > 1 ? (
           <SectionLinksMobileContents

--- a/src/library/slices/Image/Image.storydata.ts
+++ b/src/library/slices/Image/Image.storydata.ts
@@ -1,0 +1,9 @@
+import { ImageProps } from './Image.types';
+
+export const ImageWithCaption: ImageProps = {
+  imageLarge: 'https://via.placeholder.com/800x600?text=4+by+3+image',
+  imageSmall: 'https://via.placeholder.com/400x300',
+  imageAltText: 'The image alt text',
+  ratio: '4by3',
+  caption: 'The caption helps describe the image',
+};

--- a/src/library/slices/Image/Image.styles.js
+++ b/src/library/slices/Image/Image.styles.js
@@ -7,13 +7,13 @@ export const Container = styled.figure`
       ? props.theme.theme_vars.colours.white
       : props.theme.theme_vars.colours.grey_light};
   border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey};
-  margin-bottom: 15px;
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.medium};
   float: ${(props) => (props.wrapText === true ? 'left' : 'none')};
   width: ${(props) => (props.wrapText === true ? '30%' : '100%')};
-  margin-top: 1rem;
+  margin-top: ${(props) => props.theme.theme_vars.spacingSizes.medium};
   margin-right: ${(props) => (props.wrapText === true ? '1.5rem' : '0')};
 
-  @media screen and (max-width: ${props => props.theme.theme_vars.breakpoints.s}){
+  @media screen and (max-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
     float: none;
     width: 100%;
     margin-right: 0;

--- a/src/library/slices/Image/Image.types.ts
+++ b/src/library/slices/Image/Image.types.ts
@@ -12,7 +12,7 @@ export interface ImageProps {
   /**
    * The image alt text to describe the image
    */
-  imageAltText?: string;
+  imageAltText?: string | null;
 
   /**
    * The image ratio, either '4by3' or '16by9'
@@ -22,7 +22,7 @@ export interface ImageProps {
   /**
    * The optional image caption that goes under the image
    */
-  caption?: string;
+  caption?: string | null;
 
   /**
    * Set to true to have following text wrap against image

--- a/src/library/slices/ImageAndText/ImageAndText.stories.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Story } from '@storybook/react/types-6-0';
+import ImageAndText from './ImageAndText';
+import { ImageAndTextProps } from './ImageAndText.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
+import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
+import PageMain from '../../structure/PageMain/PageMain';
+import { ImageAndTextWithHeading } from './ImageAndText.storydata';
+
+export default {
+  title: 'Library/Slices/ImageAndText',
+  component: ImageAndText,
+  parameters: {
+    status: {
+      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+    },
+  },
+};
+
+const Template: Story<ImageAndTextProps> = (args) => (
+  <SBPadding>
+    <MaxWidthContainer>
+      <PageMain>
+        <ImageAndText {...args} />
+      </PageMain>
+    </MaxWidthContainer>
+  </SBPadding>
+);
+
+export const ExampleImageAndText = Template.bind({});
+ExampleImageAndText.args = ImageAndTextWithHeading;
+
+export const ExampleImageAndTextWithoutHeading = Template.bind({});
+ExampleImageAndTextWithoutHeading.args = {
+  ...ImageAndTextWithHeading,
+  heading: undefined,
+};

--- a/src/library/slices/ImageAndText/ImageAndText.storydata.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.storydata.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from 'react';
+import { ImageWithCaption } from '../Image/Image.storydata';
+import { ImageAndTextProps } from './ImageAndText.types';
+
+const longContent: ReactNode = (
+  <>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquet eleifend ante, ut pretium nibh laoreet ac.
+    </p>
+    <ul>
+      <li>Mauris id dui sit amet turpis iaculis placerat.</li>
+      <li>Cras venenatis gravida tortor, sit amet mollis velit congue non.</li>
+      <li>Aliquam et tincidunt enim. Praesent elit lorem, sollicitudin a purus ac, dictum varius metus.</li>
+      <li> Nullam nunc massa, rutrum et aliquam non, laoreet sed ante.</li>
+    </ul>
+    <p>
+      Vestibulum interdum mi et dolor pharetra maximus. In tristique, neque et semper pretium, erat ante dignissim
+      magna, in congue dolor diam sit amet elit. Sed sit amet tortor ut urna finibus fermentum id in libero.
+    </p>
+    <p>
+      Duis non elit placerat mauris vulputate semper. Sed aliquet gravida orci, vel vehicula massa imperdiet elementum.
+      Praesent eget faucibus sem. Cras efficitur efficitur lorem, eu eleifend odio iaculis non. Suspendisse potenti.
+    </p>
+  </>
+);
+
+export const ImageAndTextWithHeading: ImageAndTextProps = {
+  heading: 'An example heading',
+  content: longContent,
+  image: ImageWithCaption,
+};

--- a/src/library/slices/ImageAndText/ImageAndText.storydata.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.storydata.tsx
@@ -2,8 +2,7 @@ import React, { ReactNode } from 'react';
 import { ImageWithCaption } from '../Image/Image.storydata';
 import { ImageAndTextProps } from './ImageAndText.types';
 
-const longContent: ReactNode = (
-  <>
+const longContent: string = `
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquet eleifend ante, ut pretium nibh laoreet ac.
     </p>
@@ -20,12 +19,10 @@ const longContent: ReactNode = (
     <p>
       Duis non elit placerat mauris vulputate semper. Sed aliquet gravida orci, vel vehicula massa imperdiet elementum.
       Praesent eget faucibus sem. Cras efficitur efficitur lorem, eu eleifend odio iaculis non. Suspendisse potenti.
-    </p>
-  </>
-);
+    </p>`;
 
 export const ImageAndTextWithHeading: ImageAndTextProps = {
   heading: 'An example heading',
-  content: longContent,
+  textContent: longContent,
   image: ImageWithCaption,
 };

--- a/src/library/slices/ImageAndText/ImageAndText.styles.js
+++ b/src/library/slices/ImageAndText/ImageAndText.styles.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: block;
+`;
+
+export const HeadingContainer = styled.div`
+  h3 {
+    margin-bottom: 0;
+  }
+`;
+
+export const Content = styled.div`
+  margin: ${(props) => props.theme.theme_vars.spacingSizes.medium} 0;
+`;

--- a/src/library/slices/ImageAndText/ImageAndText.test.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ImageAndText from './ImageAndText';
+import { ImageAndTextProps } from './ImageAndText.types';
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
+import { ImageAndTextWithHeading } from './ImageAndText.storydata';
+
+describe('Test Component', () => {
+  let props: ImageAndTextProps;
+
+  beforeEach(() => {
+    props = ImageAndTextWithHeading;
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <ImageAndText {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render the image, heading and content correctly', () => {
+    const { getByTestId, getByRole } = renderComponent();
+
+    const component = getByTestId('ImageAndText');
+    const heading = getByRole('heading');
+    const image = getByRole('img');
+
+    expect(heading).toHaveTextContent('An example heading');
+    expect(component).toHaveTextContent('Lorem ipsum dolor sit amet');
+    expect(image).toBeVisible();
+    expect(image).toHaveAttribute('src', 'https://via.placeholder.com/400x300');
+    expect(image).toHaveAttribute('alt', 'The image alt text');
+  });
+
+  it('should render without a heading', () => {
+    props.heading = undefined;
+
+    const { getByTestId, queryByRole, getByRole } = renderComponent();
+
+    const component = getByTestId('ImageAndText');
+    const heading = queryByRole('heading');
+    const image = getByRole('img');
+
+    expect(heading).toBeNull();
+    expect(component).toHaveTextContent('Lorem ipsum dolor sit amet');
+    expect(image).toBeVisible();
+  });
+});

--- a/src/library/slices/ImageAndText/ImageAndText.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.tsx
@@ -5,11 +5,12 @@ import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
 import Image from '../Image/Image';
 import Heading from '../../components/Heading/Heading';
+import sanitizeHtml from 'sanitize-html';
 
 /**
  * A container for an image and text content, with an optional heading
  */
-const ImageAndText: React.FunctionComponent<ImageAndTextProps> = ({ heading, content, image }) => (
+const ImageAndText: React.FunctionComponent<ImageAndTextProps> = ({ heading, textContent, image }) => (
   <Styles.Container data-testid="ImageAndText">
     <Row>
       {heading && (
@@ -23,7 +24,7 @@ const ImageAndText: React.FunctionComponent<ImageAndTextProps> = ({ heading, con
         <Image {...image} />
       </Column>
       <Column small="full" medium="two-thirds" large="two-thirds">
-        <Styles.Content>{content}</Styles.Content>
+        <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(textContent) }} />
       </Column>
     </Row>
   </Styles.Container>

--- a/src/library/slices/ImageAndText/ImageAndText.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ImageAndTextProps } from './ImageAndText.types';
+import * as Styles from './ImageAndText.styles';
+import Row from '../../components/Row/Row';
+import Column from '../../components/Column/Column';
+import Image from '../Image/Image';
+import Heading from '../../components/Heading/Heading';
+
+/**
+ * A container for an image and text content, with an optional heading
+ */
+const ImageAndText: React.FunctionComponent<ImageAndTextProps> = ({ heading, content, image }) => (
+  <Styles.Container data-testid="ImageAndText">
+    <Row>
+      {heading && (
+        <Column small="full" medium="full" large="full">
+          <Styles.HeadingContainer>
+            <Heading text={heading} level={3} />
+          </Styles.HeadingContainer>
+        </Column>
+      )}
+      <Column small="full" medium="one-third" large="one-third">
+        <Image {...image} />
+      </Column>
+      <Column small="full" medium="two-thirds" large="two-thirds">
+        <Styles.Content>{content}</Styles.Content>
+      </Column>
+    </Row>
+  </Styles.Container>
+);
+
+export default ImageAndText;

--- a/src/library/slices/ImageAndText/ImageAndText.types.ts
+++ b/src/library/slices/ImageAndText/ImageAndText.types.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ImageProps } from '../Image/Image.types';
+
+export interface ImageAndTextProps {
+  /**
+   * An optional heading
+   */
+  heading?: string;
+
+  /**
+   * The html text content
+   */
+  content: React.ReactNode;
+
+  /**
+   * The image, containing the paths, alt text and caption
+   */
+  image: ImageProps;
+}

--- a/src/library/slices/ImageAndText/ImageAndText.types.ts
+++ b/src/library/slices/ImageAndText/ImageAndText.types.ts
@@ -5,12 +5,12 @@ export interface ImageAndTextProps {
   /**
    * An optional heading
    */
-  heading?: string;
+  heading?: string | null;
 
   /**
-   * The html text content
+   * The string of html text content
    */
-  content: React.ReactNode;
+  textContent: string;
 
   /**
    * The image, containing the paths, alt text and caption

--- a/src/library/structure/PageMain/PageMain.stories.tsx
+++ b/src/library/structure/PageMain/PageMain.stories.tsx
@@ -1,175 +1,176 @@
-
-import React from "react";
-import PageMain from "./PageMain";
-import { PageMainProps } from "./PageMain.types";
+import React from 'react';
+import PageMain from './PageMain';
+import { PageMainProps } from './PageMain.types';
 import { Story } from '@storybook/react/types-6-0';
 
 export default {
-    title: 'Library/structure/Page Main Container',
-    component: PageMain,
-    parameters: {
-      status: {
-        type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      }
+  title: 'Library/structure/Page Main Container',
+  component: PageMain,
+  parameters: {
+    status: {
+      type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
     },
+  },
 };
 
-const Template: Story<PageMainProps> = (args) => <PageMain {...args}>Children of the page container goes here</PageMain>;
+const Template: Story<PageMainProps> = (args) => (
+  <PageMain {...args}>Children of the page container goes here</PageMain>
+);
 
 export const PageMainExample = Template.bind({});
 PageMainExample.args = {
   classes: 'testclass',
 };
 
-
-export const ExampleOfTables = () =>
+export const ExampleOfTables = () => (
   <PageMain>
     <p>This is an example container for page main including a table:</p>
     <table>
       <tbody>
-          <tr>
-              <td>Monday</td>
-              <td>Closed</td>
-          </tr>
-          <tr>
-              <td>Tuesday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Wednesday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Thursday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Friday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Saturday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Sunday</td>
-              <td>Closed</td>
-          </tr>
+        <tr>
+          <td>Monday</td>
+          <td>Closed</td>
+        </tr>
+        <tr>
+          <td>Tuesday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Wednesday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Thursday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Friday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Saturday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Sunday</td>
+          <td>Closed</td>
+        </tr>
       </tbody>
     </table>
 
     <p>A table with header rows</p>
     <table>
       <thead>
-          <tr>
-              <th>Date</th>
-              <th>Status</th>
-          </tr>
+        <tr>
+          <th>Date</th>
+          <th>Status</th>
+        </tr>
       </thead>
       <tbody>
-          <tr>
-              <td>Monday</td>
-              <td>Closed</td>
-          </tr>
-          <tr>
-              <td>Tuesday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Wednesday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Thursday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Friday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Saturday</td>
-              <td>10:30 — 19:00</td>
-          </tr>
-          <tr>
-              <td>Sunday</td>
-              <td>Closed</td>
-          </tr>
+        <tr>
+          <td>Monday</td>
+          <td>Closed</td>
+        </tr>
+        <tr>
+          <td>Tuesday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Wednesday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Thursday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Friday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Saturday</td>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <td>Sunday</td>
+          <td>Closed</td>
+        </tr>
       </tbody>
-  </table>
+    </table>
 
-  <p>A table with both header rows</p>
-  <table>
-    <thead>
+    <p>A table with both header rows</p>
+    <table>
+      <thead>
         <tr>
-            <th>Date</th>
-            <th>Status</th>
+          <th>Date</th>
+          <th>Status</th>
         </tr>
-    </thead>
-    <tbody>
+      </thead>
+      <tbody>
         <tr>
-            <th>Monday</th>
-            <td>Closed</td>
-        </tr>
-        <tr>
-            <th>Tuesday</th>
-            <td>10:30 — 19:00</td>
-        </tr>
-        <tr>
-            <th>Wednesday</th>
-            <td>10:30 — 19:00</td>
-        </tr>
-        <tr>
-            <th>Thursday</th>
-            <td>10:30 — 19:00</td>
-        </tr>
-        <tr>
-            <th>Friday</th>
-            <td>10:30 — 19:00</td>
-        </tr>
-        <tr>
-            <th>Saturday</th>
-            <td>10:30 — 19:00</td>
-        </tr>
-        <tr>
-            <th>Sunday</th>
-            <td>Closed</td>
-        </tr>
-    </tbody>
-  </table>
-
-  <p>A table with side heading row with caption</p>
-  <table>
-    <caption>test caption</caption>
-    <tbody>
-      <tr>
           <th>Monday</th>
           <td>Closed</td>
-      </tr>
-      <tr>
+        </tr>
+        <tr>
           <th>Tuesday</th>
           <td>10:30 — 19:00</td>
-      </tr>
-      <tr>
+        </tr>
+        <tr>
           <th>Wednesday</th>
           <td>10:30 — 19:00</td>
-      </tr>
-      <tr>
+        </tr>
+        <tr>
           <th>Thursday</th>
           <td>10:30 — 19:00</td>
-      </tr>
-      <tr>
+        </tr>
+        <tr>
           <th>Friday</th>
           <td>10:30 — 19:00</td>
-      </tr>
-      <tr>
+        </tr>
+        <tr>
           <th>Saturday</th>
           <td>10:30 — 19:00</td>
-      </tr>
-      <tr>
+        </tr>
+        <tr>
           <th>Sunday</th>
           <td>Closed</td>
-      </tr>
-    </tbody>
-  </table>
-</PageMain>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>A table with side heading row with caption</p>
+    <table>
+      <caption>test caption</caption>
+      <tbody>
+        <tr>
+          <th>Monday</th>
+          <td>Closed</td>
+        </tr>
+        <tr>
+          <th>Tuesday</th>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <th>Wednesday</th>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <th>Thursday</th>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <th>Friday</th>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <th>Saturday</th>
+          <td>10:30 — 19:00</td>
+        </tr>
+        <tr>
+          <th>Sunday</th>
+          <td>Closed</td>
+        </tr>
+      </tbody>
+    </table>
+  </PageMain>
+);

--- a/src/library/structure/PageMain/PageMain.styles.js
+++ b/src/library/structure/PageMain/PageMain.styles.js
@@ -1,98 +1,109 @@
-import styled from "styled-components";
+import styled, { css } from 'styled-components';
 
 export const Container = styled.main`
-    padding-top: 30px;
+  padding-top: 30px;
 
-    a {
-        ${props => props.theme.linkStyles}
-        &:hover{
-            ${props => props.theme.linkStylesHover}
-        }
-        &:focus{
-            ${props => props.theme.linkStylesFocus}
-        }
-        &:active{
-            ${props => props.theme.linkStylesActive}
-        }
+  a {
+    ${(props) => props.theme.linkStyles}
+    &:hover {
+      ${(props) => props.theme.linkStylesHover}
     }
+    &:focus {
+      ${(props) => props.theme.linkStylesFocus}
+    }
+    &:active {
+      ${(props) => props.theme.linkStylesActive}
+    }
+  }
 
-    p {
-        margin-bottom: 15px;
-    }
-    
-    strong, bold {
-        font-weight: 700;
-    }
-    em {
-        font-style: italic;
-    }
+  p {
+    margin-bottom: 15px;
+  }
 
-    sub, sup {
-        font-size: 75%;
-        line-height: 0;
-        position: relative;
-        vertical-align: baseline;
-    }
-    sup {
-        top: -.5em;
-    }
-    sub {
-        bottom: -.25em;
-    }
+  & > p,
+  & > ul,
+  & > ol,
+  & > h2,
+  & > h3,
+  & > h4 {
+    max-width: ${(props) => (props.fullWidthText ? `100%` : '750px')};
+  }
 
-    // TABLE STYLES
-    .table-container {
-        max-width: 100%;
-        overflow-y: auto;
+  strong,
+  bold {
+    font-weight: 700;
+  }
+  em {
+    font-style: italic;
+  }
 
-        table { 
-            max-width: none;
-        }
-    }
-    table { 
-        width: 100%; 
-        border-collapse: collapse; 
-        margin-bottom: 25px;
-        max-width: 100%;
-        overflow-y: auto;
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sup {
+    top: -0.5em;
+  }
+  sub {
+    bottom: -0.25em;
+  }
 
-        caption {
-            text-align: left;
-            padding-left: 10px;
-            margin-bottom: 15px;
-            font-weight: bold;
-        }
-    }
+  // TABLE STYLES
+  .table-container {
+    max-width: 100%;
+    overflow-y: auto;
 
-    tr {
-        border-bottom: 1px solid ${props => props.theme.theme_vars.colours.grey};
-        &:hover {
-            background: ${props => props.theme.theme_vars.colours.grey_light} !important; 
-        }
+    table {
+      max-width: none;
     }
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 25px;
+    max-width: 100%;
+    overflow-y: auto;
 
-    tr:nth-of-type(even) { 
-        background: ${props => props.theme.theme_vars.colours.grey_light}40; 
+    caption {
+      text-align: left;
+      padding-left: 10px;
+      margin-bottom: 15px;
+      font-weight: bold;
     }
+  }
 
-    td, th { 
-        padding: 10px; 
-        text-align: left; 
+  tr {
+    border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey};
+    &:hover {
+      background: ${(props) => props.theme.theme_vars.colours.grey_light} !important;
     }
-    th {
-        font-weight: bold;
-    }
-    thead tr {
-        border-bottom: 1px solid ${props => props.theme.theme_vars.colours.black};
-        &:hover {
-            background: transparent !important; 
-        }
-    }
+  }
 
+  tr:nth-of-type(even) {
+    background: ${(props) => props.theme.theme_vars.colours.grey_light}40;
+  }
 
-    @media only screen and (max-width: ${props => props.theme.theme_vars.breakpoints.s}){
-        table { 
-            width: 100%; 
-        }
+  td,
+  th {
+    padding: 10px;
+    text-align: left;
+  }
+  th {
+    font-weight: bold;
+  }
+  thead tr {
+    border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.black};
+    &:hover {
+      background: transparent !important;
     }
-`
+  }
+
+  @media only screen and (max-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
+    table {
+      width: 100%;
+    }
+  }
+`;

--- a/src/library/structure/PageMain/PageMain.test.tsx
+++ b/src/library/structure/PageMain/PageMain.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
+import PageMain from './PageMain';
+import { PageMainProps } from './PageMain.types';
+
+describe('PageMain', () => {
+  let props: PageMainProps = {};
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <PageMain {...props}>
+          <p>Some example content</p>
+          <ul>
+            <li>List item</li>
+            <li>Another item</li>
+          </ul>
+        </PageMain>
+      </ThemeProvider>
+    );
+
+  it('should render the content', () => {
+    const { getByTestId, getByText, getByRole } = renderComponent();
+
+    const component = getByTestId('PageMain');
+    const sampleText = getByText('Some example content');
+    const list = getByRole('list');
+
+    expect(component).toBeVisible();
+
+    expect(sampleText).toBeVisible();
+    expect(sampleText).toHaveStyle('max-width: 750px');
+
+    expect(list).toBeVisible();
+    expect(list).toHaveStyle('max-width: 750px');
+  });
+
+  it('should toggle the width to full width', () => {
+    props.fullWidthText = true;
+
+    const { getByText, getByRole } = renderComponent();
+
+    const sampleText = getByText('Some example content');
+    const list = getByRole('list');
+
+    expect(sampleText).toBeVisible();
+    expect(sampleText).toHaveStyle('max-width: 100%');
+
+    expect(list).toBeVisible();
+    expect(list).toHaveStyle('max-width: 100%');
+  });
+
+  it('should add the classes', () => {
+    props.classes = 'class-one class-two';
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('PageMain');
+
+    expect(component).toHaveClass('class-one');
+    expect(component).toHaveClass('class-two');
+  });
+});

--- a/src/library/structure/PageMain/PageMain.tsx
+++ b/src/library/structure/PageMain/PageMain.tsx
@@ -1,25 +1,15 @@
+import React from 'react';
 
-import React from "react";
-
-import { PageMainProps } from "./PageMain.types";
-import * as Styles from "./PageMain.styles";
+import { PageMainProps } from './PageMain.types';
+import * as Styles from './PageMain.styles';
 
 /**
  * A container for holding the main content of a page
  */
-const PageMain: React.FC<PageMainProps> = ({
-  children,
-  classes,
-  ...props
-}) => (
-  <Styles.Container
-    id="main" 
-    className={classes}
-    {...props}
-  >
+const PageMain: React.FunctionComponent<PageMainProps> = ({ children, classes, fullWidthText = false, ...props }) => (
+  <Styles.Container id="main" className={classes} fullWidthText={fullWidthText} {...props} data-testid="PageMain">
     {children}
   </Styles.Container>
 );
 
 export default PageMain;
-

--- a/src/library/structure/PageMain/PageMain.types.ts
+++ b/src/library/structure/PageMain/PageMain.types.ts
@@ -3,4 +3,9 @@ export interface PageMainProps {
    * Any unique class names to apply to the page container
    */
   classes?: string;
+
+  /**
+   * Should the paragraph text be full width?
+   */
+  fullWidthText?: boolean;
 }


### PR DESCRIPTION
Reuse the existing Image component, but adding heading (optional) and content, putting it all in a responsive grid layout using Row and Column components. This layout stops the text from wrapping under the image and keeps the layout consistent. 

Also updated Content page example with the Image and ImageAndText slices. 

## Testing
- `npm run dev` for manual testing
- `npm run test ImageAndText`