### PR TITLE
Make file download title paragraph tag

### DIFF
--- a/src/library/components/FileDownload/FileDownload.stories.tsx
+++ b/src/library/components/FileDownload/FileDownload.stories.tsx
@@ -3,6 +3,8 @@ import { Story } from '@storybook/react/types-6-0';
 import FileDownload from './FileDownload';
 import { FileDownloadProps } from './FileDownload.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
+import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
+import PageMain from '../../structure/PageMain/PageMain';
 
 export default {
   title: 'Library/Components/File download',
@@ -16,7 +18,11 @@ export default {
 
 const Template: Story<FileDownloadProps> = (args) => (
   <SBPadding>
-    <FileDownload {...args} />
+    <MaxWidthContainer>
+      <PageMain>
+        <FileDownload {...args} />
+      </PageMain>
+    </MaxWidthContainer>
   </SBPadding>
 );
 

--- a/src/library/components/FileDownload/FileDownload.styles.js
+++ b/src/library/components/FileDownload/FileDownload.styles.js
@@ -65,10 +65,11 @@ export const FileDetails = styled.div`
   max-width: calc(100% - 45px);
   transition: transform 0.3s;
 `;
-export const Title = styled.span`
+export const Title = styled.p`
   display: block;
   color: ${(props) => props.theme.theme_vars.colours.action};
   font-weight: 700;
+  margin-bottom: 0 !important;
 `;
 export const Type = styled.span`
   color: ${(props) => props.theme.theme_vars.colours.black};


### PR DESCRIPTION
Fixes #334 

Making the title a paragraph tag should mean that screen readers see the file title as a separate piece of content to the file type. 

## Testing
- Checkout this branch and run `npm run dev` testing the FileDownload looks as expected
- Run `yalc publish` and then in the frontend `yalc add northants-design-system` then `yarn install` and `yarn dev`
- Visit a page with file downloads and check that it all appears the same as before, but the title should now be in a paragraph tag. 