### PR TITLE
Hide the signpost links in search results for West

### DIFF
--- a/src/library/structure/SearchResultsList/SearchResultsData.js
+++ b/src/library/structure/SearchResultsList/SearchResultsData.js
@@ -1,140 +1,144 @@
 export const searchResults = {
-    searchTerm: "Council tax",
-    pageNumber: 1,
-    totalResults: 23,
-    results: [
-      {
-        title: "Council tax",
-        link: "/council-tax",
-        summary: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper."
-      },
-      {
-        title: "Paying council tax",
-        link: "/",
-        summary: "Pay your council tax online",
-        signpostLinksArray: [
-          {
-            sovereignCode: 1,
-            areaName: "Corby",
-            url: "/"
+  searchTerm: 'Council tax',
+  pageNumber: 1,
+  totalResults: 23,
+  results: [
+    {
+      title: 'Council tax',
+      link: '/council-tax',
+      summary:
+        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+    },
+    {
+      title: 'Paying council tax',
+      link: '/',
+      summary: 'Pay your council tax online',
+      signpostLinksArray: [
+        {
+          sovereignCode: 1,
+          areaName: 'Corby',
+          url: '/',
         },
         {
-            sovereignCode: 3,
-            areaName: "East Northamptonshire",
-            url: "/"
+          sovereignCode: 3,
+          areaName: 'East Northamptonshire',
+          url: '/',
         },
         {
-            sovereignCode: 4,
-            areaName: "Kettering",
-            url: "/"
+          sovereignCode: 4,
+          areaName: 'Kettering',
+          url: '/',
         },
         {
-            sovereignCode: 7,
-            areaName: "Wellingborough",
-            url: "/"
-        }
-      ]
-      },
-      {
-        title: "Council tax",
-        link: "/council-tax",
-        summary: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper."
-      },
-      {
-        title: "Council tax single CTA",
-        link: "/council-tax",
-        summary: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.",
-        signpostLinksArray: [
-          {
-            sovereignCode: 2,
-            areaName: "Northamptonshire County Council",
-            url: "/"
-          }
-        ]
-      },
-      {
-        title: "Paying council tax",
-        link: "/",
-        summary: "Pay your council tax online",
-        TopLineText: "Change to the topline text",
-        signpostLinksArray: [
-          {
-            sovereignCode: 2,
-            areaName: "Daventry",
-            url: "/"
+          sovereignCode: 7,
+          areaName: 'Wellingborough',
+          url: '/',
+        },
+      ],
+    },
+    {
+      title: 'Council tax',
+      link: '/council-tax',
+      summary:
+        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+    },
+    {
+      title: 'Council tax single CTA',
+      link: '/council-tax',
+      summary:
+        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+      signpostLinksArray: [
+        {
+          sovereignCode: 2,
+          areaName: 'Northamptonshire County Council',
+          url: '/',
+        },
+      ],
+    },
+    {
+      title: 'Paying council tax',
+      link: '/',
+      summary: 'Pay your council tax online',
+      TopLineText: 'Change to the topline text',
+      signpostLinksArray: [
+        {
+          sovereignCode: 2,
+          areaName: 'Daventry',
+          url: '/',
         },
         {
-            sovereignCode: 5,
-            areaName: "Northampton",
-            url: "/"
+          sovereignCode: 5,
+          areaName: 'Northampton',
+          url: '/',
         },
         {
-            sovereignCode: 6,
-            areaName: "South Northamptonshire",
-            url: "/"
-        }
-      ]
-      },
-  ]
-  };
+          sovereignCode: 6,
+          areaName: 'South Northamptonshire',
+          url: '/',
+        },
+      ],
+    },
+  ],
+};
 
+export const noSearchResults = {
+  searchTerm: 'Council tax',
+  totalResults: 0,
+  results: [],
+};
 
