### PR TITLE
Rename heading to description on service page

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -24,15 +24,20 @@ describe('Test Component', () => {
     );
 
   it('should render Service correctly', () => {
-    const { getByTestId, getByRole } = renderComponent();
+    const { getByTestId, getByRole, getByText } = renderComponent();
 
     const component = getByTestId('DirectoryService');
     const heading = getByRole('heading', { level: 1 });
+    const descriptionHeading = getByText('Description');
 
     expect(heading).toHaveTextContent('West Northamptonshire Council');
     expect(component).toHaveTextContent(
       'West Northamptonshire Council is the single unitary council responsible for providing a range of public services to residents and businesses'
     );
+    expect(component).toHaveTextContent('Ofsted Grade: Good (4 July 2019)');
+    expect(component).toHaveTextContent('Contact provider for cost details');
+    expect(descriptionHeading).toBeVisible();
+    expect(descriptionHeading.tagName).toEqual('H2');
   });
 
   it('should not show the how to contact section if no contact details set', () => {

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -190,7 +190,7 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
         )}
 
         <Column small="full" medium="full" large="full" classes="striped-column">
-          <Heading level={2} text="How this service can help" />
+          <Heading level={2} text="Description" />
           <div>
             <>{descriptionElement}</>
           </div>


### PR DESCRIPTION
Rename the 'How this service can help' heading to 'Description' and update test. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Example Directory Service and confirm the heading now says 'Description' 
- Run tests with `npm run test`