### PR TITLE
Remove the message when service is not visitable

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.storydata.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.storydata.tsx
@@ -94,6 +94,7 @@ export const ExampleService: DirectoryServiceProps = {
       description: 'The main council building',
       latitude: '52.23555414368587',
       longitude: '-0.8957390701320571',
+      is_visitable: true,
       physical_addresses: [
         {
           id: 123,

--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -61,4 +61,40 @@ describe('Test Component', () => {
     expect(queryByText('This is a heading', { selector: 'h4' })).toBeNull();
     expect(queryByText('This is a block quote', { selector: 'blockquote' })).toBeNull();
   });
+
+  it('should show the map when is_visitable and latitude and longitude is set', () => {
+    const { getByText } = renderComponent();
+
+    const addressTitle = getByText('Main office');
+    const mapLink = getByText('View in Google Maps');
+
+    expect(addressTitle).toBeVisible();
+
+    expect(mapLink).toBeVisible();
+    expect(mapLink).toHaveAttribute(
+      'href',
+      'https://www.google.com/maps/search/?api=1&query=52.23555414368587%2C-0.8957390701320571'
+    );
+  });
+
+  it('should not show the map when is_visitable and latitude and longitude is not set', () => {
+    const locationWithoutLatLon = { ...ExampleService.service_at_locations[0], ...{ latitude: '', longitude: '' } };
+    props.service_at_locations = [locationWithoutLatLon];
+
+    const { queryByText } = renderComponent();
+
+    expect(queryByText('View in Google Maps')).toBeNull();
+  });
+
+  it('should show the service address but not the map when not visitable', () => {
+    const nonVisitableLocation = { ...ExampleService.service_at_locations[0], ...{ is_visitable: false } };
+    props.service_at_locations = [nonVisitableLocation];
+
+    const { getByText, queryByText } = renderComponent();
+    const addressTitle = getByText('Main office');
+
+    expect(addressTitle).toBeVisible();
+
+    expect(queryByText('View in Google Maps')).toBeNull();
+  });
 });

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -247,7 +247,7 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
                 return location.is_visitable == false;
               })
               .map((location) => (
-                <Row>
+                <Row key={location.id}>
                   <Column small="full" medium="one-half" large="one-third" key={location.id}>
                     <Heading level={2} text={location.name} />
                     {location.physical_addresses.map((address) => (
@@ -272,11 +272,6 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
                         </ul>
                       </>
                     )}
-                  </Column>
-                  <Column small="full" medium="one-half" large="two-thirds">
-                    <WarningText title="Please note" isWarning>
-                      <p>This address is not open to visitors.</p>
-                    </WarningText>
                   </Column>
                 </Row>
               ))}


### PR DESCRIPTION
The wording in the message does not apply to all services locations that are not visitable. The simplest solution for this defects sprint is to remove the message. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Example Directory Service Not Visitable and check the address is at the bottom of the page and that there is no warning text message next to the address.
- Run tests with `npm run test`