### PR TITLE
Add trailing slash to instagram urls

### DIFF
--- a/src/themes/theme_london_bridge_north.jsx
+++ b/src/themes/theme_london_bridge_north.jsx
@@ -17,7 +17,7 @@ export const lb_vars_north = {
   twitter_link: 'https://twitter.com/NNorthantsC',
   linkedin_link: 'https://www.linkedin.com/company/north-northamptonshire-council',
   facebook_link: 'https://www.facebook.com/NorthNorthants',
-  instagram_link: 'https://www.instagram.com/northnorthantscouncil',
+  instagram_link: 'https://www.instagram.com/northnorthantscouncil/',
   youtube_link: 'https://www.youtube.com/channel/UCnng5JhKCm4lUbvuzZM07sA',
 
   breakpointsVals: {

--- a/src/themes/theme_london_bridge_west.jsx
+++ b/src/themes/theme_london_bridge_west.jsx
@@ -17,7 +17,7 @@ export const lb_vars_west = {
   twitter_link: 'https://twitter.com/WestNorthants',
   linkedin_link: 'https://www.linkedin.com/company/west-northamptonshire-council',
   facebook_link: 'https://www.facebook.com/WestNorthants',
-  instagram_link: 'https://www.instagram.com/westnorthants',
+  instagram_link: 'https://www.instagram.com/westnorthants/',
   youtube_link: 'https://www.youtube.com/channel/UCDyc2cNcl19OvcGOCuZDTBQ',
 
   breakpointsVals: {

--- a/src/themes/theme_north.jsx
+++ b/src/themes/theme_north.jsx
@@ -17,7 +17,7 @@ export const north_vars = {
   twitter_link: 'https://twitter.com/NNorthantsC',
   linkedin_link: 'https://www.linkedin.com/company/north-northamptonshire-council',
   facebook_link: 'https://www.facebook.com/NorthNorthants',
-  instagram_link: 'https://www.instagram.com/northnorthantscouncil',
+  instagram_link: 'https://www.instagram.com/northnorthantscouncil/',
   youtube_link: 'https://www.youtube.com/channel/UCnng5JhKCm4lUbvuzZM07sA',
 
   breakpointsVals: {

--- a/src/themes/theme_west.jsx
+++ b/src/themes/theme_west.jsx
@@ -17,7 +17,7 @@ export const west_vars = {
   twitter_link: 'https://twitter.com/WestNorthants',
   linkedin_link: 'https://www.linkedin.com/company/west-northamptonshire-council',
   facebook_link: 'https://www.facebook.com/WestNorthants',
-  instagram_link: 'https://www.instagram.com/westnorthants',
+  instagram_link: 'https://www.instagram.com/westnorthants/',
   youtube_link: 'https://www.youtube.com/channel/UCDyc2cNcl19OvcGOCuZDTBQ',
 
   breakpointsVals: {


### PR DESCRIPTION
Prevent sitemorse detecting the links as redirects, as instagram redirects to the address with a trailing slash. 