### PR TITLE
Fix section links sidebar cropping

### DIFF
--- a/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.stories.tsx
+++ b/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.stories.tsx
@@ -1,9 +1,8 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import SectionLinksSidebar from "./SectionLinksSidebar";
-import { SectionLinksSidebarProps } from "./SectionLinksSidebar.types";
-import { SBPadding } from '../../../../.storybook/SBPadding'; 
+import SectionLinksSidebar from './SectionLinksSidebar';
+import { SectionLinksSidebarProps } from './SectionLinksSidebar.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
 
 export default {
   title: 'Library/Structure/Section Links - sidebar',
@@ -11,165 +10,167 @@ export default {
   parameters: {
     status: {
       type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-    }
+    },
   },
 };
 
+const Template: Story<SectionLinksSidebarProps> = (args) => (
+  <SBPadding>
+    <div style={{ maxWidth: '340px' }}>
+      <SectionLinksSidebar {...args} />
+    </div>
+  </SBPadding>
+);
 
-const Template: Story<SectionLinksSidebarProps> = (args) => <SBPadding><div style={{maxWidth: "340px"}}><SectionLinksSidebar {...args} /></div></SBPadding>;
-
-export const ExampleSection = Template.bind({});    
+export const ExampleSection = Template.bind({});
 ExampleSection.args = {
-  Title: "Pages in this section",
+  Title: 'Pages in this section',
   Sections: [
     {
-        SectionTitle: "Your bins and rubbish",
-        SectionLinks: [
-            {
-                title: "Find your bin collection day",
-                url: "/",
-                isCurrent: true
-            },
-            {
-                title: "Arrange bulky item collection",
-                url: "/",
-                isCurrent: false
-            },
-            {
-                title: "Report a missed collection",
-                url: "/"
-            },
-            {
-                title: "Request a new or replacement bin",
-                url: "/"
-            },
-            {
-                title: "Find a household waste recycling centre",
-                url: "/"
-            },
-            {
-                title: "What to recycle and where?",
-                url: "/"
-            }
-        ]
-    }
-  ]
+      SectionTitle: 'Your bins and rubbish',
+      SectionLinks: [
+        {
+          title: 'Find your bin collection day',
+          url: '/',
+          isCurrent: true,
+        },
+        {
+          title: 'Arrange bulky item collection',
+          url: '/',
+          isCurrent: false,
+        },
+        {
+          title: 'Report a missed collection',
+          url: '/',
+        },
+        {
+          title: 'Request a new or replacement bin',
+          url: '/',
+        },
+        {
+          title: 'Find a household waste recycling centre',
+          url: '/',
+        },
+        {
+          title: 'What to recycle and where?',
+          url: '/',
+        },
+      ],
+    },
+  ],
 };
 
