### PR TITLE
Dlo 165 as an end user i can t clear age filters easily

### DIFF
--- a/src/library/components/Input/Input.tsx
+++ b/src/library/components/Input/Input.tsx
@@ -4,8 +4,9 @@ import * as Styles from './Input.styles';
 
 /**
  * Primary UI component for user interaction
+ * If value is set then treat as controlled component
  */
-const Input: React.FC<InputProps> = ({
+const Input: React.FunctionComponent<InputProps> = ({
   type = 'text',
   placeholder = '',
   isErrored = false,
@@ -15,20 +16,34 @@ const Input: React.FC<InputProps> = ({
   defaultValue,
   onChange,
   id,
+  value,
 }) => {
   return (
     <>
       {errorText && <Styles.ErrorText>{errorText}</Styles.ErrorText>}
-      <Styles.StyledInput
-        onChange={onChange}
-        type={type}
-        placeholder={placeholder}
-        name={name}
-        isErrored={isErrored}
-        maxLength={maxLength}
-        defaultValue={defaultValue}
-        id={id}
-      />
+      {typeof value !== 'undefined' ? (
+        <Styles.StyledInput
+          onChange={onChange}
+          type={type}
+          placeholder={placeholder}
+          name={name}
+          isErrored={isErrored}
+          maxLength={maxLength}
+          value={value}
+          id={id}
+        />
+      ) : (
+        <Styles.StyledInput
+          onChange={onChange}
+          type={type}
+          placeholder={placeholder}
+          name={name}
+          isErrored={isErrored}
+          maxLength={maxLength}
+          defaultValue={defaultValue}
+          id={id}
+        />
+      )}
     </>
   );
 };

--- a/src/library/components/Input/Input.types.ts
+++ b/src/library/components/Input/Input.types.ts
@@ -30,7 +30,8 @@ export interface InputProps {
   maxLength?: number;
 
   /**
-   * Optional default value
+   * Optional default value.
+   * Don't set both defaultValue and value.
    */
   defaultValue?: string | number;
 
@@ -43,4 +44,10 @@ export interface InputProps {
    * The optional input id
    */
   id?: string;
+
+  /**
+   * The optional value for a controlled component.
+   * Don't set both defaultValue and value.
+   */
+  value?: string | number;
 }

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
@@ -21,12 +21,22 @@ export default {
 
 const Template: Story<DirectoryServiceListProps> = (args) => {
   const [categories, setCategories] = useState(ExampleDirectoryCategories);
+  const [minimumAge, setMinimumAge] = useState(args.minimumAge);
+  const [maximumAge, setMaximumAge] = useState(args.maximumAge);
   return (
     <SBPadding>
       <MaxWidthContainer>
         <PageMain>
           <DirectoryShortListProvider>
-            <DirectoryServiceList {...args} categories={categories} setCategories={setCategories} />
+            <DirectoryServiceList
+              {...args}
+              categories={categories}
+              setCategories={setCategories}
+              minimumAge={minimumAge}
+              setMinimumAge={setMinimumAge}
+              maximumAge={maximumAge}
+              setMaximumAge={setMaximumAge}
+            />
           </DirectoryShortListProvider>
         </PageMain>
       </MaxWidthContainer>
@@ -48,9 +58,9 @@ ExampleDirectoryServiceList.args = {
   setSearch: () => {},
   postcode: 'NN1 1ED',
   setPostcode: () => {},
-  minimumAge: '60',
+  minimumAge: 60,
   setMinimumAge: () => {},
-  maximumAge: '288',
+  maximumAge: 288,
   setMaximumAge: () => {},
   categories: ExampleDirectoryCategories,
   setCategories: () => {},

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -108,6 +108,13 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
     setFiltersActive(hasActiveFilters());
   };
 
+  const clearAges = (e) => {
+    e.target.value = '';
+
+    handleAgeChange(e, 'minimumAge');
+    handleAgeChange(e, 'maximumAge');
+  };
+
   const from = pageNumber * perPage - (perPage - 1);
   const to = from + (services?.length ? services.length - 1 : 0);
 
@@ -174,8 +181,8 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
   };
 
   const handleAgeChange = (e, field: string) => {
-    let age: number = e.target.value ? parseInt(e.target.value, 10) : undefined;
-    if (ageInMonths && age) {
+    let age: number | string = e.target.value ? parseInt(e.target.value, 10) : '';
+    if (typeof age === 'number' && ageInMonths) {
       age = age * 12;
     }
 
@@ -284,13 +291,16 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                         </Styles.LegendButton>
                       </Styles.Legend>
                       <Styles.Accordion isOpen={accordions[0]}>
+                        <Styles.ClearFilter>
+                          <Styles.TextLink onClick={(e) => clearAges(e)}>Clear filter</Styles.TextLink>
+                        </Styles.ClearFilter>
                         <Row>
                           <Column small="full" medium="one-half" large="one-half">
                             <Styles.Label htmlFor="minimum_age">From</Styles.Label>
                             <Input
                               name="minimum_age"
                               onChange={(e) => handleAgeChange(e, 'minimumAge')}
-                              defaultValue={ageInMonths && minimumAge ? minimumAge / 12 : minimumAge}
+                              value={ageInMonths && typeof minimumAge === 'number' ? minimumAge / 12 : minimumAge}
                               id="minimum_age"
                               type="number"
                             />
@@ -300,7 +310,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                             <Input
                               name="maximum_age"
                               onChange={(e) => handleAgeChange(e, 'maximumAge')}
-                              defaultValue={ageInMonths && maximumAge ? maximumAge / 12 : maximumAge}
+                              value={ageInMonths && typeof maximumAge === 'number' ? maximumAge / 12 : maximumAge}
                               id="maximum_age"
                               type="number"
                             />

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -66,6 +66,10 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
     setFiltersActive(hasActiveFilters());
   }, []);
 
+  useEffect(() => {
+    setFiltersActive(hasActiveFilters());
+  }, [minimumAge, maximumAge, categories]);
+
   if (accordions.length === 0) {
     const tempAccordions = [];
     categories?.forEach(() => {
@@ -105,7 +109,6 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
     });
 
     setCategories(newCategories);
-    setFiltersActive(hasActiveFilters());
   };
 
   const clearAges = (e) => {
@@ -194,14 +197,16 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
   };
 
   const hasActiveFilters = () => {
-    return categories.some((category) => {
-      return category.options.some((option) => {
-        return option.checked == true;
-      });
-    });
+    return (
+      maximumAge !== '' ||
+      minimumAge !== '' ||
+      categories.some((category) => {
+        return category.options.some((option) => {
+          return option.checked == true;
+        });
+      })
+    );
   };
-
-  hasActiveFilters();
 
   return (
     <Styles.Container data-testid="DirectoryServiceList">

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -95,7 +95,6 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
     });
 
     setCategories(newCategories);
-    setFiltersActive(hasActiveFilters());
   };
 
   /**

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.types.ts
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.types.ts
@@ -80,22 +80,22 @@ export interface DirectoryServiceListProps {
   /**
    * The minimum age filter
    */
-  minimumAge?: number;
+  minimumAge?: number | string;
 
   /**
    * Function prop passed in to handle updating minimumAge
    */
-  setMinimumAge: Dispatch<SetStateAction<number | undefined>>;
+  setMinimumAge: Dispatch<SetStateAction<number | string | undefined>>;
 
   /**
    * The maximum age filter
    */
-  maximumAge?: number;
+  maximumAge?: number | string;
 
   /**
    * Function prop passed in to handle updating maximumAge
    */
-  setMaximumAge: Dispatch<SetStateAction<number | undefined>>;
+  setMaximumAge: Dispatch<SetStateAction<number | string | undefined>>;
 
   /**
    *  Where to centre the map, in the format 'lat,lng'


### PR DESCRIPTION
Use this branch for frontend testing:
- https://github.com/FutureNorthants/northants-website/pull/835

- Update Input component so it can be either controlled or uncontrolled component
- Add a clear filter button to age search
- Update the DirectoryServiceList to use useEffect() to determine whether or not to show 'Clear all filters' button instead of calling it throughout the component
- Update the hasActiveFilters method to also check if minimum or maximum ages are set, not just any categories checked. 

## Testing
- Checkout this branch and run `npm run dev` and view the DirectoryServiceList component
- Test clearing age filters
- Test that 'Clear all filters' button appears when either a category or age filter is set
- Test that 'Clear all filters' button is not shown when no age or category filters are selected
- Checkout this branch on the frontend: https://github.com/FutureNorthants/northants-website/pull/835
- Run `yalc publish` and then in the frontend `yalc add northants-design-system && yarn install && yarn dev`
- Test the frontend directory page that 'Clear all filters' button is shown when either age or category filters are entered, that it is hidden when none are selected. Also test the 'Clear filters' for age search clears any values and that the results are still updated when ages are entered into the age search. 