### PR TITLE
Update Council Tax directory slice to use bandings

### DIFF
--- a/src/library/pages/CouncilTaxParishPageExample/CouncilTaxParishPageExample.tsx
+++ b/src/library/pages/CouncilTaxParishPageExample/CouncilTaxParishPageExample.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import * as PageStructures from '../../structure/PageStructures';
 import Heading from '../../components/Heading/Heading';
-
-import AlphabeticalDirectory from '../../components/AlphabeticalDirectory/AlphabeticalDirectory';
-
 import CouncilTaxAlphabeticalDirectory from '../../slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory';
-import { exampleParishes } from '../../slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.storydata';
+import { exampleBandings } from '../../slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.storydata';
+
 export interface CouncilTaxParishPageExampleProps {
   version: string;
 }
@@ -35,7 +33,7 @@ export const CouncilTaxParishPageExample: React.FC<CouncilTaxParishPageExamplePr
           <PageStructures.PageMain>
             <Heading level={1} text="2022/23 council tax charges by Parish" />
 
-            <CouncilTaxAlphabeticalDirectory financialYear="2022/23" parishes={exampleParishes} />
+            <CouncilTaxAlphabeticalDirectory financialYear="2022/23" parishes={exampleBandings} />
 
             <Heading level={2} text="Check a property's band" />
 

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.stories.tsx
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.stories.tsx
@@ -4,7 +4,7 @@ import CouncilTaxAlphabeticalDirectory from './CouncilTaxAlphabeticalDirectory';
 import { CouncilTaxAlphabeticalDirectoryProps } from './CouncilTaxAlphabeticalDirectory.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 import { MaxWidthContainer, PageMain } from '../../structure/PageStructures';
-import { exampleParishes } from './CouncilTaxAlphabeticalDirectory.storydata';
+import { exampleBandings } from './CouncilTaxAlphabeticalDirectory.storydata';
 
 export default {
   title: 'Library/Slices/Council Tax Alphabetical Directory',
@@ -29,5 +29,5 @@ const Template: Story<CouncilTaxAlphabeticalDirectoryProps> = (args) => (
 export const ExampleCouncilTaxAlphabeticalDirectory = Template.bind({});
 ExampleCouncilTaxAlphabeticalDirectory.args = {
   financialYear: '2022/23',
-  parishes: exampleParishes,
+  parishes: exampleBandings,
 };

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.storydata.ts
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.storydata.ts
@@ -1,4 +1,4 @@
-import { ParishAPIResponse, ParishBands } from './CouncilTaxAlphabeticalDirectory.types';
+import { BandingAPIResponse, ParishAPIResponse, ParishBands } from './CouncilTaxAlphabeticalDirectory.types';
 
 export const exampleBands: ParishBands = {
   a: '1319.87',
@@ -60,5 +60,32 @@ export const exampleParishes: ParishAPIResponse[] = [
     official_parish: 'Daventry CP',
     code: 'E04006799',
     unitary: 'West',
+  },
+];
+
+export const exampleBandings: BandingAPIResponse[] = [
+  {
+    parish: 'Abthorpe',
+    bands: exampleBands,
+  },
+  {
+    parish: 'Adstone',
+    bands: exampleBands,
+  },
+  {
+    parish: 'Alderton',
+    bands: exampleBands,
+  },
+  {
+    parish: 'Althorp',
+    bands: exampleBands,
+  },
+  {
+    parish: 'Arthingworth',
+    bands: exampleBands,
+  },
+  {
+    parish: 'Ashby Saint Ledgers',
+    bands: exampleBands,
   },
 ];

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.test.tsx
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.test.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import CouncilTaxAlphabeticalDirectory from './CouncilTaxAlphabeticalDirectory';
-import { CouncilTaxAlphabeticalDirectoryProps, ParishBands } from './CouncilTaxAlphabeticalDirectory.types';
-import { exampleParishes } from './CouncilTaxAlphabeticalDirectory.storydata';
+import { CouncilTaxAlphabeticalDirectoryProps } from './CouncilTaxAlphabeticalDirectory.types';
+import { exampleBandings } from './CouncilTaxAlphabeticalDirectory.storydata';
 import { west_theme } from '../../../themes/theme_generator';
 import { ThemeProvider } from 'styled-components';
 
 let props: CouncilTaxAlphabeticalDirectoryProps = {
   financialYear: '2022/23',
-  parishes: exampleParishes,
+  parishes: exampleBandings,
 };
 
 describe('Council Tax Alphabetical Directory', () => {
   beforeEach(() => {
     props = {
       financialYear: '2022/23',
-      parishes: exampleParishes,
+      parishes: exampleBandings,
     };
   });
 
@@ -44,7 +44,7 @@ describe('Council Tax Alphabetical Directory', () => {
 
     expect(component).toBeVisible();
     expect(component).toHaveTextContent('Abthorpe');
-    expect(component).toHaveTextContent('Brixworth');
+    expect(component).toHaveTextContent('Adstone');
   });
 
   it('should display the bands when the parish name is clicked, then hide when back is clicked', async () => {

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.tsx
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
+  BandingAPIResponse,
   CouncilTaxAlphabeticalDirectoryProps,
-  ParishAPIResponse,
   SortedData,
   SortedParish,
 } from './CouncilTaxAlphabeticalDirectory.types';
@@ -49,20 +49,20 @@ const CouncilTaxAlphabeticalDirectory: React.FunctionComponent<CouncilTaxAlphabe
    * @param data
    * @returns
    */
-  const formatParishData = (data: ParishAPIResponse[]) => {
+  const formatParishData = (data: BandingAPIResponse[]) => {
     const sortData = data.reduce((r, e) => {
       // get first letter of name of current element
-      let group = e.official_parish[0];
+      let group = e.parish[0];
 
       if (!r[group]) {
         // there is no property in accumulator with this letter so create it
         r[group] = {
           group,
-          children: [{ title: trimParishName(e.official_parish), values: e.bands }],
+          children: [{ title: trimParishName(e.parish), values: e.bands }],
         };
       } else {
         // push current element to children array for that letter
-        r[group].children.push({ title: trimParishName(e.official_parish), values: e.bands });
+        r[group].children.push({ title: trimParishName(e.parish), values: e.bands });
       }
 
       return r;

--- a/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.types.ts
+++ b/src/library/slices/CouncilTaxAlphabeticalDirectory/CouncilTaxAlphabeticalDirectory.types.ts
@@ -1,6 +1,6 @@
 export interface CouncilTaxAlphabeticalDirectoryProps {
   financialYear: string;
-  parishes: ParishAPIResponse[] | undefined;
+  parishes: BandingAPIResponse[] | undefined;
 }
 
 /**
@@ -75,4 +75,19 @@ export interface ParishAPIResponse {
    * The unitary council name, such as 'West' or 'North'
    */
   unitary: string;
+}
+
+/**
+ * The raw banding data from the API
+ */
+export interface BandingAPIResponse {
+  /**
+   * The parish name
+   */
+  parish: string;
+
+  /**
+   * An object of Parish Bands
+   */
+  bands: ParishBands;
 }


### PR DESCRIPTION
Fixes https://github.com/FutureNorthants/northants-website/issues/787

Update the Council Tax Directory slice to use the North/West Bandings API endpoints instead of the Parishes endpoints. The bandings endpoint has a different response type to the Parishes endpoint. 

I have left the Parishes types in the design system in case they are needed at a later date. 

## Testing
- Checkout this branch and run `npm run test`
- Run `npm run dev` to manually test the Council Tax Directory slice
- Check that the BandingAPIResponse interface matches the expected response from the live API endpoint. 