### PR TITLE
Fix/row min width

### DIFF
--- a/src/library/components/Row/Row.styles.js
+++ b/src/library/components/Row/Row.styles.js
@@ -11,7 +11,10 @@ export const Container = styled.div`
   border: ${(props) => (props.hasBorder ? `1px solid ${props.theme.theme_vars.colours.grey}` : 'none')};
   list-style: none;
   max-width: none !important;
-  min-width: 100%;
+  min-width: calc(
+    100% + ${(props) => props.theme.theme_vars.spacingSizes.small} +
+      ${(props) => props.theme.theme_vars.spacingSizes.small}
+  );
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
     flex-wrap: ${(props) => (props.hasWrap ? `wrap` : `nowrap`)};

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.stories.tsx
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.stories.tsx
@@ -1,46 +1,54 @@
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import NewsArticleFeaturedBlock from "./NewsArticleFeaturedBlock";
-import { NewsArticleFeaturedBlockProps } from "./NewsArticleFeaturedBlock.types";
+import NewsArticleFeaturedBlock from './NewsArticleFeaturedBlock';
+import { NewsArticleFeaturedBlockProps } from './NewsArticleFeaturedBlock.types';
 import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
 import { NewsArticleData } from './NewsArticleFeaturedBlock.storydata';
 
 export default {
-    title: 'Library/Structure/News Article Featured Block',
-    component: NewsArticleFeaturedBlock,
-    parameters: {
-      status: {
-        type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      }
+  title: 'Library/Structure/News Article Featured Block',
+  component: NewsArticleFeaturedBlock,
+  parameters: {
+    status: {
+      type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
     },
+  },
 };
 
-const Template: Story<NewsArticleFeaturedBlockProps> = (args) => <MaxWidthContainer><NewsArticleFeaturedBlock {...args} /></MaxWidthContainer>;
+const Template: Story<NewsArticleFeaturedBlockProps> = (args) => (
+  <MaxWidthContainer>
+    <NewsArticleFeaturedBlock {...args} />
+  </MaxWidthContainer>
+);
 
-export const ExampleNewsArticleFeaturedBlock = Template.bind({});    
+export const ExampleNewsArticleFeaturedBlock = Template.bind({});
 ExampleNewsArticleFeaturedBlock.args = {
   articles: NewsArticleData,
-  viewAllLink: "/"
+  viewAllLink: '/',
 };
 
-export const ExampleNoNewsArticleFeaturedBlock = Template.bind({});    
+export const ExampleNoNewsArticleFeaturedBlock = Template.bind({});
 ExampleNoNewsArticleFeaturedBlock.args = {
   articles: [],
 };
 
-export const ExampleNoTitleOrButton = Template.bind({});    
+export const ExampleNoTitleOrButton = Template.bind({});
 ExampleNoTitleOrButton.args = {
   articles: NewsArticleData,
   withoutTitle: true,
-  viewAllLink: ""
+  viewAllLink: '',
 };
 
-export const Example2Articles = Template.bind({});    
+export const Example3Articles = Template.bind({});
+Example3Articles.args = {
+  articles: NewsArticleData.slice(0, 3),
+};
+export const Example2Articles = Template.bind({});
 Example2Articles.args = {
-  articles: NewsArticleData.slice(0, 2)
+  articles: NewsArticleData.slice(0, 2),
 };
 
-export const Example1Article = Template.bind({});    
+export const Example1Article = Template.bind({});
 Example1Article.args = {
-  articles: NewsArticleData.slice(0, 1)
+  articles: NewsArticleData.slice(0, 1),
 };

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.stories.tsx
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.stories.tsx
@@ -43,6 +43,7 @@ export const Example3Articles = Template.bind({});
 Example3Articles.args = {
   articles: NewsArticleData.slice(0, 3),
 };
+
 export const Example2Articles = Template.bind({});
 Example2Articles.args = {
   articles: NewsArticleData.slice(0, 2),

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.storydata.js
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.storydata.js
@@ -5,7 +5,7 @@ export const NewsArticleData = [
   {
     id: '6036694e95f7c8c6729a46bf',
     url: '/',
-    title: 'Veniam nostrud excepteur ',
+    title: 'Veniam nostrud excepteur',
     date: 1614178638,
     image720x405:
       'https://cms-staging.westnorthants.gov.uk/sites/default/files/styles/responsive/public/720/405/0/2022-02/HMD-Facebook-graphic_3.jpg',
@@ -16,7 +16,7 @@ export const NewsArticleData = [
   {
     id: '6036694e71b8eedb00cff39f',
     url: '/',
-    title: 'Non minim ad ullamco ',
+    title: 'Non minim ad ullamco',
     excerpt:
       'Cillum occaecat eiusmod pariatur cillum Lorem sunt pariatur proident aliquip pariatur aute nostrud. Veniam aliqua qui id consectetur sit incididunt. Sint non voluptate adipisicing anim. Amet tempor id in adipisicing sunt. Aliquip dolore ipsum occaecat officia anim aliqua minim consequat Lorem ipsum.\r\n',
     date: 1614178638,

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.storydata.js
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.storydata.js
@@ -5,7 +5,7 @@ export const NewsArticleData = [
   {
     id: '6036694e95f7c8c6729a46bf',
     url: '/',
-    title: 'Veniam nostrud excepteur elit non cupidatat deserunt sunt amet ad ipsum sunt incididunt.',
+    title: 'Veniam nostrud excepteur ',
     date: 1614178638,
     image720x405:
       'https://cms-staging.westnorthants.gov.uk/sites/default/files/styles/responsive/public/720/405/0/2022-02/HMD-Facebook-graphic_3.jpg',
@@ -16,7 +16,7 @@ export const NewsArticleData = [
   {
     id: '6036694e71b8eedb00cff39f',
     url: '/',
-    title: 'Non minim ad ullamco exercitation pariatur eu dolor occaecat ullamco culpa excepteur cillum irure.',
+    title: 'Non minim ad ullamco ',
     excerpt:
       'Cillum occaecat eiusmod pariatur cillum Lorem sunt pariatur proident aliquip pariatur aute nostrud. Veniam aliqua qui id consectetur sit incididunt. Sint non voluptate adipisicing anim. Amet tempor id in adipisicing sunt. Aliquip dolore ipsum occaecat officia anim aliqua minim consequat Lorem ipsum.\r\n',
     date: 1614178638,
@@ -29,7 +29,7 @@ export const NewsArticleData = [
   {
     id: '6036694ed3c1de9114024a02',
     url: '/',
-    title: 'In sint incididunt dolor officia consectetur proident mollit exercitation magna.',
+    title: 'In sint incididunt dolor',
     date: 1614178638,
     image720x405:
       'https://cms-staging.westnorthants.gov.uk/sites/default/files/styles/responsive/public/720/405/0/2022-01/For%20The%20Love%20Of%20Books%20-%20logo%20-%20landscape.png',


### PR DESCRIPTION
This affected NewsArticleFeaturedBlock when the title content wasn't wide enough to push the Row wider than the min-width. 

I've shortened the titles in the story data to help replicate the issue.

## Testing
- Test NewsArticleFeaturedBlock component with 3 articles story
- With the Row fix the `ul` should be the full width of the containing div
- Revert the Row min-width css fix and the `ul` is no longer as wide as the containing div