### PR TITLE
Fix opening times table accessibility

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -116,4 +116,16 @@ describe('Test Component', () => {
 
     expect(queryByText('View in Google Maps')).toBeNull();
   });
+
+  it('should show the opening hours', () => {
+    const { getByTestId, getByText } = renderComponent();
+    const component = getByTestId('DirectoryService');
+    const dayOfWeek = getByText('Monday');
+
+    expect(component).toHaveTextContent('Monday');
+    expect(component).toHaveTextContent('Tuesday');
+    expect(component).toHaveTextContent('Wednesday');
+
+    expect(dayOfWeek.tagName).toBe('TD');
+  });
 });

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -215,7 +215,7 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
                 <tbody>
                   {regular_schedules?.map((schedule, scheduleIndex) => (
                     <tr key={scheduleIndex}>
-                      <th>{schedule.weekday}</th>
+                      <td>{schedule.weekday}</td>
                       <td>{schedule.opens_at}</td>
                       <td>{schedule.closes_at}</td>
                     </tr>


### PR DESCRIPTION
Update the weekday to be in a `<td>` instead of a `<th>`. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Directory Service component and inspect the opening times table. The weekday should now be in a `<td>` instead of a `<th>`. 