### PR TITLE
Prevent scrollbar with nested list in table

### DIFF
--- a/src/library/pages/ContentPage/ContentPage.tsx
+++ b/src/library/pages/ContentPage/ContentPage.tsx
@@ -143,8 +143,8 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
               </tr>
             </thead>
             <tbody>
-              {smallTable.data.map((row) => (
-                <tr key={row}>
+              {smallTable.data.map((row, index) => (
+                <tr key={index}>
                   {row.map((item) => (
                     <td key={item}>{item}</td>
                   ))}
@@ -176,6 +176,38 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
                   ))}
                 </tr>
               ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p>Example table with a nested list:</p>
+        <div className="table-container">
+          <table>
+            <caption>Example table with a nested list</caption>
+            <thead>
+              <tr>
+                <th scope="col">Heading</th>
+                <th scope="col">Heading</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>Example item</th>
+                <td>
+                  <ul>
+                    <li>List item</li>
+                    <li>
+                      List item
+                      <ul>
+                        <li>Nested list item</li>
+                        <li>Nested list item</li>
+                        <li>Nested list item</li>
+                      </ul>
+                    </li>
+                    <li>List item</li>
+                  </ul>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/src/themes/GlobalStyleReset.jsx
+++ b/src/themes/GlobalStyleReset.jsx
@@ -148,4 +148,7 @@ export const GlobalStyleReset = createGlobalStyle`
     border-collapse: collapse;
     border-spacing: 0;
   }
+  .table-container li {
+    left: 0;
+  }
 `;


### PR DESCRIPTION
Issue occurs in revision for 22/07 2022 09:25
https://staging.westnorthants.gov.uk/visiting-library/computers-internet-and-wifi 

This fix removes the default left on list items when inside a `.table-container`. 

## Testing
- Checkout this branch and comment out the css change in `GlobalStyleReset.jsx`
- Run `npm run dev` and view the Content Page example. Scroll down to the 'Example table with a nested list' and there should be a scrollbar
- Uncomment the css change and save the file
- Refresh the Content Page example and the scrollbar should be removed

## Frontend testing
- `yalc publish` and then in the frontend `yalc add northants-design-system && yarn install && yarn dev` then visit a page with a list in a table and the scrollbar should be removed