### PR TITLE
Fix promoted links alignment on mobile

### DIFF
--- a/src/library/components/PromotedLinks/PromotedLinks.stories.tsx
+++ b/src/library/components/PromotedLinks/PromotedLinks.stories.tsx
@@ -1,51 +1,53 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import PromotedLinks from "./PromotedLinks";
-import { PromotedLinksProps } from "./PromotedLinks.types";
+import PromotedLinks from './PromotedLinks';
+import { PromotedLinksProps } from './PromotedLinks.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 
 export default {
-    title: 'Library/Structure/Promoted Links',
-    component: PromotedLinks
+  title: 'Library/Components/Promoted Links',
+  component: PromotedLinks,
 };
 
-const Template: Story<PromotedLinksProps> = (args) => <SBPadding><PromotedLinks {...args} /></SBPadding>;
+const Template: Story<PromotedLinksProps> = (args) => (
+  <SBPadding>
+    <PromotedLinks {...args} />
+  </SBPadding>
+);
 
-export const ExamplePromotedLinks = Template.bind({});    
+export const ExamplePromotedLinks = Template.bind({});
 ExamplePromotedLinks.args = {
   promotedLinksArray: [
     {
-        title: "Make a payment",
-        url: "/"
+      title: 'Make a payment',
+      url: '/',
     },
     {
-        title: "Contact the council",
-        url: "/"
+      title: 'Contact the council',
+      url: '/',
     },
     {
-        title: "About our new website",
-        url: "/"
-    }
-]
+      title: 'About our new website',
+      url: '/',
+    },
+  ],
 };
 
-
-export const ExamplePromotedLinksOneCol = Template.bind({});    
+export const ExamplePromotedLinksOneCol = Template.bind({});
 ExamplePromotedLinksOneCol.args = {
   promotedLinksArray: [
     {
-        title: "Make a payment",
-        url: "/"
+      title: 'Make a payment',
+      url: '/',
     },
     {
-        title: "Contact the council",
-        url: "/"
+      title: 'Contact the council',
+      url: '/',
     },
     {
-        title: "About our new website",
-        url: "/"
-    }
-],
-oneCol: true
+      title: 'About our new website',
+      url: '/',
+    },
+  ],
+  oneCol: true,
 };

--- a/src/library/components/PromotedLinks/PromotedLinks.styles.js
+++ b/src/library/components/PromotedLinks/PromotedLinks.styles.js
@@ -43,7 +43,7 @@ export const PromotedLink = styled.a`
     0px 4px 15px rgba(0, 0, 0, 0.11);
 
   padding: 20px 15px;
-  width: calc(100% - 30px);
+  width: 100%;
   margin-bottom: 15px;
 
   span {


### PR DESCRIPTION
The promoted links were not full screen on mobile. This PR sets the width to 100% which is now ok with the box-sizing having been set in global styles. 

![image](https://user-images.githubusercontent.com/4160546/188832288-d929eb58-e362-411e-9b4b-e2a05aa47a50.png)

## Testing
- Checkout this branch and `npm run dev`
- Test the Homepage preview in different device resolutions and the promoted links should now be full width