-  export const noSearchResults = {
-    searchTerm: "Council tax",
-    totalResults: 0,
-    results: []
-  };
-
-
-  export const searchResultsWithServiceArea = {
-    searchTerm: "Council tax",
-    pageNumber: 2,
-    totalResults: 23,
-    results: [
-      {
-        service: "Council tax",
-        title: "Council tax",
-        link: "/council-tax",
-        summary: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper."
-      },
-      {
-        service: "Council tax",
-        title: "Paying council tax",
-        link: "/",
-        summary: "Pay your council tax online",
-        signpostLinksArray: [
-          {
-            sovereignCode: 1,
-            areaName: "Corby",
-            url: "/"
+export const searchResultsWithServiceArea = {
+  searchTerm: 'Council tax',
+  pageNumber: 2,
+  totalResults: 23,
+  results: [
+    {
+      service: 'Council tax',
+      title: 'Council tax',
+      link: '/council-tax',
+      summary:
+        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+    },
+    {
+      service: 'Council tax',
+      title: 'Paying council tax',
+      link: '/',
+      summary: 'Pay your council tax online',
+      signpostLinksArray: [
+        {
+          sovereignCode: 1,
+          areaName: 'Corby',
+          url: '/',
         },
         {
-            sovereignCode: 3,
-            areaName: "East Northamptonshire",
-            url: "/"
+          sovereignCode: 3,
+          areaName: 'East Northamptonshire',
+          url: '/',
         },
         {
-            sovereignCode: 4,
-            areaName: "Kettering",
-            url: "/"
+          sovereignCode: 4,
+          areaName: 'Kettering',
+          url: '/',
         },
         {
-            sovereignCode: 7,
-            areaName: "Wellingborough",
-            url: "/"
-        }
-      ]
-      },
-      {
-        service: "Bins, recycling and waste",
-        title: "Council tax not same area",
-        link: "/council-tax",
-        summary: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper."
-      },
-      {
-        title: "Council tax without service area",
-        link: "/council-tax",
-        summary: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper."
-      }
-  ]
-  };
+          sovereignCode: 7,
+          areaName: 'Wellingborough',
+          url: '/',
+        },
+      ],
+    },
+    {
+      service: 'Bins, recycling and waste',
+      title: 'Council tax not same area',
+      link: '/council-tax',
+      summary:
+        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+    },
+    {
+      title: 'Council tax without service area',
+      link: '/council-tax',
+      summary:
+        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+    },
+  ],
+};

--- a/src/library/structure/SearchResultsList/SearchResultsList.stories.tsx
+++ b/src/library/structure/SearchResultsList/SearchResultsList.stories.tsx
@@ -1,8 +1,7 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import SearchResultsList from "./SearchResultsList";
-import { SearchResultsListProps } from "./SearchResultsList.types";
+import SearchResultsList from './SearchResultsList';
+import { SearchResultsListProps } from './SearchResultsList.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 import { searchResults, noSearchResults, searchResultsWithServiceArea } from './SearchResultsData';
 
@@ -12,19 +11,21 @@ export default {
   parameters: {
     status: {
       type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-    }
+    },
   },
 };
 
-const Template: Story<SearchResultsListProps> = (args) => <SBPadding><SearchResultsList {...args} /></SBPadding>;
+const Template: Story<SearchResultsListProps> = (args) => (
+  <SBPadding>
+    <SearchResultsList {...args} />
+  </SBPadding>
+);
 
-export const ExampleSearchResultsList = Template.bind({});    
+export const ExampleSearchResultsList = Template.bind({});
 ExampleSearchResultsList.args = searchResults;
 
+export const ExampleNoSearchResultsList = Template.bind({});
+ExampleNoSearchResultsList.args = noSearchResults;
 
-export const ExampleNoSearchResultsList = Template.bind({});   
-ExampleNoSearchResultsList.args = noSearchResults
-
-
-export const ExampleSearchResultsListWithServiceArea = Template.bind({});    
+export const ExampleSearchResultsListWithServiceArea = Template.bind({});
 ExampleSearchResultsListWithServiceArea.args = searchResultsWithServiceArea;

