### PR TITLE
Fix how to contact section showing when no contacts

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.stories.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.stories.tsx
@@ -54,4 +54,4 @@ export const ExampleDirectoryNoLogo = Template.bind({});
 ExampleDirectoryNoLogo.args = { ...ExampleService, ...{ organization: { logo: null } } };
 
 export const ExampleDirectoryServiceNoContactDetails = Template.bind({});
-ExampleDirectoryServiceNoContactDetails.args = { ...ExampleService, ...{ email: null, url: null, contacts: null } };
+ExampleDirectoryServiceNoContactDetails.args = { ...ExampleService, ...{ email: '', url: '', contacts: [] } };

--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -24,21 +24,23 @@ describe('Test Component', () => {
     );
 
   it('should render Service correctly', () => {
-    const { getByTestId, getByRole } = renderComponent();
+    const { getByTestId, getByRole, getByText } = renderComponent();
 
     const component = getByTestId('DirectoryService');
     const heading = getByRole('heading', { level: 1 });
+    const howToContact = getByText('How to contact this service');
 
     expect(heading).toHaveTextContent('West Northamptonshire Council');
     expect(component).toHaveTextContent(
       'West Northamptonshire Council is the single unitary council responsible for providing a range of public services to residents and businesses'
     );
+    expect(howToContact).toBeVisible();
   });
 
   it('should not show the how to contact section if no contact details set', () => {
-    delete props.email;
-    delete props.contacts;
-    delete props.url;
+    props.email = '';
+    props.contacts = [];
+    props.url = '';
 
     const { getByTestId } = renderComponent();
 

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -181,7 +181,7 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
           </Column>
         )}
 
-        {(email || url || contacts) && (
+        {(email || url || contacts?.length > 0) && (
           <Column small="full" medium="full" large="full" classes="striped-column">
             <Heading level={2} text="How to contact this service" />
 


### PR DESCRIPTION
- Update check to see if the contacts has a length greater than zero before showing.
- Update the story with more realistic values that the API will return to ensure the how to contact section is still hidden

## Testing
- Checkout this branch and run `npm run test` to run the tests
- Run `npm run dev` and view Example Directory Service No Contact Details story to ensure the How to contact section is not show. 