### PR TITLE
Add a clear filter button to clear all options for the filter

### DIFF
--- a/src/library/components/RadioCheckboxInput/RadioCheckboxInput.tsx
+++ b/src/library/components/RadioCheckboxInput/RadioCheckboxInput.tsx
@@ -20,7 +20,7 @@ const RadioCheckboxInput: React.FunctionComponent<RadioCheckboxInputProps> = ({
           value={value}
           id={id}
           name={name}
-          onChange={onChange}
+          onClick={onChange}
           defaultChecked={checked}
         />
         <Styles.CategoryInputLabel isChecked={checked} htmlFor={id} singleSelection={singleSelection}>

--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.styles.js
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.styles.js
@@ -62,6 +62,34 @@ export const ResultInfo = styled.div`
   color: ${(props) => props.theme.theme_vars.colours.grey_dark};
 `;
 
+export const ClearFilter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: ${(props) => props.theme.theme_vars.spacingSizes.small};
+`;
+
+export const TextLink = styled.button`
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.extra_small};
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 0;
+  border-width: 0;
+  color: ${(props) => props.theme.theme_vars.colours.action};
+  background: none;
+  cursor: pointer;
+  &:hover {
+    ${(props) => props.theme.linkStylesHover};
+  }
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus};
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive};
+  }
+`;
+
 export const Fieldset = styled.fieldset`
   display: block;
   border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey};

--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.tsx
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.tsx
@@ -50,6 +50,19 @@ const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps>
     setCategories(newCategories);
   };
 
+  /**
+   * Uncheck all the options for a specific category
+   */
+  const clearCategory = (categoryIndex: number) => {
+    let newCategories = [...categories];
+
+    newCategories[categoryIndex].options.forEach((option) => {
+      option.checked = false;
+    });
+
+    setCategories(newCategories);
+  };
+
   const from = pageNumber * perPage - (perPage - 1);
   const to = from + (documents?.length ? documents.length - 1 : 0);
 
@@ -94,6 +107,10 @@ const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps>
               <Column small="full" medium="full" large="full" key={category.label}>
                 <Styles.Fieldset>
                   <Styles.Legend>{category.label}</Styles.Legend>
+
+                  <Styles.ClearFilter>
+                    <Styles.TextLink onClick={(e) => clearCategory(categoryIndex)}>Clear filter</Styles.TextLink>
+                  </Styles.ClearFilter>
 
                   {category.options.map((taxonomy) => (
                     <Styles.Category key={taxonomy.id}>

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Story } from '@storybook/react/types-6-0';
 import DirectoryServiceList from './DirectoryServiceList';
 import { DirectoryServiceListProps } from './DirectoryServiceList.types';
@@ -19,17 +19,20 @@ export default {
   },
 };
 
-const Template: Story<DirectoryServiceListProps> = (args) => (
-  <SBPadding>
-    <MaxWidthContainer>
-      <PageMain>
-        <DirectoryShortListProvider>
-          <DirectoryServiceList {...args} />
-        </DirectoryShortListProvider>
-      </PageMain>
-    </MaxWidthContainer>
-  </SBPadding>
-);
+const Template: Story<DirectoryServiceListProps> = (args) => {
+  const [categories, setCategories] = useState(ExampleDirectoryCategories);
+  return (
+    <SBPadding>
+      <MaxWidthContainer>
+        <PageMain>
+          <DirectoryShortListProvider>
+            <DirectoryServiceList {...args} categories={categories} setCategories={setCategories} />
+          </DirectoryShortListProvider>
+        </PageMain>
+      </MaxWidthContainer>
+    </SBPadding>
+  );
+};
 
 export const ExampleDirectoryServiceList = Template.bind({});
 ExampleDirectoryServiceList.args = {

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
@@ -212,6 +212,12 @@ export const AccordionControls = styled.div`
   justify-content: space-between;
 `;
 
+export const ClearFilter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: ${(props) => props.theme.theme_vars.spacingSizes.small};
+`;
+
 export const TextLink = styled.button`
   font-size: ${(props) => props.theme.theme_vars.fontSizes.extra_small};
   position: relative;

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, getByLabelText } from '@testing-library/react';
 import DirectoryServiceList from './DirectoryServiceList';
 import { DirectoryServiceListProps } from './DirectoryServiceList.types';
 import { ExampleService } from '../DirectoryService/DirectoryService.storydata';

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, getByLabelText } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import DirectoryServiceList from './DirectoryServiceList';
 import { DirectoryServiceListProps } from './DirectoryServiceList.types';
 import { ExampleService } from '../DirectoryService/DirectoryService.storydata';

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -94,6 +94,20 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
     setFiltersActive(hasActiveFilters());
   };
 
+  /**
+   * Uncheck all the options for a specific category
+   */
+  const clearCategory = (categoryIndex: number) => {
+    let newCategories = [...categories];
+
+    newCategories[categoryIndex].options.forEach((option) => {
+      option.checked = false;
+    });
+
+    setCategories(newCategories);
+    setFiltersActive(hasActiveFilters());
+  };
+
   const from = pageNumber * perPage - (perPage - 1);
   const to = from + (services?.length ? services.length - 1 : 0);
 
@@ -305,6 +319,11 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                           </Styles.LegendButton>
                         </Styles.Legend>
                         <Styles.Accordion isOpen={accordions[categoryIndex + 1]}>
+                          <Styles.ClearFilter>
+                            <Styles.TextLink onClick={(e) => clearCategory(categoryIndex)}>
+                              Clear filter
+                            </Styles.TextLink>
+                          </Styles.ClearFilter>
                           {category.options.map((taxonomy) => (
                             <Styles.Category key={taxonomy.id}>
                               <RadioCheckboxInput


### PR DESCRIPTION
Add a clear filter button to the DirectoryServiceList accordion items. This unchecks all of the checkboxes or radio buttons for that category. 

## Testing
- Checkout this branch and run `npm run dev` and then visit the DirectoryServiceList component in Directory folder
- Click a few options in the filters and then press `Clear filter` and it should uncheck all of the options within that section. Other sections should remain unchanged
- Publish the design system using`yalc publish` and then pull it into the frontend using `yalc add northants-design-system && yarn && yarn dev`
- Test the local offer page on the frontend, selecting a few filters and then pressing the `Clear filter` button ensuring the radio/checkboxes are unchecked, the url is updated and the results are updated.  