### PR TITLE
Update Page examples with heading before service alert

### DIFF
--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.stories.tsx
@@ -60,6 +60,17 @@ TopServicesExample.args = {
   topServices: threeTopServicesData,
 };
 
+export const TopServicesWithAlert = Template.bind({});
+TopServicesWithAlert.args = {
+  title: 'Bin collection, recycling and waste',
+  icon: 'bins',
+  breadcrumbsArray: breadcrumbs,
+  sections: sections.slice(0, 1),
+  footerLinks,
+  topServices: threeTopServicesData,
+  serviceAlert,
+};
+
 export const SixTopServicesExample = Template.bind({});
 SixTopServicesExample.args = {
   title: 'Bin collection, recycling and waste',

--- a/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
+++ b/src/library/pages/ServiceLandingPageExample/ServiceLandingPageExample.tsx
@@ -46,13 +46,14 @@ export const ServiceLandingPageExample: React.FunctionComponent<ServiceLandingPa
     ) : (
       <PageStructures.MaxWidthContainer noPadding>
         <PageStructures.Breadcrumbs breadcrumbsArray={breadcrumbsArray} hasMargin />
+
+        <Heading text={title} level={1} />
+
         {serviceAlert?.alertType && (
           <PageStructures.AlertBannerService {...serviceAlert}>
             {serviceAlert.children}
           </PageStructures.AlertBannerService>
         )}
-
-        {icon ? <HeadingWithIcon icon={icon} level={1} text={title} /> : <Heading text={title} />}
       </PageStructures.MaxWidthContainer>
     )}
 

--- a/src/library/pages/ServicePageExample/ServicePageExample.stories.tsx
+++ b/src/library/pages/ServicePageExample/ServicePageExample.stories.tsx
@@ -25,3 +25,12 @@ ServicePageWithContents.args = {
     contents: ContentsExampleData,
   },
 };
+
+export const ServicePageWithContentsAndAlert = Template.bind({});
+ServicePageWithContentsAndAlert.args = {
+  contents: {
+    currentPath: '/second-page',
+    contents: ContentsExampleData,
+  },
+  showServiceAlert: true,
+};

--- a/src/library/pages/ServicePageExample/ServicePageExample.tsx
+++ b/src/library/pages/ServicePageExample/ServicePageExample.tsx
@@ -37,6 +37,8 @@ export const ServicePageExample: React.FunctionComponent<ServicePageExampleProps
         ]}
       />
       <PageStructures.PageMain>
+        <Heading level={1} text="A fourth level basic page" />
+
         {showServiceAlert && (
           <AlertBannerService title="Example Service Alert" alertType="alert">
             <p>
@@ -45,8 +47,6 @@ export const ServicePageExample: React.FunctionComponent<ServicePageExampleProps
             </p>
           </AlertBannerService>
         )}
-
-        <Heading level={1} text="A fourth level basic page" />
 
         {contents && <Contents {...contents} />}
 


### PR DESCRIPTION
For correct content flow, the H1 should be before H2 tag in the service alert. This PR is for demonstration purposes only and the same changes will need to be made again in the frontend website. 

This also adds a couple of additional stories to demonstrate how the pages could look with alerts in different situations. 