### PR TITLE
Open service website link in a new window

### DIFF
--- a/src/library/directory/ServiceContact/ServiceContact.tsx
+++ b/src/library/directory/ServiceContact/ServiceContact.tsx
@@ -20,7 +20,9 @@ const ServiceContact: React.FunctionComponent<ServiceContactComponentProps> = ({
               <WebsiteIcon colourFill={themeContext.theme_vars.colours.black} />
             </Styles.IconContainer>
             <Styles.Content>
-              <Styles.WebLink href={website}>{website}</Styles.WebLink>
+              <Styles.WebLink href={website} target="_blank">
+                {website}
+              </Styles.WebLink>
             </Styles.Content>
           </Column>
         )}


### PR DESCRIPTION
Force the directory service website link to open in a new window. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Example Directory Service and click the website link. It should open in a new window. 