### PR TITLE
Update back link to allow using browser history

### DIFF
--- a/src/library/structure/BackLink/BackLink.stories.tsx
+++ b/src/library/structure/BackLink/BackLink.stories.tsx
@@ -1,24 +1,31 @@
-
-import React from "react";
+import React from 'react';
 import { Story } from '@storybook/react/types-6-0';
-import BackLink from "./BackLink";
-import { BackLinkProps } from "./BackLink.types";
+import BackLink from './BackLink';
+import { BackLinkProps } from './BackLink.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 
 export default {
-    title: 'Library/Structure/Back Link',
-    component: BackLink,
-    parameters: {
-      status: {
-        type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      }
+  title: 'Library/Structure/Back Link',
+  component: BackLink,
+  parameters: {
+    status: {
+      type: 'stable', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
     },
+  },
 };
 
-const Template: Story<BackLinkProps> = (args) => <SBPadding><BackLink {...args} /></SBPadding>;
+const Template: Story<BackLinkProps> = (args) => (
+  <SBPadding>
+    <BackLink {...args} />
+  </SBPadding>
+);
 
-export const ExampleBackLink = Template.bind({});    
+export const ExampleBackLink = Template.bind({});
 ExampleBackLink.args = {
-  link: "/"
+  link: '/',
 };
 
+export const ExampleBackLinkUseHistory = Template.bind({});
+ExampleBackLinkUseHistory.args = {
+  useHistory: true,
+};

--- a/src/library/structure/BackLink/BackLink.styles.js
+++ b/src/library/structure/BackLink/BackLink.styles.js
@@ -1,31 +1,29 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Container = styled.a`
-
-
-
   display: inline-block;
   position: relative;
   margin-top: 15px;
   margin-bottom: 15px;
   padding-left: 14px;
+  border: none;
+  background: transparent;
 
+  ${(props) => props.theme.fontStyles}
 
-  ${props => props.theme.fontStyles}
-
-  &:hover{
-      ${props => props.theme.linkStylesHover}
+  &:hover {
+    ${(props) => props.theme.linkStylesHover}
+    cursor: pointer;
   }
-  &:focus{
-      ${props => props.theme.linkStylesFocus}
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus}
   }
-  &:active{
-      ${props => props.theme.linkStylesActive}
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
   }
-
 
   &:before {
-    content: "";
+    content: '';
     display: block;
     position: absolute;
     top: 0;
@@ -47,11 +45,11 @@ export const Container = styled.a`
   }
 
   &:after {
-    content: "";
+    content: '';
     position: absolute;
     top: -14px;
     right: 0;
     bottom: -14px;
     left: 0;
   }
-`
+`;

--- a/src/library/structure/BackLink/BackLink.test.tsx
+++ b/src/library/structure/BackLink/BackLink.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import BackLink from './BackLink';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+import { BackLinkProps } from './BackLink.types';
+
+describe('Back Link', () => {
+  let props: BackLinkProps;
+
+  beforeEach(() => {
+    props = {
+      link: '/back',
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <BackLink {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render the back link as an anchor tag by default', () => {
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('BackLink');
+
+    expect(component).toHaveAttribute('href', '/back');
+    expect(component).toHaveTextContent('Back');
+  });
+
+  it('should render the back link as a button when useHistory', () => {
+    props.useHistory = true;
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('BackLink');
+
+    expect(component).not.toHaveAttribute('href', '/back');
+    expect(component).toHaveTextContent('Back');
+  });
+});

--- a/src/library/structure/BackLink/BackLink.tsx
+++ b/src/library/structure/BackLink/BackLink.tsx
@@ -1,12 +1,22 @@
+import React from 'react';
+import { BackLinkProps } from './BackLink.types';
+import * as Styles from './BackLink.styles';
 
-import React from "react";
-
-import { BackLinkProps } from "./BackLink.types";
-import * as Styles from "./BackLink.styles";
-
-const BackLink: React.FC<BackLinkProps> = ({ link }) => (
-    <Styles.Container href={link} data-testid="BackLink">Back</Styles.Container>
+/**
+ * A back link or a back button when using history
+ */
+const BackLink: React.FunctionComponent<BackLinkProps> = ({ link, useHistory = false }) => (
+  <>
+    {useHistory ? (
+      <Styles.Container onClick={() => history.back()} data-testid="BackLink" as="button">
+        Back
+      </Styles.Container>
+    ) : (
+      <Styles.Container href={link} data-testid="BackLink">
+        Back
+      </Styles.Container>
+    )}
+  </>
 );
 
 export default BackLink;
-

--- a/src/library/structure/BackLink/BackLink.types.ts
+++ b/src/library/structure/BackLink/BackLink.types.ts
@@ -1,7 +1,11 @@
-
 export interface BackLinkProps {
   /**
-   * What is this?
+   * The optional uri to navigate back to
    */
-  link: string;
+  link?: string;
+
+  /**
+   * Should the browser history be used instead of the link?
+   */
+  useHistory?: boolean;
 }


### PR DESCRIPTION
Users can get stuck in a loop if there are two pages in a row with a back link on as it adds to the browser history (as a link) instead of removing an item from the browser history. 

This change allows you to set `useHistory` to go back using the browser history instead. 

When useHistory is true it will be a button to use the onClick event. When it is a link it will be a standard anchor tag. 

## Testing
- Checkout this branch and run `npm run dev` to test the two stories
- The useHistory should navigate you back to the previous page you were on and the other should be a standard link
- Run `npm run test` to manually run the test suite 