### PR TITLE
Use official parish and fix css grid bug

### DIFF
--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.storydata.ts
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.storydata.ts
@@ -13,16 +13,30 @@ export const exampleBands: ParishBands = {
 
 export const exampleParishes: ParishAPIResponse[] = [
   {
-    banding_parish: 'Abthorpe',
+    banding_parish: 'Abthorpe and Adstone',
     bands: exampleBands,
     official_parish: 'Abthorpe CP',
     code: 'E04006798',
     unitary: 'West',
   },
   {
-    banding_parish: 'Adstone',
+    banding_parish: 'Abthorpe and Adstone',
     bands: exampleBands,
     official_parish: 'Adstone CP',
+    code: 'E04006799',
+    unitary: 'West',
+  },
+  {
+    banding_parish: 'Alderton',
+    bands: exampleBands,
+    official_parish: 'Alderton NCP',
+    code: 'E04006799',
+    unitary: 'West',
+  },
+  {
+    banding_parish: 'Althorpe',
+    bands: exampleBands,
+    official_parish: 'Althorpe CP',
     code: 'E04006799',
     unitary: 'West',
   },

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.styles.js
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.styles.js
@@ -8,23 +8,11 @@ export const Container = styled.div`
 export const Row = styled.div`
   margin-bottom: 15px;
   border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey};
-  display: grid;
-  grid-template-columns: minmax(80px, min-content) 1fr;
-  grid-template-rows: 1fr;
-  gap: 0px 1em;
-  grid-template-areas: 'letter data';
 `;
 
 export const Letter = styled.div`
   text-transform: uppercase;
   ${(props) => props.theme.theme_vars.h1}
-  grid-area: letter;
-`;
-
-export const Data = styled.div`
-  padding: 15px;
-  column-count: 2;
-  column-gap: 15px;
 `;
 
 export const Link = styled.a`

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.tsx
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.tsx
@@ -6,6 +6,8 @@ import {
   SortedParish,
 } from './CouncilTaxAlphabeticalDirectory.types';
 import * as Styles from './CouncilTaxAlphabeticalDirectory.styles';
+import Column from '../../components/Column/Column';
+import Row from '../../components/Row/Row';
 
 /**
  * An list of parishes, sorted alphabetically, containing parish council tax bands
@@ -22,6 +24,21 @@ const CouncilTaxAlphabeticalDirectory: React.FunctionComponent<CouncilTaxAlphabe
   }, []);
 
   /**
+   * Trim NCP or CP from the end of the parish name
+   */
+  const trimParishName = (officialParish: string): string => {
+    if (officialParish.endsWith('NCP')) {
+      return officialParish.slice(0, -4);
+    }
+
+    if (officialParish.endsWith('CP')) {
+      return officialParish.slice(0, -3);
+    }
+
+    return officialParish;
+  };
+
+  /**
    * take the data we get from the API and make it how we want it
    * @param data
    * @returns
@@ -29,14 +46,17 @@ const CouncilTaxAlphabeticalDirectory: React.FunctionComponent<CouncilTaxAlphabe
   const formatParishData = (data: ParishAPIResponse[]) => {
     const sortData = data.reduce((r, e) => {
       // get first letter of name of current element
-      let group = e.banding_parish[0];
+      let group = e.official_parish[0];
 
       if (!r[group]) {
         // there is no property in accumulator with this letter so create it
-        r[group] = { group, children: [{ title: e.banding_parish, values: e.bands }] };
+        r[group] = {
+          group,
+          children: [{ title: trimParishName(e.official_parish), values: e.bands }],
+        };
       } else {
         // push current element to children array for that letter
-        r[group].children.push({ title: e.banding_parish, values: e.bands });
+        r[group].children.push({ title: trimParishName(e.official_parish), values: e.bands });
       }
 
       return r;
@@ -80,14 +100,20 @@ const CouncilTaxAlphabeticalDirectory: React.FunctionComponent<CouncilTaxAlphabe
           <>
             {sortedData.map((letter, i) => (
               <Styles.Row key={i}>
-                <Styles.Letter>{letter.group}</Styles.Letter>
-                <Styles.Data>
-                  {letter.children.map((letterData, i) => (
-                    <Styles.Link onClick={() => setCurrentParish(letterData)} key={i}>
-                      {letterData.title}
-                    </Styles.Link>
-                  ))}
-                </Styles.Data>
+                <Row>
+                  <Column small="full" medium="one-quarter" large="one-quarter">
+                    <Styles.Letter>{letter.group}</Styles.Letter>
+                  </Column>
+                  <Column small="full" medium="three-quarters" large="three-quarters">
+                    <Row>
+                      {letter.children.map((letterData, i) => (
+                        <Column small="one-half" medium="one-half" large="one-half" key={i}>
+                          <Styles.Link onClick={() => setCurrentParish(letterData)}>{letterData.title}</Styles.Link>
+                        </Column>
+                      ))}
+                    </Row>
+                  </Column>
+                </Row>
               </Styles.Row>
             ))}
           </>


### PR DESCRIPTION
- Previously using 'banding_parish' but this is not unique, so updated to 'official_parish' and removed the CP and NCP text from the end. 
- The layout was using CSS Grid but has now been reverted to the flexbox grid using Row and Column components. The CSS grid had strange quirks in Safari.

> On a mobile, the bottom right Parish for each letter isn't working when you click on it e.g. Aynho
As you scroll the page and then click on the Parish link, e.g. Long Buckby - it takes you to the bottom of the content page rather than the top.

## Testing
- Test the Council Tax Directory slice in preprod_frontend and see duplicates for `Draughton with Maidwell`
-  Using Safari, try clicking on the bottom right value, such as Long Buckby and it doesn't open the parish data. The link moves up and the parishes change columns.
- Checkout this branch and `yalc publish`
- In the frontend `yalc add northants-design-system && yarn install && yarn dev`
- Refresh the page with the Council Tax Directory slice and the duplicates should now be removed
- Click on a bottom right link and the parish data should now display as expected
