### PR TITLE
Add button to view directory from documents list

### DIFF
--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.test.tsx
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import DirectoryDocumentList from './DirectoryDocumentList';
 import { DirectoryDocumentListProps } from './DirectoryDocumentList.types';
 import { ThemeProvider } from 'styled-components';
@@ -29,5 +29,18 @@ describe('Directory Document List Component', () => {
     expect(component).toHaveTextContent('This is an example document');
     expect(component).toHaveTextContent('This is an example link');
     expect(component).toHaveTextContent('Showing 1 to 2 out of 125');
+  });
+
+  it('has a link back to the directory with the search term', () => {
+    const { getByText, getByLabelText } = renderComponent();
+
+    const directoryLink = getByText('View directory');
+    const search = getByLabelText('What are you looking for?');
+
+    expect(directoryLink).toBeVisible();
+    expect(directoryLink).toHaveAttribute('href', '/directory/local-offer?search=Example');
+
+    fireEvent.change(search, { target: { value: 'schools' } });
+    expect(directoryLink).toHaveAttribute('href', '/directory/local-offer?search=schools');
   });
 });

--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.tsx
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.tsx
@@ -11,6 +11,7 @@ import RadioCheckboxInput from '../../components/RadioCheckboxInput/RadioCheckbo
 import FileDownload from '../../components/FileDownload/FileDownload';
 import LoadingSpinner from '../../components/LoadingSpinner/LoadingSpinner';
 import Pagination from '../../components/Pagination/Pagination';
+import Button from '../../components/Button/Button';
 
 const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps> = ({
   directoryPath,
@@ -93,6 +94,9 @@ const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps>
                       <SearchIcon colourFill="#fff" />
                     </Styles.Button>
                   </Styles.ButtonContainer>
+                </Column>
+                <Column small="full" medium="full" large="full">
+                  <Button url={`${directoryPath}?search=${searchTerm}`} text="View directory" primary={false} />
                 </Column>
               </Row>
             </FormWithLine>


### PR DESCRIPTION
Add a button to go back to the directory page. The link includes the search term. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Directory Documents List and see the 'View directory' button
- Update the search term and inspect the link. It should have the new search term appended to the link. 