### PR TITLE
Fix safari table bug

### DIFF
--- a/src/themes/GlobalStyleReset.jsx
+++ b/src/themes/GlobalStyleReset.jsx
@@ -151,4 +151,7 @@ export const GlobalStyleReset = createGlobalStyle`
   .table-container li {
     left: 0;
   }
+  table tr td {
+    vertical-align: top;
+  }
 `;


### PR DESCRIPTION
Fixes #351 

Set the `vertical-align: top` instead of `baseline`. 

## Testing
- On master, run `npm run dev` then visit the Content page example using Safari and scroll down to the "Example table with nested list" and see that the bottom borders don't line up as expected. 
- Checkout this branch and run `npm run dev` then visit the same page in Safari. The border should now align correctly. 
- Run `yalc publish` and then in the frontend run `yalc add northants-design-system` then `yarn install` then `yarn dev`
- Visit a page with a table, such as `/your-council/contact-us` in Safari and test that the table borders appear as they should. 
