### PR TITLE
Add focus state to CheckboxListFilter

### DIFF
--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
@@ -1,130 +1,127 @@
-import styled from "styled-components";
-import {VisuallyHidden} from './../../helpers/style-helpers'
+import styled from 'styled-components';
+import { VisuallyHidden } from './../../helpers/style-helpers';
 
 export const Container = styled.div`
-${props => props.theme.fontStyles};
+  ${(props) => props.theme.fontStyles};
   margin-bottom: 30px;
-`
+`;
 
 export const Fieldset = styled.fieldset`
-    min-width: 0;
-    margin: 0;
-    padding: 0;
-    border: 0;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
 
-    &:after {
-      content: "";
-      display: block;
-      clear: both;
-    }
-`
+  &:after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+`;
 
-const hideLabel = props => {
-  if(props.labelHidden === true) {
+const hideLabel = (props) => {
+  if (props.labelHidden === true) {
     return VisuallyHidden;
   }
-}
-
+};
 
 export const Legend = styled.legend`
-    color: #0b0c0c;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-    display: table;
-    max-width: 100%;
-    margin-bottom: 10px;
-    padding: 0;
-    white-space: normal;
-    ${hideLabel}
-`
+  color: #0b0c0c;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  display: table;
+  max-width: 100%;
+  margin-bottom: 10px;
+  padding: 0;
+  white-space: normal;
+  ${hideLabel}
+`;
 
-const hideHint = props => {
-  if(props.hintHidden === true) {
+const hideHint = (props) => {
+  if (props.hintHidden === true) {
     return VisuallyHidden;
   }
-}
-
+};
 
 export const Hint = styled.div`
-    font-size: ${props => props.theme.theme_vars.fontSizes.small};
-    display: block;
-    margin-bottom: 15px;
-    color: #505a5f;
-    margin-top: -5px;
-    ${hideHint}
-`
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.small};
+  display: block;
+  margin-bottom: 15px;
+  color: #505a5f;
+  margin-top: -5px;
+  ${hideHint}
+`;
 
 export const Checkboxes = styled.div`
-  display: block; 
-  `
-
-
+  display: block;
+`;
 
 export const Checkbox = styled.div`
-     
-    font-size: ${props => props.theme.theme_vars.fontSizes.small};
-    display: block;
-    position: relative;
-    min-height: 40px;
-    margin-bottom: 10px;
-    padding-left: 40px;
-    clear: left;
-  `
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.small};
+  display: block;
+  position: relative;
+  min-height: 40px;
+  margin-bottom: 10px;
+  padding-left: 40px;
+  clear: left;
+`;
 
 export const CheckboxInput = styled.input`
-    cursor: pointer;
-    position: absolute;
-    z-index: 1;
-    top: -2px;
-    left: -2px;
-    width: 44px;
-    height: 44px;
-    margin: 0;
-    opacity: 0;
-`
+  cursor: pointer;
+  position: absolute;
+  z-index: 1;
+  top: -2px;
+  left: -2px;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  opacity: 0;
+
+  &:focus + label:before {
+    box-shadow: 0 0 0 3px ${(props) => props.theme.theme_vars.colours.focus};
+  }
+`;
 
 export const CheckboxLabel = styled.label`
-    display: inline-block;
-    margin-bottom: 0;
-    padding: 8px 15px 5px;
-    cursor: pointer;
-    -ms-touch-action: manipulation;
-    touch-action: manipulation;
-    color: #0b0c0c;
-    display: block;
-    margin-bottom: 5px;
+  display: inline-block;
+  margin-bottom: 0;
+  padding: 8px 15px 5px;
+  cursor: pointer;
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+  color: #0b0c0c;
+  display: block;
+  margin-bottom: 5px;
 
+  &:before {
+    content: '';
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 40px;
+    height: 40px;
+    border: 2px solid currentColor;
+    background: transparent;
+  }
 
-    &:before {
-      content: "";
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 40px;
-      height: 40px;
-      border: 2px solid currentColor;
-      background: transparent;
-    }
-
-
-    &:after {
-      content: "";
-      -webkit-box-sizing: border-box;
-      box-sizing: border-box;
-      position: absolute;
-      top: 11px;
-      left: 9px;
-      width: 23px;
-      height: 12px;
-      -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
-      transform: rotate(-45deg);
-      border: solid;
-      border-width: 0 0 5px 5px;
-      border-top-color: transparent;
-      opacity: ${props => props.isChecked ? 1 : 0};
-      background: transparent;
-    }
-`
+  &:after {
+    content: '';
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    position: absolute;
+    top: 11px;
+    left: 9px;
+    width: 23px;
+    height: 12px;
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    transform: rotate(-45deg);
+    border: solid;
+    border-width: 0 0 5px 5px;
+    border-top-color: transparent;
+    opacity: ${(props) => (props.isChecked ? 1 : 0)};
+    background: transparent;
+  }
+`;

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
@@ -1,74 +1,73 @@
+import React, { useState } from 'react';
+import { CheckboxListFilterProps } from './CheckboxListFilter.types';
+import * as Styles from './CheckboxListFilter.styles';
+import { NewsArticleFilterFields } from './../../structure/NewsArticleFilterAccordion/NewsArticleFilterAccordionText';
+import { handleParams } from './../../helpers/url-helpers';
 
-import React, {useState} from "react";
+const CheckboxListFilter: React.FunctionComponent<CheckboxListFilterProps> = ({
+  options,
+  checked,
+  label,
+  hint = null,
+  displayLegend,
+}) => {
+  let labelHidden = label === null || !displayLegend ? true : false;
+  let hintHidden = hint === null ? true : false;
 
-import { CheckboxListFilterProps } from "./CheckboxListFilter.types";
-import * as Styles from "./CheckboxListFilter.styles";
+  const setupCheckboxes = () => {
+    return options.map((option) => ({ ...option, checked: checked.includes(option.value) ? true : false }));
+  };
 
-import { NewsArticleFilterFields } from "./../../structure/NewsArticleFilterAccordion/NewsArticleFilterAccordionText"
+  const [checkboxState, setCheckboxState] = useState(setupCheckboxes());
 
-import {handleParams} from './../../helpers/url-helpers';
+  const optionChecked = (e) => {
+    const checkedVal = e.target.value;
+    let newCheckboxState = [...checkboxState];
 
+    // update the state so it looks correct
+    newCheckboxState.find((val) => {
+      if (val.value === checkedVal) {
+        val.checked = !val.checked;
+      }
+    });
+    setCheckboxState(newCheckboxState);
 
-const CheckboxListFilter: React.FC<CheckboxListFilterProps> = ({ options, checked, label, hint = null, displayLegend}) => {
+    // take our new state and send a smooshed list to the handleParams method
+    let checked = [...checkboxState];
+    checked = newCheckboxState.filter((c) => c.checked === true);
 
-    let labelHidden = (label === null || !displayLegend) ? true : false;
-    let hintHidden = (hint === null) ? true : false;
+    let articleTypes = checked.map((c) => c.value).join(',');
+    handleParams('news', [{ key: NewsArticleFilterFields.articleType.queryParamKey, value: articleTypes }], ['page']);
+  };
 
-    const setupCheckboxes = () => {
-        return options.map(option => ({...option, checked: (checked.includes(option.value) ? true : false)}))
-    }
-
-    const [checkboxState, setCheckboxState] = useState(setupCheckboxes());
-    
-    const optionChecked = (e) => {
-
-        const checkedVal = e.target.value;
-        let newCheckboxState = [...checkboxState];
-
-        // update the state so it looks correct
-        newCheckboxState.find((val)=>{
-            if(val.value === checkedVal) {
-                val.checked = !val.checked;
-            }
-        })
-        setCheckboxState(newCheckboxState);
-
-        // take our new state and send a smooshed list to the handleParams method
-        let checked = [...checkboxState];
-        checked = newCheckboxState.filter(c => c.checked === true);
-        
-        let articleTypes = checked.map((c) => c.value).join(',');
-        handleParams('news', [{key: NewsArticleFilterFields.articleType.queryParamKey, value: articleTypes}],["page"]);
-    }
-
-    
-    const backupLabel = Math.random().toString(36).substring(7);
-    return (
-    
+  const backupLabel = Math.random().toString(36).substring(7);
+  return (
     <Styles.Container data-testid="CheckboxListFilter">
-
-    <Styles.Fieldset aria-describedby="waste-hint">
-        <Styles.Legend labelHidden={labelHidden}>
-            {label}
-        </Styles.Legend>
+      <Styles.Fieldset aria-describedby="waste-hint">
+        <Styles.Legend labelHidden={labelHidden}>{label}</Styles.Legend>
         <Styles.Hint id="waste-hint" hintHidden={hintHidden}>
-            {hint}
+          {hint}
         </Styles.Hint>
         <Styles.Checkboxes>
-        {checkboxState.map((option, i) => 
-                <Styles.Checkbox key={i}>
-                    <Styles.CheckboxInput id={option.value} name={labelHidden ? backupLabel : label } type="checkbox"  onChange={optionChecked} value={option.value} checked={option.checked} />
-                    <Styles.CheckboxLabel isChecked={option.checked} htmlFor={option.value}>
-                    {option.title}
-                    </Styles.CheckboxLabel>
-                </Styles.Checkbox>
-            )}
+          {checkboxState.map((option, i) => (
+            <Styles.Checkbox key={i}>
+              <Styles.CheckboxInput
+                id={option.value}
+                name={labelHidden ? backupLabel : label}
+                type="checkbox"
+                onChange={optionChecked}
+                value={option.value}
+                checked={option.checked}
+              />
+              <Styles.CheckboxLabel isChecked={option.checked} htmlFor={option.value}>
+                {option.title}
+              </Styles.CheckboxLabel>
+            </Styles.Checkbox>
+          ))}
         </Styles.Checkboxes>
-
       </Styles.Fieldset>
-    
-    
     </Styles.Container>
-)};
+  );
+};
 
 export default CheckboxListFilter;

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.types.ts
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.types.ts
@@ -1,4 +1,3 @@
-
 export interface CheckboxListFilterProps {
   /**
    * What to show in the checkboxes
@@ -10,26 +9,28 @@ export interface CheckboxListFilterProps {
    */
   checked: Array<string>;
 
-    /**
-     * 
+  /**
+   * The label text
    */
   label: string;
+
   /**
-   * 
+   * The hint text
    */
   hint: string;
-    /**
-   * 
-   */
-  displayLegend: boolean
-}
 
+  /**
+   * Should the legend be displayed
+   */
+  displayLegend: boolean;
+}
 
 export interface CheckboxValsProps {
   /**
    * Text shown in dropdown
    */
   title: string;
+
   /**
    * Filter sent to the all seeing server
    */

--- a/src/library/components/CheckboxListFilter/CheckboxListFilterData.js
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilterData.js
@@ -1,7 +1,10 @@
-export const articleOptions = [ {
-    title: "Article",
-    value: 'article'
-  }, {
-    title: "Press Release",
-    value: 'press-release'
-  } ];
+export const articleOptions = [
+  {
+    title: 'Article',
+    value: 'article',
+  },
+  {
+    title: 'Press Release',
+    value: 'press-release',
+  },
+];


### PR DESCRIPTION
The checkboxes had no hover state so you could not see which checkbox was being highlighted when using keyboard and tab to navigate the page. 

I utilised the same method as the Gov.uk design system where it adds a box shadow to the `label:before` https://design-system.service.gov.uk/components/checkboxes/

## Testing
- Checkout this branch and run `npm run dev` then visit the Library > Components > CheckboxListFilter component
- Tab to the checkboxes and it should now highlight which checkbox is focused
- Test the News Landing Page Example in Page Examples and tab through the sidebar, opening 'Type of article' then tabbing through the checkboxes to test the focus state displays as expected