### PR TITLE
Show age on service details page

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.storydata.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.storydata.tsx
@@ -4,6 +4,7 @@ import { ExampleSocialProfiles } from '../ServiceSocialLinks/ServiceSocialLinks.
 
 export const ExampleService: DirectoryServiceProps = {
   id: 'abc123',
+  ageInMonths: true,
   contacts: [
     {
       id: 1,

--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -7,7 +7,7 @@ import { west_theme } from '../../../themes/theme_generator';
 import { ExampleService } from './DirectoryService.storydata';
 import { DirectoryShortListProvider } from '../../contexts/DirectoryShortListProvider/DirectoryShortListProvider';
 
-describe('Test Component', () => {
+describe('Directory Service', () => {
   let props: DirectoryServiceProps;
 
   beforeEach(() => {
@@ -78,7 +78,7 @@ describe('Test Component', () => {
 
     expect(frenchLanguage.tagName).toBe('LI');
     expect(germanLanguage.tagName).toBe('LI');
-    expect(referralRoute.tagName).toBe('P');
+    expect(referralRoute.tagName).toBe('SPAN');
   });
 
   it('should show the map when is_visitable and latitude and longitude is set', () => {
@@ -115,5 +115,14 @@ describe('Test Component', () => {
     expect(addressTitle).toBeVisible();
 
     expect(queryByText('View in Google Maps')).toBeNull();
+  });
+
+  it('should show and format the age range', () => {
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('DirectoryService');
+
+    expect(component).toHaveTextContent('Age range');
+    expect(component).toHaveTextContent('Suitable for ages from 0 to 18 years');
   });
 });

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -26,8 +26,10 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
   id,
   name,
   accreditations,
+  ageInMonths = false,
   description,
   descriptionElement,
+  eligibilitys,
   email,
   fees,
   languages,
@@ -195,7 +197,14 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
             <>{descriptionElement}</>
           </div>
           <SummaryList
-            terms={transformDescriptionDetails(accreditations, fees, service_areas, languages)}
+            terms={transformDescriptionDetails(
+              accreditations,
+              fees,
+              service_areas,
+              languages,
+              eligibilitys,
+              ageInMonths
+            )}
             hasMargin={false}
           />
           <SummaryList terms={transformTaxonomies(service_taxonomys, taxonomiesToShow)} hasMargin={false} />

--- a/src/library/directory/DirectoryService/DirectoryService.types.ts
+++ b/src/library/directory/DirectoryService/DirectoryService.types.ts
@@ -15,6 +15,11 @@ export interface DirectoryServiceProps {
   accreditations?: string;
 
   /**
+   * Should the age be displayed in months?
+   */
+  ageInMonths?: boolean;
+
+  /**
    * An array of contacts with phone numbers
    */
   contacts?: ServiceContactProps[];

--- a/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
+++ b/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
@@ -1,5 +1,6 @@
 import { SummaryRowProps } from '../../components/SummaryList/SummaryList.types';
 import {
+  EligibilitiesProps,
   LanguagesProps,
   LocationProps,
   ServiceAreaProps,
@@ -73,7 +74,9 @@ export const transformDescriptionDetails = (
   accreditations: string,
   fees: string,
   service_areas: ServiceAreaProps[],
-  languages: LanguagesProps[]
+  languages: LanguagesProps[],
+  eligibilities: EligibilitiesProps[],
+  ageInMonths: boolean = false
 ): SummaryRowProps[] => {
   const details: SummaryRowProps[] = [];
 
@@ -94,7 +97,12 @@ export const transformDescriptionDetails = (
     });
   }
 
-  if (service_areas?.length > 0) {
+  if (service_areas?.length === 1) {
+    details.push({
+      term: 'Locality',
+      detail: `<span>${service_areas[0].service_area}</span>`,
+    });
+  } else if (service_areas?.length > 1) {
     details.push({
       term: 'Locality',
       detail:
@@ -108,7 +116,12 @@ export const transformDescriptionDetails = (
     });
   }
 
-  if (languages?.length > 0) {
+  if (languages?.length === 1) {
+    details.push({
+      term: 'Additional languages',
+      detail: `<span>${languages[0].language}</span>`,
+    });
+  } else if (languages?.length > 1) {
     details.push({
       term: 'Additional languages',
       detail:
@@ -116,6 +129,27 @@ export const transformDescriptionDetails = (
         languages
           .map((language) => {
             return `<li>${language.language}</li>`;
+          })
+          .join('') +
+        '</ul>',
+    });
+  }
+
+  if (eligibilities?.length === 1) {
+    details.push({
+      term: 'Age range',
+      detail: `<span>Suitable for ages from ${transformAge(eligibilities[0].minimum_age, ageInMonths)} to
+      ${transformAge(eligibilities[0].maximum_age, ageInMonths)}</span>`,
+    });
+  } else if (eligibilities?.length > 1) {
+    details.push({
+      term: 'Age range',
+      detail:
+        '<ul>' +
+        eligibilities
+          .map((eligibility) => {
+            return `<li>Suitable for ages from ${transformAge(eligibility.minimum_age, ageInMonths)} to 
+            ${transformAge(eligibility.maximum_age, ageInMonths)}</li>`;
           })
           .join('') +
         '</ul>',
@@ -143,7 +177,7 @@ export const transformTaxonomies = (service_taxonomys: ServiceTaxonomy[], taxono
       if (groupedTaxonomies[taxonomy.vocabulary].length === 1) {
         details.push({
           term: taxonomy.label,
-          detail: '<p>' + groupedTaxonomies[taxonomy.vocabulary][0].name + '</p>',
+          detail: '<span>' + groupedTaxonomies[taxonomy.vocabulary][0].name + '</span>',
         });
       } else {
         details.push({
@@ -162,4 +196,17 @@ export const transformTaxonomies = (service_taxonomys: ServiceTaxonomy[], taxono
   });
 
   return details;
+};
+
+export const transformAge = (age: number, ageInMonths: boolean = false) => {
+  if (age === 0) {
+    return age;
+  }
+  if (ageInMonths) {
+    if (age > 36) {
+      return Math.ceil(age / 12) + ' years';
+    }
+    return `${age} months`;
+  }
+  return `${age} years`;
 };

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -17,7 +17,7 @@ import DirectoryMap from '../DirectoryMap/DirectoryMap';
 import { StaticMapProps } from '../../components/StaticMap/StaticMap.types';
 import LoadingSpinner from '../../components/LoadingSpinner/LoadingSpinner';
 import { ThemeContext } from 'styled-components';
-import { transformSnippet } from '../DirectoryService/DirectoryServiceTransform';
+import { transformSnippet, transformAge } from '../DirectoryService/DirectoryServiceTransform';
 import RadioCheckboxInput from '../../components/RadioCheckboxInput/RadioCheckboxInput';
 import Button from '../../components/Button/Button';
 
@@ -167,19 +167,6 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
           title: `<a href="${directoryPath}/${service.id}">${service.name}</a>`,
         };
       }),
-  };
-
-  const formatAge = (age) => {
-    if (age === 0) {
-      return age;
-    }
-    if (ageInMonths) {
-      if (age > 36) {
-        return Math.ceil(age / 12) + ' years';
-      }
-      return `${age} months`;
-    }
-    return `${age} years`;
   };
 
   const handleAgeChange = (e, field: string) => {
@@ -442,8 +429,8 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                               <>
                                 {service.eligibilitys.map((eligibility) => (
                                   <Styles.Age key={eligibility.id}>
-                                    Suitable for ages from {formatAge(eligibility.minimum_age)} to{' '}
-                                    {formatAge(eligibility.maximum_age)}
+                                    Suitable for ages from {transformAge(eligibility.minimum_age, ageInMonths)} to{' '}
+                                    {transformAge(eligibility.maximum_age, ageInMonths)}
                                   </Styles.Age>
                                 ))}
                               </>


### PR DESCRIPTION
- Display the age on the service details page
- Format the ages using a transform in both the service list and service details
- Update formatting for single items in the summary list so they are in a span instead of paragraph. This removes the bottom margin and helps vertical alignment with the heading
- Add test for formatting age as expected

## Testing
- Checkout this branch and run `npm run dev`
- View the Directory Service component and test the formatting of the summary list and the alignment looks correct
- Check that the ages are showing as expected
- Use `yalc publish` to publish it locally and then on the frontend `yalc add northants-design-system && yarn install && yarn dev` then view a listing on the frontend and test the ages appear as expected and the formatting is correct with real data.