### PR TITLE
Fix sitewide alert error in react 18

### DIFF
--- a/src/library/structure/AlertBanner/AlertBanner.tsx
+++ b/src/library/structure/AlertBanner/AlertBanner.tsx
@@ -13,9 +13,15 @@ const AlertBanner: React.FunctionComponent<AlertBannerProps> = ({ uid, title, al
   const themeContext = useContext(ThemeContext);
   const elementRef = useRef(null);
   const [showAlert, setShowAlert] = useLocalStorage('alert_' + uid, true);
+  const [notServer, setNotServer] = useState(false);
   useEffect(() => {
     elementRef?.current?.addEventListener('click', embeddedLinkCLickHandler);
   }, [elementRef]);
+
+  /* Stop flash of banner on page load when previously dismissed */
+  useEffect(() => {
+    setNotServer(true);
+  }, []);
 
   /* A click on any link within the alert text dismisses the banner too */
   const embeddedLinkCLickHandler = (event) => {
@@ -26,9 +32,6 @@ const AlertBanner: React.FunctionComponent<AlertBannerProps> = ({ uid, title, al
   const hideClickHandler = () => {
     setShowAlert(false);
   };
-
-  /* Stop flash of banner on page load when previously dismissed */
-  const notServer = typeof window !== 'undefined';
 
   return (
     showAlert &&


### PR DESCRIPTION
An error is triggered in development (and a warning in production) when sitewide alert is enabled. This PR uses useEffect to ensure the browser is loaded instead of checking for the typeof window. 

```
Unhandled Runtime Error
Error: Hydration failed because the initial UI does not match what was rendered on the server.

See more info here: https://nextjs.org/docs/messages/react-hydration-error
```

## Testing
- Enable a sitewide alert in the backend
- Use preprod_frontend and `yarn dev`, visit the site and the warning should be displayed
- Checkout this branch and run `yalc publish`
- In the frontend run `yalc add northants-design-system && yarn install && yarn dev` 
- Refresh the page and the error should now be gone. 
- Test dismissing the sitewide alert and refreshing the page and that the sitewide alert still works as expected.