### PR TITLE
Fix label and hint hiding. Add test

### DIFF
--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.stories.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.stories.tsx
@@ -27,4 +27,15 @@ export const ExampleCheckboxListFilter = Template.bind({});
 ExampleCheckboxListFilter.args = {
   options: articleOptions,
   checked: NewsArticleFilters.articleType,
+  label: 'An example label',
+  hint: 'Some example hint text',
+  displayLegend: true,
+};
+
+export const ExampleCheckboxListFilterHiddenLabelHint = Template.bind({});
+ExampleCheckboxListFilterHiddenLabelHint.args = {
+  options: articleOptions,
+  checked: NewsArticleFilters.articleType,
+  hint: null,
+  label: null,
 };

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { VisuallyHidden } from './../../helpers/style-helpers';
 
 export const Container = styled.div`
   ${(props) => props.theme.fontStyles};
@@ -19,14 +20,8 @@ export const Fieldset = styled.fieldset`
 `;
 
 const hideLabel = (props) => {
-  if (props.labelHidden === true) {
-    return css`
-      display: none;
-    `;
-  } else {
-    return css`
-      display: table;
-    `;
+  if (props.labelHidden == true) {
+    return VisuallyHidden;
   }
 };
 
@@ -34,6 +29,7 @@ export const Legend = styled.legend`
   color: #0b0c0c;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  display: table;
   max-width: 100%;
   margin-bottom: 10px;
   padding: 0;

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
@@ -20,7 +20,7 @@ export const Fieldset = styled.fieldset`
 `;
 
 const hideLabel = (props) => {
-  if (props.labelHidden == true) {
+  if (props.labelHidden) {
     return VisuallyHidden;
   }
 };
@@ -39,18 +39,13 @@ export const Legend = styled.legend`
 
 const hideHint = (props) => {
   if (props.hintHidden) {
-    return css`
-      display: none;
-    `;
-  } else {
-    return css`
-      display: block;
-    `;
+    return VisuallyHidden;
   }
 };
 
 export const Hint = styled.div`
   font-size: ${(props) => props.theme.theme_vars.fontSizes.small};
+  display: block;
   margin-bottom: 15px;
   color: #505a5f;
   margin-top: -5px;

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.styles.js
@@ -1,5 +1,4 @@
-import styled from 'styled-components';
-import { VisuallyHidden } from './../../helpers/style-helpers';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   ${(props) => props.theme.fontStyles};
@@ -21,7 +20,13 @@ export const Fieldset = styled.fieldset`
 
 const hideLabel = (props) => {
   if (props.labelHidden === true) {
-    return VisuallyHidden;
+    return css`
+      display: none;
+    `;
+  } else {
+    return css`
+      display: table;
+    `;
   }
 };
 
@@ -29,7 +34,6 @@ export const Legend = styled.legend`
   color: #0b0c0c;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-  display: table;
   max-width: 100%;
   margin-bottom: 10px;
   padding: 0;
@@ -38,14 +42,19 @@ export const Legend = styled.legend`
 `;
 
 const hideHint = (props) => {
-  if (props.hintHidden === true) {
-    return VisuallyHidden;
+  if (props.hintHidden) {
+    return css`
+      display: none;
+    `;
+  } else {
+    return css`
+      display: block;
+    `;
   }
 };
 
 export const Hint = styled.div`
   font-size: ${(props) => props.theme.theme_vars.fontSizes.small};
-  display: block;
   margin-bottom: 15px;
   color: #505a5f;
   margin-top: -5px;

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.test.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import CheckboxListFilter from './CheckboxListFilter';
+import { CheckboxListFilterProps } from './CheckboxListFilter.types';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+
+describe('CheckboxListFilter', () => {
+  let props: CheckboxListFilterProps;
+
+  beforeEach(() => {
+    props = {
+      options: [
+        {
+          title: 'Article',
+          value: 'article',
+        },
+        {
+          title: 'Press Release',
+          value: 'press-release',
+        },
+      ],
+      checked: [],
+      label: null,
+      hint: null,
+      displayLegend: false,
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <CheckboxListFilter {...props} />
+      </ThemeProvider>
+    );
+
+  it('renders the component', () => {
+    const { getByTestId, getAllByRole } = renderComponent();
+
+    const component = getByTestId('CheckboxListFilter');
+    const checkboxes = getAllByRole('checkbox');
+    const legend = getByTestId('CheckboxListFilterLegend');
+    const hint = getByTestId('CheckboxListFilterHint');
+
+    expect(component).toBeVisible();
+
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).toHaveAttribute('value', 'article');
+    expect(checkboxes[0]).not.toBeChecked();
+
+    expect(checkboxes[1]).toHaveAttribute('value', 'press-release');
+    expect(checkboxes[1]).not.toBeChecked();
+
+    expect(legend).not.toBeVisible();
+    expect(hint).not.toBeVisible();
+  });
+
+  it('hides the ledgend when label is set', () => {
+    props.label = 'The legend label';
+    props.displayLegend = false;
+
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId('CheckboxListFilterLegend')).not.toBeVisible();
+  });
+
+  it('checks the checked checkbox', () => {
+    props.checked = ['article'];
+
+    const { getAllByRole } = renderComponent();
+
+    const checkboxes = getAllByRole('checkbox');
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it('displays the legend', () => {
+    props.label = 'The legend label';
+    props.displayLegend = true;
+
+    const { getByText } = renderComponent();
+
+    const legend = getByText('The legend label');
+
+    expect(legend).toBeVisible();
+    expect(legend).toHaveStyle('display: table;');
+  });
+
+  it('displays the hint text', () => {
+    props.hint = 'The hint text';
+
+    const { getByText } = renderComponent();
+
+    const hintText = getByText('The hint text');
+
+    expect(hintText).toBeVisible();
+    expect(hintText).toHaveStyle('display: block;');
+  });
+});

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.test.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.test.tsx
@@ -55,7 +55,9 @@ describe('CheckboxListFilter', () => {
     expect(legend).toHaveStyle('width: 1px;');
     expect(legend).toHaveStyle('height: 1px;');
 
-    expect(hint).not.toBeVisible();
+    // Hint should be Visually Hidden
+    expect(hint).toHaveStyle('width: 1px;');
+    expect(hint).toHaveStyle('height: 1px;');
   });
 
   it('hides the ledgend when label is set', () => {
@@ -96,6 +98,7 @@ describe('CheckboxListFilter', () => {
 
   it('displays the hint text', () => {
     props.hint = 'The hint text';
+    props.hintId = 'my-custom-hint-id';
 
     const { getByText } = renderComponent();
 
@@ -103,5 +106,6 @@ describe('CheckboxListFilter', () => {
 
     expect(hintText).toBeVisible();
     expect(hintText).toHaveStyle('display: block;');
+    expect(hintText).toHaveAttribute('id', 'my-custom-hint-id');
   });
 });

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.test.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.test.tsx
@@ -51,7 +51,10 @@ describe('CheckboxListFilter', () => {
     expect(checkboxes[1]).toHaveAttribute('value', 'press-release');
     expect(checkboxes[1]).not.toBeChecked();
 
-    expect(legend).not.toBeVisible();
+    // Legend should be Visually Hidden
+    expect(legend).toHaveStyle('width: 1px;');
+    expect(legend).toHaveStyle('height: 1px;');
+
     expect(hint).not.toBeVisible();
   });
 
@@ -60,8 +63,11 @@ describe('CheckboxListFilter', () => {
     props.displayLegend = false;
 
     const { getByTestId } = renderComponent();
+    const legend = getByTestId('CheckboxListFilterLegend');
 
-    expect(getByTestId('CheckboxListFilterLegend')).not.toBeVisible();
+    // Legend should be Visually Hidden
+    expect(legend).toHaveStyle('width: 1px;');
+    expect(legend).toHaveStyle('height: 1px;');
   });
 
   it('checks the checked checkbox', () => {
@@ -83,7 +89,8 @@ describe('CheckboxListFilter', () => {
 
     const legend = getByText('The legend label');
 
-    expect(legend).toBeVisible();
+    expect(legend).not.toHaveStyle('width: 1px;');
+    expect(legend).not.toHaveStyle('height: 1px;');
     expect(legend).toHaveStyle('display: table;');
   });
 

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
@@ -7,7 +7,7 @@ import { handleParams } from './../../helpers/url-helpers';
 const CheckboxListFilter: React.FunctionComponent<CheckboxListFilterProps> = ({
   options,
   checked,
-  label,
+  label = null,
   hint = null,
   displayLegend,
 }) => {
@@ -44,8 +44,10 @@ const CheckboxListFilter: React.FunctionComponent<CheckboxListFilterProps> = ({
   return (
     <Styles.Container data-testid="CheckboxListFilter">
       <Styles.Fieldset aria-describedby="waste-hint">
-        <Styles.Legend labelHidden={labelHidden}>{label}</Styles.Legend>
-        <Styles.Hint id="waste-hint" hintHidden={hintHidden}>
+        <Styles.Legend labelHidden={labelHidden} data-testid="CheckboxListFilterLegend">
+          {label}
+        </Styles.Legend>
+        <Styles.Hint id="waste-hint" hintHidden={hintHidden} data-testid="CheckboxListFilterHint">
           {hint}
         </Styles.Hint>
         <Styles.Checkboxes>

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.tsx
@@ -10,6 +10,7 @@ const CheckboxListFilter: React.FunctionComponent<CheckboxListFilterProps> = ({
   label = null,
   hint = null,
   displayLegend,
+  hintId = 'hint',
 }) => {
   let labelHidden = label === null || !displayLegend ? true : false;
   let hintHidden = hint === null ? true : false;
@@ -43,11 +44,11 @@ const CheckboxListFilter: React.FunctionComponent<CheckboxListFilterProps> = ({
   const backupLabel = Math.random().toString(36).substring(7);
   return (
     <Styles.Container data-testid="CheckboxListFilter">
-      <Styles.Fieldset aria-describedby="waste-hint">
+      <Styles.Fieldset aria-describedby={hintId}>
         <Styles.Legend labelHidden={labelHidden} data-testid="CheckboxListFilterLegend">
           {label}
         </Styles.Legend>
-        <Styles.Hint id="waste-hint" hintHidden={hintHidden} data-testid="CheckboxListFilterHint">
+        <Styles.Hint id={hintId} hintHidden={hintHidden} data-testid="CheckboxListFilterHint">
           {hint}
         </Styles.Hint>
         <Styles.Checkboxes>

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.types.ts
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.types.ts
@@ -12,12 +12,12 @@ export interface CheckboxListFilterProps {
   /**
    * The label text
    */
-  label: string;
+  label: string | null;
 
   /**
    * The hint text
    */
-  hint: string;
+  hint: string | null;
 
   /**
    * Should the legend be displayed

--- a/src/library/components/CheckboxListFilter/CheckboxListFilter.types.ts
+++ b/src/library/components/CheckboxListFilter/CheckboxListFilter.types.ts
@@ -20,6 +20,11 @@ export interface CheckboxListFilterProps {
   hint: string | null;
 
   /**
+   * The id for the hint aria-describedby
+   */
+  hintId?: string;
+
+  /**
    * Should the legend be displayed
    */
   displayLegend: boolean;


### PR DESCRIPTION
The label and hint were set to 'string' type and the code checked if they were null to set whether they should be hidden. 

- I updated the types to allow null and then updated the styles to use `display: none;` instead of visually hidden. 
- Added a test to check that they are hidden when they are supposed to be. 
- Added testid to hint and legend as I wasn't sure how to find them with tests when they have no text content.
- Updated story to show label and hint, then added a new story to show them hidden