### PR TITLE
Add 4by1 banner image to image slice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14866,9 +14866,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
       "dev": true,
       "funding": [
         {
@@ -14878,6 +14878,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -45502,9 +45506,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
       "dev": true
     },
     "capture-exit": {

--- a/src/library/slices/Image/Image.stories.tsx
+++ b/src/library/slices/Image/Image.stories.tsx
@@ -78,3 +78,12 @@ StandardImageWithoutCaption.args = {
   imageAltText: 'Parkland',
   ratio: '4by3',
 };
+
+export const BannerImage = Template.bind({});
+BannerImage.args = {
+  imageLarge: 'https://via.placeholder.com/800x200?text=4+by+1+image',
+  imageSmall: 'https://via.placeholder.com/400x100',
+  imageAltText: 'Parkland',
+  ratio: '4by1',
+  caption: 'The caption helps describe the image',
+};

--- a/src/library/slices/Image/Image.styles.js
+++ b/src/library/slices/Image/Image.styles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.figure`
   display: block;
@@ -20,9 +20,30 @@ export const Container = styled.figure`
   }
 `;
 
+const imageRatio = (props) => {
+  switch (props.ratio) {
+    case '4by3':
+      return css`
+        padding-top: 75%;
+      `;
+    case '4by1':
+      return css`
+        padding-top: 25%;
+      `;
+    case '16by9':
+      return css`
+        padding-top: 56.25%;
+      `;
+    default:
+      return css`
+        padding-top: 56.25%;
+      `;
+  }
+};
+
 export const ImageContainer = styled.div`
   position: relative;
-  padding-top: ${(props) => (props.ratio === '4by3' ? '75%' : '56.25%')};
+  ${imageRatio}
 `;
 
 export const Image = styled.img`

--- a/src/library/slices/Image/Image.test.tsx
+++ b/src/library/slices/Image/Image.test.tsx
@@ -6,13 +6,17 @@ import { west_theme } from '../../../themes/theme_generator';
 import { ThemeProvider } from 'styled-components';
 
 describe('Image Component', () => {
-  const props: ImageProps = {
-    imageSmall: 'foo.jpg',
-    imageLarge: 'bar.jpg',
-    imageAltText: 'The image alt text',
-    ratio: '4by3',
-    caption: 'The caption for the image',
-  };
+  let props: ImageProps;
+
+  beforeEach(() => {
+    props = {
+      imageSmall: 'foo.jpg',
+      imageLarge: 'bar.jpg',
+      imageAltText: 'The image alt text',
+      ratio: '4by3',
+      caption: 'The caption for the image',
+    };
+  });
 
   const renderComponent = () =>
     render(
@@ -36,24 +40,11 @@ describe('Image Component', () => {
 
     expect(figure).toHaveTextContent('The caption for the image');
   });
-});
-
-describe('Image component with wide image and no caption', () => {
-  const props: ImageProps = {
-    imageSmall: 'bar.jpg',
-    imageLarge: 'baz.jpg',
-    imageAltText: 'The image alt text',
-    ratio: '16by9',
-  };
-
-  const renderComponent = () =>
-    render(
-      <ThemeProvider theme={west_theme}>
-        <Image {...props} />
-      </ThemeProvider>
-    );
 
   it('should display the wide image without caption', () => {
+    props.caption = null;
+    props.ratio = '16by9';
+
     const { getByRole, getByTestId } = renderComponent();
     const imageContainer = getByTestId('ImageContainer');
     const image = getByRole('img');
@@ -61,11 +52,23 @@ describe('Image component with wide image and no caption', () => {
 
     // Lazy image loads the placeholder image (bar.jpg)
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'bar.jpg');
+    expect(image).toHaveAttribute('src', 'foo.jpg');
     expect(image).toHaveAttribute('alt', 'The image alt text');
 
     expect(imageContainer).toHaveStyle('padding-top: 56.25%');
 
     expect(figure).not.toHaveTextContent;
+  });
+
+  it('should display the banner image', () => {
+    props.ratio = '4by1';
+
+    const { getByTestId, getByRole } = renderComponent();
+
+    const image = getByRole('img');
+    const imageContainer = getByTestId('ImageContainer');
+
+    expect(image).toBeVisible();
+    expect(imageContainer).toHaveStyle('padding-top: 25%');
   });
 });


### PR DESCRIPTION
- Add styling for 4by1 banner image
- Refactor styles to a switch case statement so future sizes can be added easily. Added a default just in case. 
- Refactor the tests to use beforeEach to reduce repetition
- Added test for new image size

## Testing
- Checkout this branch and run `npm run dev`, then visit the Image slice and see the new Banner Image story
- Run `npm run test` to run tests
- Run `yalc publish` then in the frontend run `yalc add northants-design-system && yarn`. Then run `yarn build && yarn start` to test it builds and runs correctly. 