### PR TITLE
Add error states for directory list components

### DIFF
--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.stories.tsx
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.stories.tsx
@@ -42,3 +42,35 @@ ExampleDirectoryDocumentList.args = {
   setCategories: () => {},
   isLoading: false,
 };
+
+export const ExampleDirectoryDocumentListNoResults = Template.bind({});
+ExampleDirectoryDocumentListNoResults.args = {
+  isError: false,
+  directoryPath: '/directory/local-offer',
+  documents: [],
+  search: 'Example',
+  setSearch: () => {},
+  totalResults: 0,
+  pageNumber: 1,
+  setPageNumber: () => {},
+  perPage: 10,
+  categories: [LocalOfferTaxonomy],
+  setCategories: () => {},
+  isLoading: false,
+};
+
+export const ExampleDirectoryDocumentListError = Template.bind({});
+ExampleDirectoryDocumentListError.args = {
+  isError: true,
+  directoryPath: '/directory/local-offer',
+  documents: [],
+  search: 'Example',
+  setSearch: () => {},
+  totalResults: 0,
+  pageNumber: 1,
+  setPageNumber: () => {},
+  perPage: 10,
+  categories: [],
+  setCategories: () => {},
+  isLoading: false,
+};

--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.test.tsx
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.test.tsx
@@ -43,4 +43,14 @@ describe('Directory Document List Component', () => {
     fireEvent.change(search, { target: { value: 'schools' } });
     expect(directoryLink).toHaveAttribute('href', '/directory/local-offer?search=schools');
   });
+
+  it('should display the error message when error occurs', () => {
+    props.isError = true;
+    props.documents = [];
+
+    const { getByTestId } = renderComponent();
+    const component = getByTestId('DirectoryDocumentList');
+
+    expect(component).toHaveTextContent('Sorry, there was a problem fetching results. Please try again later.');
+  });
 });

--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.tsx
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.tsx
@@ -12,6 +12,7 @@ import FileDownload from '../../components/FileDownload/FileDownload';
 import LoadingSpinner from '../../components/LoadingSpinner/LoadingSpinner';
 import Pagination from '../../components/Pagination/Pagination';
 import Button from '../../components/Button/Button';
+import { AlertBannerService } from '../../structure/PageStructures';
 
 const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps> = ({
   directoryPath,
@@ -25,6 +26,7 @@ const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps>
   categories,
   setCategories,
   isLoading = false,
+  isError = false,
 }) => {
   const [searchTerm, setSearchTerm] = useState(search);
 
@@ -135,7 +137,13 @@ const DirectoryDocumentList: React.FunctionComponent<DirectoryDocumentListProps>
         </Column>
         <Column small="full" medium="two-thirds" large="two-thirds">
           <Row>
-            {isLoading ? (
+            {isError ? (
+              <Column small="full" medium="full" large="full">
+                <AlertBannerService>
+                  <p>Sorry, there was a problem fetching results. Please try again later.</p>
+                </AlertBannerService>
+              </Column>
+            ) : isLoading ? (
               <Styles.LoadingContainer>
                 <LoadingSpinner />
                 <p>Loading</p>

--- a/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.types.ts
+++ b/src/library/directory/DirectoryDocumentList/DirectoryDocumentList.types.ts
@@ -58,6 +58,11 @@ export interface DirectoryDocumentListProps {
    * Is the data loading
    */
   isLoading: boolean;
+
+  /**
+   * Is the component in error state
+   */
+  isError?: boolean;
 }
 
 export interface DirectoryDocument {

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
@@ -86,3 +86,18 @@ DirectoryServiceNoResults.args = {
   ageInMonths: true,
   hasDocuments: true,
 };
+
+export const DirectoryServiceError = Template.bind({});
+DirectoryServiceError.args = {
+  isError: true,
+  services: [],
+  totalResults: 0,
+  categories: ExampleDirectoryCategories,
+  pageNumber: 1,
+  perPage: 5,
+  directoryPath: '/directory/local-offer',
+  shortListPath: '/directory/local-offer/short-list',
+  customTaxonomyFilters: ['facilities', 'language'],
+  ageInMonths: true,
+  hasDocuments: true,
+};

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
@@ -177,4 +177,14 @@ describe('Test Component', () => {
 
     expect(component).toHaveTextContent('12 months to 5 years');
   });
+
+  it('should display the error message when error occurs', () => {
+    props.isError = true;
+    props.services = [];
+
+    const { getByTestId } = renderComponent();
+    const component = getByTestId('DirectoryServiceList');
+
+    expect(component).toHaveTextContent('Sorry, there was a problem fetching results. Please try again later.');
+  });
 });

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -20,6 +20,7 @@ import { ThemeContext } from 'styled-components';
 import { transformSnippet, transformAge } from '../DirectoryService/DirectoryServiceTransform';
 import RadioCheckboxInput from '../../components/RadioCheckboxInput/RadioCheckboxInput';
 import Button from '../../components/Button/Button';
+import { AlertBannerService } from '../../structure/PageStructures';
 
 const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> = ({
   directoryPath,
@@ -45,6 +46,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
   isLoading = false,
   ageInMonths = false,
   hasDocuments = false,
+  isError = false,
 }) => {
   const [accordions, setAccordions] = useLocalStorage(`${directoryPath.replace(/\//g, '')}-accordion`, []);
   const [openAll, setOpenAll] = useLocalStorage(`${directoryPath.replace(/\//g, '')}-accordion-all`, true);
@@ -348,7 +350,13 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
         </Column>
         <Column small="full" medium="two-thirds" large="two-thirds">
           <Row>
-            {isLoading ? (
+            {isError ? (
+              <Column small="full" medium="full" large="full">
+                <AlertBannerService>
+                  <p>Sorry, there was a problem fetching results. Please try again later.</p>
+                </AlertBannerService>
+              </Column>
+            ) : isLoading ? (
               <Styles.LoadingContainer>
                 <LoadingSpinner />
                 <p>Loading</p>

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.types.ts
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.types.ts
@@ -116,6 +116,11 @@ export interface DirectoryServiceListProps {
    * Does the directory have documents?
    */
   hasDocuments?: boolean;
+
+  /**
+   * Is the component in error state
+   */
+  isError?: boolean;
 }
 
 export interface DirectoryCategory {


### PR DESCRIPTION
Previously the error state was ignored and just displayed no results. This adds an error message to the DirectoryDocumentList and the DirectoryServiceList components when the isError prop is true. 

## Testing
- Checkout this branch and run `npm run dev`
- View the stories for DirectoryDocumentList and DirectoryServiceList and there is now a story for error state
- Manually run tests with `npm run test`

## Frontend testing
- Run `yalc publish` and then go to the frontend and run `yalc add northants-design-system && yarn install && yarn dev`
- In the frontend, update src/DirectoryPages/DirectoryPage/index.ts and add 'error' in line 182 `const { loading, error, data } = useQuery(ServicesQuery, `
- Pass in isError prop to the DirectoryServiceList component `isError={!!error}` (this is because error is not true when it exists, it's `ApolloError` type). 
- Stop your local container for open referral
- Visit both the local offer and fis directory search pages and it should now display the error message. 
- Start the open referral container again then refresh the directory search pages. Error message should be gone and the results displaying once more. Ensure loading state still shows as expected. 