### PR TITLE
Fixes for Silktide Feb 2023 findings

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -45,7 +45,7 @@ export const globalTypes = {
     toolbar: {
       icon: 'circlehollow',
       items: ['north_theme', 'west_theme', 'lb_theme_north', 'lb_theme_west'],
-      showName: true,
+      title: 'Theme',
     },
   },
 };

--- a/src/library/components/CustomSearch/CustomSearch.stories.tsx
+++ b/src/library/components/CustomSearch/CustomSearch.stories.tsx
@@ -26,3 +26,6 @@ ExampleCustomSearch.args = ExampleCustomSearchProps;
 
 export const ExampleCustomSearchWithLabel = Template.bind({});
 ExampleCustomSearchWithLabel.args = { ...ExampleCustomSearchProps, hasHiddenLabel: false };
+
+export const ExampleCustomSearchWithId = Template.bind({});
+ExampleCustomSearchWithId.args = { ...ExampleCustomSearchProps, id: 'myCustomId' };

--- a/src/library/components/CustomSearch/CustomSearch.test.tsx
+++ b/src/library/components/CustomSearch/CustomSearch.test.tsx
@@ -33,4 +33,16 @@ describe('CustomSearch Component', () => {
     expect(form).toHaveAttribute('method', 'post');
     expect(form).toHaveAttribute('action', 'https://courses.northantsglobal.net/CourseKeySearch.asp');
   });
+
+  it('should render the custom ID correctly', () => {
+    props.id = 'aCustomId';
+
+    const { getByPlaceholderText, getByText } = renderComponent();
+
+    const input = getByPlaceholderText('Search courses');
+    expect(input).toHaveAttribute('id', 'aCustomId');
+
+    const label = getByText('Search for courses', { selector: 'label' });
+    expect(label).toHaveAttribute('for', 'aCustomId');
+  });
 });

--- a/src/library/components/CustomSearch/CustomSearch.tsx
+++ b/src/library/components/CustomSearch/CustomSearch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { CustomSearchProps } from './CustomSearch.types';
 import * as Styles from './CustomSearch.styles';
 import Input from '../Input/Input';
