### PR TITLE
Resolve video slice server side render hydration error

### DIFF
--- a/src/library/slices/Video/Video.tsx
+++ b/src/library/slices/Video/Video.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { VideoProps, VideoProvider } from './Video.types';
 import * as Styles from './Video.styles';
 import { wereCookiesAccepted } from './../../helpers/cookies';
@@ -8,6 +8,7 @@ import { wereCookiesAccepted } from './../../helpers/cookies';
  */
 const Video: React.FunctionComponent<VideoProps> = ({ video_id, provider, description, allowCookies, ...props }) => {
   const cookiesAccepted: boolean = wereCookiesAccepted(allowCookies);
+  const [notServer, setNotServer] = useState(false);
   let watchLink: string;
   let embedLink: string;
 
@@ -25,9 +26,13 @@ const Video: React.FunctionComponent<VideoProps> = ({ video_id, provider, descri
 
   defineLinks();
 
+  useEffect(() => {
+    setNotServer(true);
+  }, []);
+
   return (
     <>
-      {cookiesAccepted && (
+      {cookiesAccepted && notServer ? (
         <Styles.VideoContainer data-testid="Video">
           <iframe
             src={embedLink}
@@ -36,8 +41,7 @@ const Video: React.FunctionComponent<VideoProps> = ({ video_id, provider, descri
             data-testid="VideoIframe"
           ></iframe>
         </Styles.VideoContainer>
-      )}
-      {!cookiesAccepted && (
+      ) : (
         <Styles.VideoLink href={watchLink} title={description} data-testid="VideoLink">
           {description}
         </Styles.VideoLink>


### PR DESCRIPTION
Whilst testing something else, I noticed that video slices were causing a hydration error due to the content changing between server side render and client side render. This PR uses useEffect to rerender the content on the client side as it needs access to local storage for the cookies check. 

## Testing 
- Edit a page in the CMS and add a Video slice
- Using preprod_frontend branch, run `yarn dev` and see a hydration error message
- Checkout this branch and run `yalc publish`
- In the frontend run `yalc add northants-design-system` and then `yarn install && yarn dev`
- Visit the same page with the video and the hydration warning should now be gone