### PR TITLE
Add missing scope to inquest schedule table

### DIFF
--- a/src/library/slices/InquestSchedule/InquestSchedule.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.tsx
@@ -12,13 +12,13 @@ const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAp
         <caption>{title}</caption>
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Age</th>
-            <th>Place of death</th>
-            <th>Date of death</th>
-            <th>Name of coroner</th>
-            <th>Location</th>
-            <th>Date and time</th>
+            <th scope="col">Name</th>
+            <th scope="col">Age</th>
+            <th scope="col">Place of death</th>
+            <th scope="col">Date of death</th>
+            <th scope="col">Name of coroner</th>
+            <th scope="col">Location</th>
+            <th scope="col">Date and time</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
The inquest schedule slice was missing `scope="col"` in all of the table headings. Learned something new. 

> The scope attribute specifies whether a header cell is a header for a column, row, or group of columns or rows.

https://www.w3schools.com/tags/att_th_scope.asp

## Testing
- Checkout this branch and run `npm run dev`
- Go to the Inquest Schedule slice and the all th should now have the correct scope