### PR TITLE
Add pagination to the top of DirectoryServiceList

### DIFF
--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -389,6 +389,15 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                   </Styles.FavouritesContainer>
                 </Column>
                 <Column small="full" medium="full" large="full">
+                  <Pagination
+                    currentPage={pageNumber}
+                    totalResults={totalResults}
+                    resultsPerPage={perPage}
+                    postTo={directoryPath}
+                    buttonClickOverride={setPageNumber}
+                  />
+                </Column>
+                <Column small="full" medium="full" large="full">
                   {notServer && <>{services?.length > 0 && showMap && <DirectoryMap mapProps={mapProps} />}</>}
                 </Column>
                 {services.map((service, index) => {
@@ -455,20 +464,17 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                     </Column>
                   );
                 })}
+                <Column small="full" medium="full" large="full">
+                  <Pagination
+                    currentPage={pageNumber}
+                    totalResults={totalResults}
+                    resultsPerPage={perPage}
+                    postTo={directoryPath}
+                    buttonClickOverride={setPageNumber}
+                  />
+                </Column>
               </>
             )}
-
-            <Column small="full" medium="full" large="full">
-              {!isLoading && (
-                <Pagination
-                  currentPage={pageNumber}
-                  totalResults={totalResults}
-                  resultsPerPage={perPage}
-                  postTo={directoryPath}
-                  buttonClickOverride={setPageNumber}
-                />
-              )}
-            </Column>
           </Row>
         </Column>
       </Row>


### PR DESCRIPTION
Duplicate the pagination at the top of the DirectoryServiceList so users can navigate through the pages without scrolling all the way to the bottom of the results. 

Also moved the bottom pagination section inside the same isLoading check as the services to simplify. 

## Testing
- Checkout this branch and run `npm run dev`
- Visit the Directory Service List component and see the navigation now at the top and the bottom of the page