@@ -14,8 +14,8 @@ const CustomSearch: React.FunctionComponent<CustomSearchProps> = ({
   searchText,
   id,
 }) => {
-  if (id === null) {
-    id = uniqueID();
+  if (!id) {
+    id = useId();
   }
   return (
     <Styles.Container data-testid="CustomSearch">

--- a/src/library/components/DropDownSelect/DropDownSelect.styles.js
+++ b/src/library/components/DropDownSelect/DropDownSelect.styles.js
@@ -1,46 +1,45 @@
-import styled, {css} from "styled-components";
-import {VisuallyHidden} from '../../helpers/style-helpers'
+import styled, { css } from 'styled-components';
+import { VisuallyHidden } from '../../helpers/style-helpers';
 
-export const Container = styled.div`  
-  ${props => props.theme.fontStyles};
-`
+export const Container = styled.div`
+  ${(props) => props.theme.fontStyles};
+`;
 
-const hideLabel = props => {
-  if(props.hideLabel === true) {
+const hideLabel = (props) => {
+  if (props.hideLabel === true) {
     return VisuallyHidden;
   }
-}
-
+};
 
 export const Label = styled.label`
-    display: block;
-    margin-bottom: 5px;
-    ${hideLabel}
-`
+  display: block;
+  margin-bottom: 5px;
+  ${hideLabel}
+`;
 
 export const Select = styled.select`
-
-  ${props => props.theme.fontStyles};
-  border-radius: ${props => props.theme.theme_vars.border_radius};
+  ${(props) => props.theme.fontStyles};
+  border-radius: ${(props) => props.theme.theme_vars.border_radius};
   box-sizing: border-box;
   max-width: 100%;
   height: 40px;
   height: 2.5rem;
   padding: 5px;
-  border: 2px solid ${props => props.theme.theme_vars.colours.black};
+  border: 2px solid ${(props) => props.theme.theme_vars.colours.black};
 
   &:focus {
-    outline: none;
-    box-shadow: ${props => props.theme.theme_vars.colours.focus} 0 0 0 3px;
+    outline: 2px transparent solid;
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+      ${(props) => props.theme.theme_vars.colours.black} 0 0 0 4px;
     transition: box-shadow 0.3s ease 0s;
   }
-`
+`;
 
 export const Option = styled.option`
-  :active, :checked,:focus::-ms-value {
+  :active,
+  :checked,
+  :focus::-ms-value {
     color: #fff;
-    background-color: #1d70b8
+    background-color: #1d70b8;
   }
-
-`
-
+`;

--- a/src/library/components/TextInput/TextInput.styles.js
+++ b/src/library/components/TextInput/TextInput.styles.js
@@ -17,7 +17,8 @@ export const StyledTextInput = styled.input`
 
   &:focus {
     outline: none;
-    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+      ${(props) => props.theme.theme_vars.colours.black} 0 0 0 4px;
     transition: box-shadow 0.3s ease 0s;
   }
 

--- a/src/library/slices/Accordion/AccordionSection.tsx
+++ b/src/library/slices/Accordion/AccordionSection.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { AccordionSectionProps } from './Accordion.types';
 import * as Styles from './Accordion.styles';
-import { uniqueID } from './../../helpers/helpers';
 
 const AccordionSection: React.FunctionComponent<AccordionSectionProps> = ({
   title,
@@ -16,7 +15,7 @@ const AccordionSection: React.FunctionComponent<AccordionSectionProps> = ({
 }) => {
   const onSectionToggle = () =>
     isExpanded === true ? onToggle(accordionSectionId, false) : onToggle(accordionSectionId, true);
-  const thisSectionId = sectionId === false ? `accordion_section${uniqueID()}` : sectionId;
+  const thisSectionId = sectionId === false ? `accordion_section${useId()}` : sectionId;
   return (
     <Styles.Section id={thisSectionId} className={isExpanded && 'accordion__section--expanded'}>
       <Styles.SectionHeader onClick={onSectionToggle}>

--- a/src/library/structure/Footer/Footer.styles.js
+++ b/src/library/structure/Footer/Footer.styles.js
@@ -52,14 +52,27 @@ export const SocialLinkSingle = styled.a`
   }
   &:focus {
     outline: 2px transparent solid;
-    border-radius: 3px;
+    border-radius: 4px;
     box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
     transition: box-shadow 0.3s ease 0s;
+
+    svg {
+      path {
+        fill: ${(props) => props.theme.theme_vars.colours.focus} !important;
+      }
+    }
   }
   &:active {
     opacity: 1;
+    border-radius: 4px;
     box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
     transition: box-shadow 0.3s ease 0s;
+
+    svg {
+      path {
+        fill: ${(props) => props.theme.theme_vars.colours.focus} !important;
+      }
+    }
   }
 `;
 

--- a/src/library/structure/Footer/Footer.styles.js
+++ b/src/library/structure/Footer/Footer.styles.js
@@ -51,22 +51,15 @@ export const SocialLinkSingle = styled.a`
     opacity: 0.8;
   }
   &:focus {
-    outline: none;
-
-    svg {
-      path {
-        fill: ${(props) => props.theme.theme_vars.colours.focus} !important;
-      }
-    }
+    outline: 2px transparent solid;
+    border-radius: 3px;
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
+    transition: box-shadow 0.3s ease 0s;
   }
   &:active {
     opacity: 1;
-
-    svg {
-      path {
-        fill: ${(props) => props.theme.theme_vars.colours.focus} !important;
-      }
-    }
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
+    transition: box-shadow 0.3s ease 0s;
   }
 `;
 

--- a/src/library/structure/Header/Header.styles.js
+++ b/src/library/structure/Header/Header.styles.js
@@ -56,21 +56,23 @@ export const StyledMaxWidthContainer = styled(MaxWidthContainer)`
   }
 `;
 
-const LogoStyles = `
+const LogoStyles = () => {
+  return css`
     svg {
-        width: 240px;
-        height: auto;
-        vertical-align: middle;
+      width: 240px;
+      height: auto;
+      vertical-align: middle;
     }
     &.black_logo {
-        svg {
-            fill: black !important;
-            path {
-                fill: black !important;
-            }
+      svg {
+        fill: black !important;
+        path {
+          fill: black !important;
         }
+      }
     }
-`;
+  `;
+};
 
 export const LogoColoured = styled.div`
   ${LogoStyles}
@@ -95,8 +97,13 @@ export const HomeLink = styled.a`
     }
   }
   &:focus {
-    outline: none;
-    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
+    outline: 2px transparent solid;
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+      ${(props) =>
+          props.theme.cardinal_name === 'north'
+            ? props.theme.theme_vars.colours.black
+            : props.theme.theme_vars.colours.focus}
+        0 0 0 4px;
     transition: box-shadow 0.3s ease 0s;
   }
 `;

--- a/src/library/structure/SectionLinks/SectionLinks.styles.js
+++ b/src/library/structure/SectionLinks/SectionLinks.styles.js
@@ -43,16 +43,13 @@ export const Pagelink = styled.a`
     }
   }
   &:focus {
-    outline: none;
-    box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
-    -webkit-box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
-    -moz-box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
+    ${(props) => props.theme.linkStylesFocus}
   }
   &:active {
     transform: translate(3px);
-    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
-    -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
-    -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
+    box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
+    -webkit-box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
+    -moz-box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset !important;
   }
 `;
 
@@ -89,4 +86,4 @@ export const Image = styled.img`
   left: 0;
   width: 100%;
   height: 100%;
-'`;
+`;

--- a/src/themes/theme_generator.jsx
+++ b/src/themes/theme_generator.jsx
@@ -59,9 +59,9 @@ const generate_theme = (theme_vars) => {
       background: ${theme_vars.colours.focus};
       outline: none;
       text-decoration: none !important;
-      box-shadow: 0 -6px ${theme_vars.colours.focus}, 0 3px ${theme_vars.colours.black};
-      -webkit-box-shadow: 0 -6px ${theme_vars.colours.focus}, 0 3px ${theme_vars.colours.black};
-      -moz-box-shadow: 0 -6px ${theme_vars.colours.focus}, 0 3px ${theme_vars.colours.black};
+      box-shadow: 0 0 0 1px ${theme_vars.colours.focus}, 0 0 0 3px ${theme_vars.colours.black};
+      -webkit-box-shadow: 0 0 0 1px ${theme_vars.colours.focus}, 0 0 0 3px ${theme_vars.colours.black};
+      -moz-box-shadow: 0 0 0 1px ${theme_vars.colours.focus}, 0 0 0 3px ${theme_vars.colours.black};
     `,
     linkStylesActive: css`
       color: ${theme_vars.colours.black};


### PR DESCRIPTION
Silktide has reported some potential issues with the Custom Search component and the focus states not having high enough contrast for several components. This is part of the WCAG 2.2 guidelines which are scheduled to be released in April this year. 

The main change is to keep a 2px focus colour border (previously 3px), but then add a 2px black border around the focus border to provide greater contrast to the white background. The change has been applied to the default `linkStylesFocus` from the theme, then applied manually where needed elsewhere. 

This is difficult to test as the Axe Dev tools only test the current rules, but here is some additional guidance (currently in draft): https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum

Fixes #339 