### PR TITLE
Hero image call to action secondary

### DIFF
--- a/src/library/slices/SearchBox/SearchBox.stories.tsx
+++ b/src/library/slices/SearchBox/SearchBox.stories.tsx
@@ -25,6 +25,9 @@ const Template: Story<SearchBoxProps> = (args) => (
 export const ExampleSearchBox = Template.bind({});
 ExampleSearchBox.args = ExampleSearchBoxProps;
 
+export const ExampleSearchBoxSecondaryLink = Template.bind({});
+ExampleSearchBoxSecondaryLink.args = { ...ExampleSearchBoxProps, searchBoxLinkIsPrimary: false };
+
 export const ExampleSearchBoxWithLabel = Template.bind({});
 ExampleSearchBoxWithLabel.args = {
   ...ExampleSearchBoxProps,

--- a/src/library/slices/SearchBox/SearchBox.test.tsx
+++ b/src/library/slices/SearchBox/SearchBox.test.tsx
@@ -41,4 +41,14 @@ describe('SearchBox Component', () => {
 
     expect(heading).toHaveTextContent('Search adult learning courses');
   });
+
+  it('should render the search box link as secondary button', () => {
+    props.searchBoxLinkIsPrimary = false;
+
+    const { getByRole } = renderComponent();
+
+    const link = getByRole('link');
+
+    expect(link).toHaveStyle('background-color: transparent;');
+  });
 });

--- a/src/library/slices/SearchBox/SearchBox.tsx
+++ b/src/library/slices/SearchBox/SearchBox.tsx
@@ -14,6 +14,7 @@ const SearchBox: React.FunctionComponent<SearchBoxProps> = ({
   imageLarge,
   imageAltText,
   searchBoxLink,
+  searchBoxLinkIsPrimary = true,
   title,
 }) => {
   const searchInner = (
@@ -30,7 +31,7 @@ const SearchBox: React.FunctionComponent<SearchBoxProps> = ({
         {searchBoxLink && (
           <Column small="full" medium="full" large="one-third">
             <Styles.LinkContainer>
-              <Button text={searchBoxLink.title} url={searchBoxLink.url} />
+              <Button text={searchBoxLink.title} url={searchBoxLink.url} primary={searchBoxLinkIsPrimary} />
             </Styles.LinkContainer>
           </Column>
         )}

--- a/src/library/slices/SearchBox/SearchBox.types.ts
+++ b/src/library/slices/SearchBox/SearchBox.types.ts
@@ -27,6 +27,11 @@ export interface SearchBoxProps {
   searchBoxLink?: SearchBoxLinkProps | null;
 
   /**
+   * Is the search box link primary (true) or secondary (false)
+   */
+  searchBoxLinkIsPrimary?: boolean;
+
+  /**
    * Optional title
    */
   title?: string | null;

--- a/src/library/structure/HeroImage/HeroImage.storydata.ts
+++ b/src/library/structure/HeroImage/HeroImage.storydata.ts
@@ -52,5 +52,6 @@ export const HeroImageExampleBoxedWithCustomSearch: HeroImageProps = {
   content: '<p>Search our catalogue of adult learning courses.</p>',
   callToActionText: 'View all courses',
   callToActionURL: 'https://courses.northantsglobal.net/AvailableCoursesList.asp',
+  callToActionIsPrimary: false,
   customSearch: ExampleCustomSearchProps,
 };

--- a/src/library/structure/HeroImage/HeroImage.test.tsx
+++ b/src/library/structure/HeroImage/HeroImage.test.tsx
@@ -176,9 +176,12 @@ it('should render the custom search box', () => {
 
   const input = getByPlaceholderText('Search courses');
   const form = getByRole('form');
+  const link = getByRole('link');
 
   expect(input).toBeVisible();
 
   expect(form).toHaveAttribute('method', 'post');
   expect(form).toHaveAttribute('action', 'https://courses.northantsglobal.net/CourseKeySearch.asp');
+
+  expect(link).toHaveStyle('background-color: transparent;');
 });

--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -15,6 +15,7 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
   content,
   callToActionText,
   callToActionURL,
+  callToActionIsPrimary = true,
   backgroundBox = true,
   imageLarge,
   imageSmall,
@@ -47,7 +48,9 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
                     <CustomSearch {...customSearch} />
                   </Styles.Search>
                 )}
-                {callToActionURL && backgroundBox && <CallToAction url={callToActionURL} text={callToActionText} />}
+                {callToActionURL && backgroundBox && (
+                  <CallToAction url={callToActionURL} text={callToActionText} primary={callToActionIsPrimary} />
+                )}
                 {!callToActionURL && backgroundBox && <br />}
                 {callToActionURL && !backgroundBox && (
                   <Styles.CallToActionLink href={callToActionURL}>

--- a/src/library/structure/HeroImage/HeroImage.types.ts
+++ b/src/library/structure/HeroImage/HeroImage.types.ts
@@ -38,6 +38,11 @@ export interface HeroImageProps {
   callToActionURL?: string;
 
   /**
+   * Is the call to action a primary button
+   */
+  callToActionIsPrimary?: boolean;
+
+  /**
    * Set to true to put the text and call to action on a white box, false to overlay on a darkened image
    */
   backgroundBox: boolean;


### PR DESCRIPTION
Allow the call to action in HeroImage and the link in SearchBox to be marked as secondary. This will show the differentiation between the priority action (searching) and the secondary action (clicking the link). 

The default is set to true for primary as to not effect current usage of the HeroImage. 