--- a/src/library/structure/SearchResultsList/SearchResultsList.test.tsx
+++ b/src/library/structure/SearchResultsList/SearchResultsList.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { searchResults } from './SearchResultsData';
+import SearchResultsList from './SearchResultsList';
+import { SearchResultsListProps } from './SearchResultsList.types';
+import { north_theme, west_theme } from '../../../themes/theme_generator';
+import { render } from '@testing-library/react';
+
+describe('SearchResultsList - West', () => {
+  let props: SearchResultsListProps;
+
+  beforeEach(() => {
+    props = searchResults;
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <SearchResultsList {...props} />
+      </ThemeProvider>
+    );
+
+  it('hides the signpost links for West', () => {
+    const { queryByText } = renderComponent();
+
+    expect(queryByText('Corby')).toBeNull();
+    expect(queryByText('Select your local area for information:')).toBeNull();
+    expect(queryByText('Go straight to the information:')).toBeNull();
+  });
+});
+
+describe('SearchResultsList - North', () => {
+  let props: SearchResultsListProps;
+
+  beforeEach(() => {
+    props = searchResults;
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={north_theme}>
+        <SearchResultsList {...props} />
+      </ThemeProvider>
+    );
+
+  it('shows the signpost links for North', () => {
+    const { getByTestId, getByText } = renderComponent();
+
+    const component = getByTestId('SearchResultsList');
+    const signpostLinkCorby = getByText('Corby');
+
+    expect(component).toHaveTextContent('Select your local area for information:');
+    expect(component).toHaveTextContent('Go straight to the information:');
+
+    expect(signpostLinkCorby).toBeVisible();
+    expect(signpostLinkCorby).toHaveAttribute('href', '/');
+    expect(signpostLinkCorby).toHaveAttribute('title', 'Corby (this link will take you to an external website)');
+  });
+});

--- a/src/library/structure/SearchResultsList/SearchResultsList.tsx
+++ b/src/library/structure/SearchResultsList/SearchResultsList.tsx
@@ -1,63 +1,52 @@
+import React, { useContext } from 'react';
+import { SearchResultsListProps } from './SearchResultsList.types';
+import * as Styles from './SearchResultsList.styles';
+import SignpostLinksList from '../../components/SignpostLinksList/SignpostLinksList';
+import { ThemeContext } from 'styled-components';
 
-import React from "react";
+const SearchResultsList: React.FunctionComponent<SearchResultsListProps> = ({
+  searchTerm,
+  results,
+  totalResults = 0,
+  pageNumber = 0,
+}) => {
+  const themeContext = useContext(ThemeContext);
+  if (totalResults === 0) {
+    return (
+      <Styles.Container data-testid="SearchResultsList">
+        <Styles.ResultInfo>No results found</Styles.ResultInfo>
+      </Styles.Container>
+    );
+  } else {
+    return (
+      <Styles.Container data-testid="SearchResultsList">
+        <Styles.ResultInfo>
+          {pageNumber > 1 && 'Page ' + pageNumber + ' of '}
+          {totalResults} total results for '{searchTerm}'
+        </Styles.ResultInfo>
 
-import { SearchResultsListProps } from "./SearchResultsList.types";
-import * as Styles from "./SearchResultsList.styles";
-import SignpostLinksList from "../../components/SignpostLinksList/SignpostLinksList";
-
-const SearchResultsList: React.FC<SearchResultsListProps> = ({ searchTerm, results, totalResults = 0, pageNumber = 0 }) => {
-
-    if(totalResults === 0) {
-        return (
-            <Styles.Container data-testid="SearchResultsList">
-                <Styles.ResultInfo>No results found</Styles.ResultInfo>
-            </Styles.Container>
-        );
-    }
-    else {
-        return (
-
-            <Styles.Container data-testid="SearchResultsList">
-
-
-                <Styles.ResultInfo>{(pageNumber) > 1 && ("Page " + (pageNumber) + " of ")}{totalResults} total results for '{searchTerm}'</Styles.ResultInfo>
-                
-                {results.map((result,i) => 
-                    
-                    <Styles.Result key={i}>
-                        {result.service && <Styles.ServiceArea>{result.service}</Styles.ServiceArea>}
-                        <Styles.Title href={result.link}>{result.title}</Styles.Title>
-                        <Styles.Summary>{result.summary}</Styles.Summary>
-                        {result.signpostLinksArray &&
-                            <Styles.SignpostContainer>
-                                {result.signpostLinksArray.length > 1 ?
-                                    <>{result.TopLineText ?
-                                        <p>{result.TopLineText}</p>
-                                        :
-                                        <p>Select your local area for information:</p>
-                                    }</>
-                                :
-                                    <>{result.TopLineText ?
-                                        <p>{result.TopLineText}</p>
-                                        :
-                                        <p>Go straight to the information:</p>
-                                    }</>
-                                }
-                                <SignpostLinksList signpostLinksArray={result.signpostLinksArray} />
-                            </Styles.SignpostContainer>
-                        }
-                    </Styles.Result>
-                    
+        {results.map((result, i) => (
+          <Styles.Result key={i}>
+            {result.service && <Styles.ServiceArea>{result.service}</Styles.ServiceArea>}
+            <Styles.Title href={result.link}>{result.title}</Styles.Title>
+            <Styles.Summary>{result.summary}</Styles.Summary>
+            {result.signpostLinksArray && themeContext.cardinal_name === 'north' && (
+              <Styles.SignpostContainer>
+                {result.signpostLinksArray.length > 1 ? (
+                  <>
+                    {result.TopLineText ? <p>{result.TopLineText}</p> : <p>Select your local area for information:</p>}
+                  </>
+                ) : (
+                  <>{result.TopLineText ? <p>{result.TopLineText}</p> : <p>Go straight to the information:</p>}</>
                 )}
-
-            
-            
-    
-        </Styles.Container>
-        );
-    }
-
-}
+                <SignpostLinksList signpostLinksArray={result.signpostLinksArray} />
+              </Styles.SignpostContainer>
+            )}
+          </Styles.Result>
+        ))}
+      </Styles.Container>
+    );
+  }
+};
 
 export default SearchResultsList;
-

--- a/src/library/structure/SearchResultsList/SearchResultsList.types.ts
+++ b/src/library/structure/SearchResultsList/SearchResultsList.types.ts
@@ -1,48 +1,55 @@
-import {SignpostLinkProp} from '../../components/SignpostLinksList/SignpostLinksList.types'
+import { SignpostLinkProp } from '../../components/SignpostLinksList/SignpostLinksList.types';
+
 export interface SearchResultsListProps {
   /**
    * What you searched for
    */
   searchTerm: string;
+
   /**
    * Array of results
    */
   results: Array<SearchResultProps>;
+
   /**
    * The total number of results
    */
   totalResults?: number;
+
   /**
    * The current page number
    */
   pageNumber?: number;
 }
 
-
 export interface SearchResultProps {
   /**
    * Search result title
    */
   title: string;
+
   /**
    * Link to page
    */
   link: string;
+
   /**
    * Summary of page
    */
   summary: string;
+
   /**
    * If it contains signposting links include them here
    */
   signpostLinksArray?: Array<SignpostLinkProp>;
+
   /**
    * Optional override for the top line of text
    */
   TopLineText?: string;
+
   /**
    * If there is a service area tied to the result
    */
   service?: string;
 }
-


### PR DESCRIPTION
- Hide the signpost links in search results for the West https://github.com/FutureNorthants/northants-website/issues/832
- Add test
- Prettier formatting

## Testing
- Checkout this branch and run `npm run dev`
- View the Search Results List story.
- The signpost links should be visible for North and LB North themes.
- The signpost links should be hidden for West and LB West themes. 