### PR TITLE
Single taxonomies in a paragraph, multiple in a list

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -61,4 +61,16 @@ describe('Test Component', () => {
     expect(queryByText('This is a heading', { selector: 'h4' })).toBeNull();
     expect(queryByText('This is a block quote', { selector: 'blockquote' })).toBeNull();
   });
+
+  it('should have single value taxonomies in a paragraph and multiple in a list', () => {
+    const { getByText } = renderComponent();
+
+    const frenchLanguage = getByText('French');
+    const germanLanguage = getByText('German');
+    const referralRoute = getByText('Professional referral');
+
+    expect(frenchLanguage.tagName).toBe('LI');
+    expect(germanLanguage.tagName).toBe('LI');
+    expect(referralRoute.tagName).toBe('P');
+  });
 });

--- a/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
+++ b/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
@@ -140,17 +140,24 @@ export const transformTaxonomies = (service_taxonomys: ServiceTaxonomy[], taxono
 
   taxonomiesToShow.forEach((taxonomy, taxonomyIndex) => {
     if (groupedTaxonomies.hasOwnProperty(taxonomy.vocabulary)) {
-      details.push({
-        term: taxonomy.label,
-        detail:
-          '<ul>' +
-          groupedTaxonomies[taxonomy.vocabulary]
-            .map((item) => {
-              return `<li>${item.name}</li>`;
-            })
-            .join('') +
-          '</ul>',
-      });
+      if (groupedTaxonomies[taxonomy.vocabulary].length === 1) {
+        details.push({
+          term: taxonomy.label,
+          detail: '<p>' + groupedTaxonomies[taxonomy.vocabulary][0].name + '</p>',
+        });
+      } else {
+        details.push({
+          term: taxonomy.label,
+          detail:
+            '<ul>' +
+            groupedTaxonomies[taxonomy.vocabulary]
+              .map((item) => {
+                return `<li>${item.name}</li>`;
+              })
+              .join('') +
+            '</ul>',
+        });
+      }
     }
   });
 


### PR DESCRIPTION
Resolves DLO-172.

Update the service details so when there is only a single value it is in a paragraph tag, otherwise it will put them in a list. 

## Testing
- Checkout this branch and then `npm run dev`
- View the Directory Service story and check that the single value taxonomies are in a paragraph and the multiple in a list