-export const ExampleRelated = Template.bind({});    
+export const ExampleRelated = Template.bind({});
 ExampleRelated.args = {
-  Title: "Also found in",
-  Sections: [
-      {
-        SectionLinks: [
-            {
-                title: "Bin collection, recycling and waste",
-                url: "/"
-            }
-        ]
-      }
-  ]
-};
-
-export const ExampleMultiple = Template.bind({});    
-ExampleMultiple.args = {
-  Title: "Pages in this section",
+  Title: 'Also found in',
   Sections: [
     {
-        SectionTitle: "Your bins and rubbish",
-        SectionLinks: [
-            {
-                title: "Contact the council",
-                url: "/",
-                isCurrent: true
-            },
-            {
-                title: "Give feedback on our services",
-                url: "/"
-            },
-            {
-                title: "Requesting information from the council",
-                url: "/"
-            },
-            {
-                title: "Privacy",
-                url: "/"
-            },
-            {
-                title: "Policies",
-                url: "/"
-            }
-        ]
+      SectionLinks: [
+        {
+          title: 'Bin collection, recycling and waste',
+          url: '/',
+        },
+      ],
+    },
+  ],
+};
+
+export const ExampleMultiple = Template.bind({});
+ExampleMultiple.args = {
+  Title: 'Pages in this section',
+  Sections: [
+    {
+      SectionTitle: 'Your bins and rubbish',
+      SectionLinks: [
+        {
+          title: 'Contact the council',
+          url: '/',
+          isCurrent: true,
+        },
+        {
+          title: 'Give feedback on our services',
+          url: '/',
+        },
+        {
+          title: 'Requesting information from the council',
+          url: '/',
+        },
+        {
+          title: 'Privacy',
+          url: '/',
+        },
+        {
+          title: 'Policies',
+          url: '/',
+        },
+      ],
     },
 
     {
-        SectionTitle: "Your bins and rubbish",
-        SectionLinks: [
-            {
-                title: "Contact the council",
-                url: "/",
-                isCurrent: true
-            },
-            {
-                title: "Give feedback on our services",
-                url: "/",
-                isCurrent: false
-            },
-            {
-                title: "Requesting information from the council",
-                url: "/",
-                isCurrent: false
-            },
-            {
-                title: "Privacy",
-                url: "/",
-                isCurrent: false
-            },
-            {
-                title: "Policies",
-                url: "/",
-                isCurrent: false
-            }
-        ]
-    }
-  ]
+      SectionTitle: 'Your bins and rubbish',
+      SectionLinks: [
+        {
+          title: 'Contact the council',
+          url: '/',
+          isCurrent: true,
+        },
+        {
+          title: 'Give feedback on our services',
+          url: '/',
+          isCurrent: false,
+        },
+        {
+          title: 'Requesting information from the council',
+          url: '/',
+          isCurrent: false,
+        },
+        {
+          title: 'Privacy',
+          url: '/',
+          isCurrent: false,
+        },
+        {
+          title: 'Policies',
+          url: '/',
+          isCurrent: false,
+        },
+      ],
+    },
+  ],
 };
 
-
-
-
-
-export const ExampleReallyLongLinkText = Template.bind({});    
+export const ExampleReallyLongLinkText = Template.bind({});
 ExampleReallyLongLinkText.args = {
-  Title: "Really long link text example",
+  Title: 'Really long link text example',
   Sections: [
     {
-        SectionLinks: [
-            {
-                title: "Maecenas sed diam eget risus varius blandit sit amet non magna. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.",
-                url: "/"
-            },
-            {
-                title: "Contact the council",
-                url: "/"
-            },
-            {
-                title: "Give feedback on our services",
-                url: "/"
-            },
-            {
-                title: "Requesting information from the council",
-                url: "/"
-            },
-            {
-                title: "Privacy",
-                url: "/"
-            },
-            {
-                title: "Policies",
-                url: "/"
-            }
-        ]
-    }
-    ]
+      SectionLinks: [
+        {
+          title:
+            'Maecenas sed diam eget risus varius blandit sit amet non magna. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.',
+          url: '/',
+        },
+        {
+          title: 'Contact the council',
+          url: '/',
+        },
+        {
+          title: 'Give feedback on our services',
+          url: '/',
+        },
+        {
+          title: 'Requesting information from the council',
+          url: '/',
+        },
+        {
+          title: 'Privacy',
+          url: '/',
+        },
+        {
+          title: 'Policies',
+          url: '/',
+        },
+      ],
+    },
+  ],
 };

--- a/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.styles.js
+++ b/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.styles.js
@@ -1,119 +1,117 @@
-import styled, {css} from "styled-components";
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
-  ${props => props.theme.fontStyles}
-  background-color: ${props => props.theme.theme_vars.colours.action_light}; 
-  border-radius: ${props => props.theme.theme_vars.border_radius};
+  ${(props) => props.theme.fontStyles}
+  background-color: ${(props) => props.theme.theme_vars.colours.action_light};
+  border-radius: ${(props) => props.theme.theme_vars.border_radius};
   margin-bottom: 25px;
-  
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){  
-    background-color: transparent; 
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    background-color: transparent;
   }
