### PR TITLE
Fix/dlo 155 rich text accreditations

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -46,4 +46,19 @@ describe('Test Component', () => {
 
     expect(component).not.toHaveTextContent('How to contact this service');
   });
+
+  it('should sanitize the accreditations and remove tags', () => {
+    props.accreditations =
+      '<p>This is an accreditation</p><h4>This is a heading</h4><blockquote>This is a block quote</blockquote>';
+
+    const { getByTestId, queryByText } = renderComponent();
+
+    const component = getByTestId('DirectoryService');
+
+    expect(component).toHaveTextContent('This is a heading');
+    expect(component).toHaveTextContent('This is a block quote');
+
+    expect(queryByText('This is a heading', { selector: 'h4' })).toBeNull();
+    expect(queryByText('This is a block quote', { selector: 'blockquote' })).toBeNull();
+  });
 });

--- a/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
+++ b/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
@@ -80,7 +80,10 @@ export const transformDescriptionDetails = (
   if (accreditations) {
     details.push({
       term: 'Accreditations',
-      detail: accreditations,
+      detail: sanitizeHtml(accreditations, {
+        allowedTags: ['p', 'b', 'i', 'em', 'strong', 'a', 'ul', 'li', 'ol'],
+        allowedStyles: {},
+      }),
     });
   }
 


### PR DESCRIPTION
The accreditations field is [being updated to a HTML field](https://github.com/FutureNorthants/OpenReferral/pull/180) to allow more information to be recorded with better formatting, such as a link to the ofsted report. This change sanitizes the HTML and only allows specific tags to be used to prevent the page from breaking on the frontend. 

## Testing
- Checkout this branch and run `npm run dev` to test the Service page example
- Run the tests with `npm run test`
- Use `yalc publish` and then in the frontend use `yalc add northants-design-system && yarn install && yarn dev` then test out service pages still show accreditations as expected. 