### PR TITLE
Add button to accept cookies from the static map

### DIFF
--- a/src/library/components/StaticMap/StaticMap.styles.js
+++ b/src/library/components/StaticMap/StaticMap.styles.js
@@ -12,3 +12,26 @@ export const Message = styled.div`
   background-color: ${(props) => props.theme.theme_vars.colours.focus};
   padding: ${(props) => props.theme.theme_vars.spacingSizes.medium};
 `;
+
+export const Cookies = styled.button`
+  outline: none;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  font-size: ${(props) => props.theme.theme_vars.fontSizes.small};
+  color: ${(props) => props.theme.theme_vars.colours.action};
+  text-decoration: underline;
+  ${(props) => props.theme.theme_vars.linkStyles}
+
+  &:hover {
+    ${(props) => props.theme.linkStylesHover}
+  }
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus}
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
+  }
+`;

--- a/src/library/components/StaticMap/StaticMap.tsx
+++ b/src/library/components/StaticMap/StaticMap.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StaticMapProps } from './StaticMap.types';
 import * as Styles from './StaticMap.styles';
+import { AcceptCookies } from '../../structure/CookieBanner/CookieBanner';
 
 /**
  * A static Google map with optional markers
@@ -28,7 +29,9 @@ const StaticMap: React.FunctionComponent<StaticMapProps> = ({
   return (
     <Styles.Container data-testid="StaticMap">
       <Styles.Message>
-        <span>To interact with the map, you need to accept cookies.</span>
+        <span>
+          To interact with the map, you need to <Styles.Cookies onClick={AcceptCookies}>accept cookies</Styles.Cookies>.
+        </span>
       </Styles.Message>
       <Styles.MapImage
         src={`https://maps.googleapis.com/maps/api/staticmap?center=${centre}&size=${size}&zoom=${zoom}&maptype=${mapType}${markerPath}&key=${apiKey}`}

--- a/src/library/structure/CookieBanner/CookieBanner.tsx
+++ b/src/library/structure/CookieBanner/CookieBanner.tsx
@@ -6,6 +6,34 @@ import { cookieName, getCookie } from './../../helpers/cookies';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
+export const AcceptCookies = () => {
+  let date = new Date();
+  // Cookie is valid 1 year
+  date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000);
+  // NB cookie created is actually cookie expiry - safer to minus a year from the value in calculations than change it.
+  const cookie = {
+    bannerDismissed: true,
+    cookiesAccepted: true,
+    cookiesAcceptedConfirmationBanner: false,
+    cookieCreated: date.toUTCString(),
+  };
+  document.cookie = `${cookieName}=${JSON.stringify(cookie)};expires=${date.toUTCString()};path=/`;
+  location.reload(); // reload to load the updated cookies
+};
+
+export const RejectCookies = () => {
+  let date = new Date();
+  // Cookie is valid 1 year
+  date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000);
+  const cookie = {
+    bannerDismissed: true,
+    cookiesAccepted: false,
+    cookiesAcceptedConfirmationBanner: false,
+    cookieCreated: date.toUTCString(),
+  };
+  document.cookie = `${cookieName}=${JSON.stringify(cookie)};expires=${date.toUTCString()};path=/`;
+};
+
 const CookieBanner: React.FunctionComponent<CookieBannerProps> = ({
   title,
   paragraph,
@@ -69,28 +97,10 @@ const CookieBanner: React.FunctionComponent<CookieBannerProps> = ({
   };
 
   const toggleCookie = (accepted) => {
-    let cookie = {};
-    let date = new Date();
-    // Cookie is valid 1 year
-    date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000);
     if (accepted === true) {
-      // NB cookie created is actually cookie expiry - safer to minus a year from the value in calculations than change it.
-      cookie = {
-        bannerDismissed: true,
-        cookiesAccepted: true,
-        cookiesAcceptedConfirmationBanner: false,
-        cookieCreated: date.toUTCString(),
-      };
-      document.cookie = `${cookieName}=${JSON.stringify(cookie)};expires=${date.toUTCString()};path=/`;
-      location.reload(); // reload to load the cookiesss
+      AcceptCookies();
     } else {
-      cookie = {
-        bannerDismissed: true,
-        cookiesAccepted: false,
-        cookiesAcceptedConfirmationBanner: false,
-        cookieCreated: date.toUTCString(),
-      };
-      document.cookie = `${cookieName}=${JSON.stringify(cookie)};expires=${date.toUTCString()};path=/`;
+      RejectCookies();
       setShowCookieBanner(false);
       setShowCookiesRejectedBanner(true);
     }


### PR DESCRIPTION
Add a button that allows users to accept cookies on the static map, so that users can choose to interact with a map instead of seeing the static map only. 

- Updated cookie banner to export the Accept and Reject cookies methods
- Update static map to use the accept cookies method

## Testing
- Run `npm run dev` and then clear your cookies for localhost
- Visit the static map and press `accept cookies`. The page should reload.
- Check your cookies and there should now be a cookie with the name `fn-cookie` with an expiry date set to a years time. 

## Frontend testing
- Run `yalc publish` and then in the frontend run `yalc add northants-design-system && yarn install && yarn dev`
- Visit the directory page and clear your cookies
- The static map should show when you press Show Map. 
- Click the `accept cookies` button in the static map message.
- The page should reload and the cookies should now be accepted and the interactive map should now show when you click Show Map. 