-`
+`;
 
 export const MobileTitleButton = styled.button`
   width: 100%;
   background: none;
   border: none;
   text-align: left;
-  border-bottom: 2px solid ${props => props.theme.theme_vars.colours.action};
-  padding: ${props => props.theme.theme_vars.spacingSizes.small};
+  border-bottom: 2px solid ${(props) => props.theme.theme_vars.colours.action};
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
   font-size: 1em;
 
   svg {
-    fill: ${props => props.theme.theme_vars.colours.action};
+    fill: ${(props) => props.theme.theme_vars.colours.action};
     vertical-align: middle;
   }
 
   &:focus {
     outline: none;
-    ${props => props.theme.linkStylesFocus}
+    ${(props) => props.theme.linkStylesFocus}
     border-bottom: 2px solid;
     svg {
-      fill: ${props => props.theme.theme_vars.colours.black};
+      fill: ${(props) => props.theme.theme_vars.colours.black};
     }
   }
-  &:active{
-    ${props => props.theme.linkStylesActive}
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
   }
 
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){  
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     display: none;
   }
-`
+`;
 export const IconWrapper = styled.span`
-    display: inline-block;
-    margin-left: 10px;
-    margin-right: 5px;
-    float: right;
-`
+  display: inline-block;
+  margin-left: 10px;
+  margin-right: 5px;
+  float: right;
+`;
 
 export const Title = styled.span`
   display: none;
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){  
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     display: block;
-    border-bottom: 1px solid ${props => props.theme.theme_vars.colours.action};
-    padding: ${props => props.theme.theme_vars.spacingSizes.small};
-    font-size: ${props => props.theme.theme_vars.fontSizes.extra_small};
+    border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.action};
+    padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+    font-size: ${(props) => props.theme.theme_vars.fontSizes.extra_small};
 
     &:focus {
       outline: none;
     }
   }
-`
-
+`;
 
 export const Body = styled.div`
   &.closed {
     display: none;
   }
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){  
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     &.closed {
       display: block;
     }
   }
-`
+`;
 
 export const SectionTitle = styled.p`
-  margin: ${props => props.theme.theme_vars.spacingSizes.extra_small} 0;
-  padding: ${props => props.theme.theme_vars.spacingSizes.small};
+  margin: ${(props) => props.theme.theme_vars.spacingSizes.extra_small} 0;
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
   font-weight: bold;
-`
+`;
 
 export const List = styled.ul`
   list-style: none;
   margin: 0 !important;
   padding: 0 !important;
-`
+`;
 
 const focusListItem = css`
-    color: ${props => props.theme.theme_vars.colours.black};
-    background-color: ${props => props.theme.theme_vars.colours.focus};
-    outline: none;
-    box-shadow: 0px -2px 0px 0px ${props => props.theme.theme_vars.colours.black} inset;
-    -webkit-box-shadow: 0px -2px 0px 0px ${props => props.theme.theme_vars.colours.black} inset;
-    -moz-box-shadow: 0px -2px 0px 0px ${props => props.theme.theme_vars.colours.black} inset;
-`
-
+  color: ${(props) => props.theme.theme_vars.colours.black};
+  background-color: ${(props) => props.theme.theme_vars.colours.focus};
+  outline: none;
+  box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+  -webkit-box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+  -moz-box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+`;
 
 export const ListItem = styled.li`
   list-style: none !important;
   margin: 0 !important;
   padding: 0 !important;
+  left: 0;
 
   &::before {
     display: none;
     position: relative;
   }
 
