### PR TITLE
Add search box slice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import GoogleMap from './library/slices/GoogleMap/GoogleMap';
 import Image from './library/slices/Image/Image';
 import ImageAndText from './library/slices/ImageAndText/ImageAndText';
 import Promotions from './library/slices/Promotions/Promotions';
+import SearchBox from './library/slices/SearchBox/SearchBox';
 import Video from './library/slices/Video/Video';
 import WarningText from './library/slices/WarningText/WarningText';
 import WarningTextDisclaimer from './library/slices/WarningTextDisclaimer/WarningTextDisclaimer';
@@ -51,6 +52,7 @@ export {
   Image,
   ImageAndText,
   Promotions,
+  SearchBox,
   Video,
   WarningText,
   WarningTextDisclaimer,

--- a/src/library/components/Input/Input.tsx
+++ b/src/library/components/Input/Input.tsx
@@ -12,6 +12,7 @@ const Input: React.FC<InputProps> = ({
   errorText,
   name,
   maxLength,
+  id,
 }) => {
   return (
     <>
@@ -22,6 +23,7 @@ const Input: React.FC<InputProps> = ({
         name={name}
         isErrored={isErrored}
         maxLength={maxLength}
+        id={id}
       />
     </>
   );

--- a/src/library/components/Input/Input.types.ts
+++ b/src/library/components/Input/Input.types.ts
@@ -28,4 +28,9 @@ export interface InputProps {
    * The max length attribute
    */
   maxLength?: number;
+
+  /**
+   * The optional input id
+   */
+  id?: string;
 }

--- a/src/library/pages/ContentPage/ContentPage.tsx
+++ b/src/library/pages/ContentPage/ContentPage.tsx
@@ -17,6 +17,7 @@ import Image from '../../slices/Image/Image';
 import ImageAndText from '../../slices/ImageAndText/ImageAndText';
 import { ImageWithCaption } from '../../slices/Image/Image.storydata';
 import { ImageAndTextWithHeading } from '../../slices/ImageAndText/ImageAndText.storydata';
+import SearchBox from '../../slices/SearchBox/SearchBox';
 
 export interface ContentPageProps {}
 
@@ -250,6 +251,13 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
         <Heading level={2} text="Full Width Image" />
         <Image {...ImageWithCaption} />
         <ImageAndText {...ImageAndTextWithHeading} />
+        <SearchBox
+          fieldName="keyword"
+          label="Search for courses"
+          method="get"
+          path="https://courses.northantsglobal.net/CourseKeySearch.asp"
+          searchText="Search courses"
+        />
         <WarningTextDisclaimer />
       </PageStructures.PageMain>
     </PageStructures.MaxWidthContainer>

--- a/src/library/slices/SearchBox/SearchBox.stories.tsx
+++ b/src/library/slices/SearchBox/SearchBox.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Story } from '@storybook/react/types-6-0';
+import SearchBox from './SearchBox';
+import { SearchBoxProps } from './SearchBox.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
+
+export default {
+  title: 'Library/Slices/SearchBox',
+  component: SearchBox,
+  parameters: {
+    status: {
+      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+    },
+  },
+};
+
+const Template: Story<SearchBoxProps> = (args) => (
+  <SBPadding>
+    <SearchBox {...args} />
+  </SBPadding>
+);
+
+export const ExampleSearchBox = Template.bind({});
+ExampleSearchBox.args = {
+  path: 'https://courses.northantsglobal.net/CourseKeySearch.asp',
+  method: 'post',
+  fieldName: 'keyword',
+  searchText: 'Search courses',
+  placeholder: 'Search courses',
+  label: 'Search courses',
+  labelHidden: true,
+};
+
+export const ExampleSearchBoxWithLabel = Template.bind({});
+ExampleSearchBoxWithLabel.args = {
+  path: 'https://courses.northantsglobal.net/CourseKeySearch.asp',
+  method: 'post',
+  fieldName: 'keyword',
+  searchText: 'Search',
+  placeholder: 'Enter search term',
+  label: 'Search courses',
+  labelHidden: false,
+};

--- a/src/library/slices/SearchBox/SearchBox.styles.js
+++ b/src/library/slices/SearchBox/SearchBox.styles.js
@@ -1,0 +1,80 @@
+import styled from 'styled-components';
+import { VisuallyHidden } from './../../helpers/style-helpers';
+
+export const Container = styled.div`
+  background-color: ${(props) =>
+    props.theme.cardinal_name === 'west'
+      ? props.theme.theme_vars.colours.grey_light + '7a'
+      : props.theme.theme_vars.colours.white};
+  box-shadow: 1px 1px 5px 1px rgba(0, 0, 0, 0.2);
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.large};
+  border-radius: ${(props) => props.theme.theme_vars.border_radius};
+  margin: ${(props) => props.theme.theme_vars.spacingSizes.medium} 0;
+  ${(props) => props.theme.fontStyles}
+
+  input[type="text"] {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    flex-grow: 1;
+    margin-bottom: 0;
+  }
+`;
+
+const hideLabel = (props) => {
+  if (props.labelHidden) {
+    return VisuallyHidden;
+  }
+};
+
+export const Label = styled.label`
+  font-weight: bold;
+  ${hideLabel}
+`;
+
+export const InputWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  width: 100%;
+`;
+
+export const Button = styled.input`
+  flex-grow: 0;
+  cursor: pointer;
+  margin: 0;
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  background: ${(props) =>
+    props.isLight ? props.theme.theme_vars.colours.action : props.theme.theme_vars.colours.grey_darkest};
+  color: ${(props) => props.theme.theme_vars.colours.white};
+  border: 1px solid transparent;
+  border-top-right-radius: calc(${(props) => props.theme.theme_vars.border_radius} * 2);
+  border-bottom-right-radius: calc(${(props) => props.theme.theme_vars.border_radius} * 2);
+  text-align: center;
+  height: ${(props) => (props.isLarge ? '2.9rem' : '2.28rem')};
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    height: ${(props) => (props.isLarge ? '3.22rem' : '2.6rem')};
+  }
+
+  &:hover {
+    background: ${(props) =>
+      props.isLight ? props.theme.theme_vars.colours.action_dark : props.theme.theme_vars.colours.black};
+  }
+
+  &:focus {
+    outline: none;
+    background: ${(props) => props.theme.theme_vars.colours.focus};
+    svg {
+      path {
+        fill: ${(props) => props.theme.theme_vars.colours.black};
+      }
+    }
+  }
+
+  &:active {
+    transform: translateY(1px);
+    background-color: ${(props) => props.theme.theme_vars.colours.focus};
+    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black};
+    border-top-color: ${(props) => props.theme.theme_vars.colours.black};
+    border-bottom-color: transparent;
+  }
+`;

--- a/src/library/slices/SearchBox/SearchBox.test.tsx
+++ b/src/library/slices/SearchBox/SearchBox.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SearchBox from './SearchBox';
+import { SearchBoxProps } from './SearchBox.types';
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
+
+describe('SearchBox Component', () => {
+  let props: SearchBoxProps;
+
+  beforeEach(() => {
+    props = {
+      label: 'Search for courses label',
+      method: 'get',
+      fieldName: 'search_field',
+      path: '/test',
+      searchText: 'Search',
+      placeholder: 'Search for courses',
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <SearchBox {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render search box correctly', () => {
+    const { getByTestId, getByPlaceholderText, getByRole } = renderComponent();
+
+    const component = getByTestId('SearchBox');
+    const input = getByPlaceholderText('Search for courses');
+    const form = getByRole('form');
+
+    expect(component).toBeVisible();
+    expect(component).toHaveTextContent('Search for courses label');
+    expect(input).toHaveAttribute('name', 'search_field');
+
+    expect(form).toHaveAttribute('method', 'get');
+    expect(form).toHaveAttribute('action', '/test');
+  });
+});

--- a/src/library/slices/SearchBox/SearchBox.tsx
+++ b/src/library/slices/SearchBox/SearchBox.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { SearchBoxProps } from './SearchBox.types';
+import * as Styles from './SearchBox.styles';
+import Input from '../../components/Input/Input';
+import { uniqueID } from '../../helpers/helpers';
+
+const SearchBox: React.FC<SearchBoxProps> = ({
+  fieldName = 'search',
+  id = null,
+  label,
+  labelHidden = true,
+  method = 'post',
+  path,
+  placeholder,
+  searchText = 'Search',
+}) => {
+  if (id === null) {
+    id = uniqueID();
+  }
+
+  return (
+    <Styles.Container data-testid="SearchBox">
+      <form method={method} action={path} aria-label={label}>
+        <div role="search">
+          <Styles.Label htmlFor={id} labelHidden={labelHidden}>
+            {label}
+          </Styles.Label>
+          <Styles.InputWrapper>
+            <Input name={fieldName} placeholder={placeholder} id={id} />
+            <Styles.Button type="submit" value={searchText} />
+          </Styles.InputWrapper>
+        </div>
+      </form>
+    </Styles.Container>
+  );
+};
+
+export default SearchBox;

--- a/src/library/slices/SearchBox/SearchBox.types.ts
+++ b/src/library/slices/SearchBox/SearchBox.types.ts
@@ -1,0 +1,41 @@
+export interface SearchBoxProps {
+  /**
+   * Field name for search box
+   */
+  fieldName: string;
+
+  /**
+   * The search box id
+   */
+  id?: string;
+
+  /**
+   * The search box label
+   */
+  label: string;
+
+  /**
+   * Should the label be visible
+   */
+  labelHidden?: boolean;
+
+  /**
+   * Form submission method
+   */
+  method: 'get' | 'post';
+
+  /**
+   * Where to submit the form
+   */
+  path: string;
+
+  /**
+   * Optional placeholder text
+   */
+  placeholder?: string;
+
+  /**
+   * The search button text
+   */
+  searchText: string;
+}


### PR DESCRIPTION
Add a new slice for search box. This will initially be used for the search for [adult learning courses](https://www.northamptonshire.gov.uk/councilservices/children-families-education/adult-learning/Pages/default.aspx), but is fully customisable so can be used for other searches where needed. 

The placeholder, label, button text, form method and form action are all customisable. 

Also added optional ID to the input component so labels can be associated with the input component. 

