### PR TITLE
Update test runner versions

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -2,10 +2,10 @@ name: Jest Tests
 on: push
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
           cache: 'npm'
@@ -14,10 +14,10 @@ jobs:
       - name: Build
         run: npm run build
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
           cache: 'npm'


### PR DESCRIPTION
Ubuntu 18 test runners are being deprecated so swapping to Ubuntu version 22.04. 
https://github.com/actions/runner-images/issues/6002

Also updating to use the new versions of checkout and setup-node actions. 