-
   &[aria-current] a {
     display: none;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){  
+    @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
       display: block;
-      background-color: ${props => props.theme.theme_vars.colours.action_light};
-      color: ${props => props.theme.theme_vars.colours.black};
+      background-color: ${(props) => props.theme.theme_vars.colours.action_light};
+      color: ${(props) => props.theme.theme_vars.colours.black};
       border-bottom-color: transparent;
 
       &:focus {
@@ -121,20 +119,18 @@ export const ListItem = styled.li`
       }
     }
   }
-
-`
+`;
 
 export const ListItemLink = styled.a`
   display: block;
-  color: ${props => props.theme.theme_vars.colours.action};
+  color: ${(props) => props.theme.theme_vars.colours.action};
   padding: 5px 10px;
   text-decoration: none;
-  
 
   &:hover {
     cursor: pointer;
     transition: background-color 0.3s ease 0s;
-    background-color: ${props => props.theme.theme_vars.colours.action_light}80;
+    background-color: ${(props) => props.theme.theme_vars.colours.action_light}80;
   }
 
   &:focus {
@@ -142,12 +138,12 @@ export const ListItemLink = styled.a`
   }
   &:active {
     transform: translateY(1px);
-    box-shadow: 0px -1px 0px 0px ${props => props.theme.theme_vars.colours.black} inset;
-    -webkit-box-shadow: 0px -1px 0px 0px ${props => props.theme.theme_vars.colours.black} inset;
-    -moz-box-shadow: 0px -1px 0px 0px ${props => props.theme.theme_vars.colours.black} inset;
+    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+    -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+    -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
   }
 
-  @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){  
-    margin: ${props => props.theme.theme_vars.spacingSizes.extra_small} 0;
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    margin: ${(props) => props.theme.theme_vars.spacingSizes.extra_small} 0;
   }
-`
+`;

--- a/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.test.tsx
+++ b/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.test.tsx
@@ -1,21 +1,31 @@
-import React from "react";
-import { render } from "@testing-library/react";
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
 
-import SectionLinksSidebar from "./SectionLinksSidebar";
-import { SectionLinksSidebarProps } from "./SectionLinksSidebar.types";
+import SectionLinksSidebar from './SectionLinksSidebar';
+import { SectionLinksSidebarProps } from './SectionLinksSidebar.types';
 
-import { ThemeProvider } from "styled-components";
-import { west_theme } from "../../../themes/theme_generator";
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
 
-describe("Test Component", () => {
-  let props: SectionLinksSidebarProps;
-
-  beforeEach(() => {
-    props = {
-      Title: "testing section",
-      Sections: [],
-    };
-  });
+describe('Test Component', () => {
+  let props: SectionLinksSidebarProps = {
+    Title: 'Pages in this section',
+    Sections: [
+      {
+        SectionTitle: 'The section title',
+        SectionLinks: [
+          {
+            title: 'An example link',
+            url: '/an-example-link',
+          },
+          {
+            title: 'Another example link',
+            url: '/another-example-link',
+          },
+        ],
+      },
+    ],
+  };
 
   const renderComponent = () =>
     render(
@@ -24,12 +34,24 @@ describe("Test Component", () => {
       </ThemeProvider>
     );
 
-  it("should render foo text correctly", () => {
-    props.Title = "example content";
-    const { getByTestId } = renderComponent();
+  it('should render foo text correctly', () => {
+    const { getByTestId, getAllByRole, getByRole, queryAllByRole } = renderComponent();
 
-    const component = getByTestId("SectionLinksSidebar");
+    const component = getByTestId('SectionLinksSidebar');
 
-    expect(component).toHaveTextContent("example content");
+    expect(component).toHaveTextContent('Pages in this section');
+
+    // Links hidden by default on mobile
+    expect(queryAllByRole('link')).toHaveLength(0);
+
+    fireEvent.click(getByRole('button'));
+    const links = getAllByRole('link');
+
+    expect(component).toHaveTextContent('The section title');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent('An example link');
+    expect(links[0]).toHaveAttribute('href', '/an-example-link');
+    expect(links[1]).toHaveTextContent('Another example link');
+    expect(links[1]).toHaveAttribute('href', '/another-example-link');
   });
 });

--- a/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.tsx
+++ b/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.tsx
@@ -1,41 +1,36 @@
-import React, { useState } from "react";
-
-import { SectionLinksSidebarProps } from "./SectionLinksSidebar.types";
-import * as Styles from "./SectionLinksSidebar.styles";
+import React, { useState } from 'react';
+import { SectionLinksSidebarProps } from './SectionLinksSidebar.types';
+import * as Styles from './SectionLinksSidebar.styles';
 import ChevronIcon from '../../components/icons/ChevronIcon/ChevronIcon';
 
-const SectionLinksSidebar: React.FC<SectionLinksSidebarProps> = ({ Title, Sections }) => {
-    const [open, setOpen] = useState(false);
+const SectionLinksSidebar: React.FunctionComponent<SectionLinksSidebarProps> = ({ Title, Sections }) => {
+  const [open, setOpen] = useState(false);
 
-    return(
-        <Styles.Container data-testid="SectionLinksSidebar">
-            <Styles.MobileTitleButton onClick={() => open ? setOpen(false) : setOpen(true)}>
-                {Title}
-                <Styles.IconWrapper>
-                    <ChevronIcon direction={open ? "up" : "down"} />
-                </Styles.IconWrapper>
-            </Styles.MobileTitleButton>
-            <Styles.Title>
-                {Title}
-            </Styles.Title>
-            <Styles.Body className={!open && "closed"}>
-                {Sections.map((Section, index) => 
-                <div key={index}>
-                    {Section.SectionTitle && 
-                        <Styles.SectionTitle>{Section.SectionTitle}</Styles.SectionTitle>
-                    }
-                    <Styles.List>
-                        {Section.SectionLinks.map((link, i) =>
-                            <Styles.ListItem key={i} aria-current={link.isCurrent ? "true" : null}>
-                                <Styles.ListItemLink href={link.url} title={link.title}>{link.title}</Styles.ListItemLink>
-                            </Styles.ListItem>
-                        )}
-                    </Styles.List>
-                </div>
-                )} 
-            </Styles.Body>
-        </Styles.Container>
-    );
-}
+  return (
+    <Styles.Container data-testid="SectionLinksSidebar">
+      <Styles.MobileTitleButton onClick={() => (open ? setOpen(false) : setOpen(true))}>
+        {Title}
+        <Styles.IconWrapper>
+          <ChevronIcon direction={open ? 'up' : 'down'} />
+        </Styles.IconWrapper>
+      </Styles.MobileTitleButton>
+      <Styles.Title>{Title}</Styles.Title>
+      <Styles.Body className={!open && 'closed'}>
+        {Sections.map((Section, index) => (
+          <div key={index}>
+            {Section.SectionTitle && <Styles.SectionTitle>{Section.SectionTitle}</Styles.SectionTitle>}
+            <Styles.List>
+              {Section.SectionLinks.map((link, i) => (
+                <Styles.ListItem key={i} aria-current={link.isCurrent ? 'true' : null}>
+                  <Styles.ListItemLink href={link.url}>{link.title}</Styles.ListItemLink>
+                </Styles.ListItem>
+              ))}
+            </Styles.List>
+          </div>
+        ))}
+      </Styles.Body>
+    </Styles.Container>
+  );
+};
 
 export default SectionLinksSidebar;

--- a/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.types.ts
+++ b/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.types.ts
@@ -1,28 +1,40 @@
-
 export interface SectionLinksSidebarProps {
   /**
    * Title
    */
   Title: string;
-  Sections: Array<SectionsProps>
+
+  /**
+   * An array of sections
+   */
+  Sections: Array<SectionsProps>;
 }
 
 export interface SectionsProps {
+  /**
+   * The optional section title
+   */
   SectionTitle?: string;
+
+  /**
+   * The array of section links
+   */
   SectionLinks: Array<LinksProp>;
 }
 
 export interface LinksProp {
-    /**
-    * Title of the page
-    */
-    title: string;
-    /**
-    * URL of the page
-    */
-    url: string;
-    /**
-     * Is this the current page
-     */
-    isCurrent?: boolean;
+  /**
+   * Title of the page
+   */
+  title: string;
+
+  /**
+   * URL of the page
+   */
+  url: string;
+
+  /**
+   * Is this the current page
+   */
+  isCurrent?: boolean;
 }


### PR DESCRIPTION
The links in the section links sidebar sometimes have the right hand side of the [link text cropped from view](https://www.northnorthants.gov.uk/primary-school-places/apply-primary-school-place). Reset the `left` property to prevent this. 

- Resaved the files to apply prettier to all the files in the component
- Updated test to be more thorough
- Added comments to types