### PR TITLE
Add costs and addresses to the DirectoryShortlist

### DIFF
--- a/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.tsx
+++ b/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.tsx
@@ -5,6 +5,7 @@ import {
   DirectoryShortListProviderProps,
   ShortListProps,
 } from './DirectoryShortListProvider.types';
+import { PhysicalAddressProps } from '../../directory/DirectoryService/DirectoryService.types';
 
 const DirectoryShortListContext = createContext<DirectoryShortListContextType>({});
 
@@ -20,7 +21,8 @@ export const DirectoryShortListProvider: React.FunctionComponent<DirectoryShortL
     snippet?: string,
     email?: string,
     website?: string,
-    phone?: string
+    phone?: string,
+    addresses?: PhysicalAddressProps[]
   ) => {
     const updatedFavourites: ShortListProps[] = [...favourites];
 
@@ -35,6 +37,7 @@ export const DirectoryShortListProvider: React.FunctionComponent<DirectoryShortL
         email: email,
         website: website,
         phone: phone,
+        addresses: addresses,
       });
     }
 

--- a/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.tsx
+++ b/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.tsx
@@ -22,7 +22,8 @@ export const DirectoryShortListProvider: React.FunctionComponent<DirectoryShortL
     email?: string,
     website?: string,
     phone?: string,
-    addresses?: PhysicalAddressProps[]
+    addresses?: PhysicalAddressProps[],
+    fees?: string
   ) => {
     const updatedFavourites: ShortListProps[] = [...favourites];
 
@@ -38,6 +39,7 @@ export const DirectoryShortListProvider: React.FunctionComponent<DirectoryShortL
         website: website,
         phone: phone,
         addresses: addresses,
+        fees: fees,
       });
     }
 

--- a/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.types.ts
+++ b/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.types.ts
@@ -25,7 +25,8 @@ export interface DirectoryShortListContextType {
     email?: string,
     website?: string,
     phone?: string,
-    addresses?: PhysicalAddressProps[]
+    addresses?: PhysicalAddressProps[],
+    fees?: string
   ) => void;
   isFavourite?: (id: string) => boolean;
 }
@@ -65,4 +66,9 @@ export interface ShortListProps {
    * The optional addresses
    */
   addresses?: PhysicalAddressProps[];
+
+  /**
+   * The optional fees for the service
+   */
+  fees?: string;
 }

--- a/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.types.ts
+++ b/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.types.ts
@@ -1,4 +1,5 @@
 import React, { SetStateAction, Dispatch } from 'react';
+import { PhysicalAddressProps } from '../../directory/DirectoryService/DirectoryService.types';
 
 export interface DirectoryShortListProviderProps {
   /**
@@ -23,7 +24,8 @@ export interface DirectoryShortListContextType {
     snippet: string,
     email?: string,
     website?: string,
-    phone?: string
+    phone?: string,
+    addresses?: PhysicalAddressProps[]
   ) => void;
   isFavourite?: (id: string) => boolean;
 }
@@ -58,4 +60,9 @@ export interface ShortListProps {
    * The optional phone number
    */
   phone?: string;
+
+  /**
+   * The optional addresses
+   */
+  addresses?: PhysicalAddressProps[];
 }

--- a/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.tsx
+++ b/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.tsx
@@ -13,13 +13,14 @@ const DirectoryAddToShortList: React.FunctionComponent<DirectoryAddToShortListPr
   email,
   website,
   phone,
+  addresses,
 }) => {
   const { toggleFavourites: toggleFavourites, isFavourite: isFavourite } = useDirectoryShortListContext();
   const themeContext = useContext(ThemeContext);
   const favourite = isFavourite(id);
   return (
     <Styles.AddToShortlist
-      onClick={(e) => toggleFavourites(id, name, snippet, email, website, phone)}
+      onClick={(e) => toggleFavourites(id, name, snippet, email, website, phone, addresses)}
       data-testid="DirectoryAddToShortList"
       favourite={favourite}
     >

--- a/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.tsx
+++ b/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.tsx
@@ -14,13 +14,14 @@ const DirectoryAddToShortList: React.FunctionComponent<DirectoryAddToShortListPr
   website,
   phone,
   addresses,
+  fees,
 }) => {
   const { toggleFavourites: toggleFavourites, isFavourite: isFavourite } = useDirectoryShortListContext();
   const themeContext = useContext(ThemeContext);
   const favourite = isFavourite(id);
   return (
     <Styles.AddToShortlist
-      onClick={(e) => toggleFavourites(id, name, snippet, email, website, phone, addresses)}
+      onClick={(e) => toggleFavourites(id, name, snippet, email, website, phone, addresses, fees)}
       data-testid="DirectoryAddToShortList"
       favourite={favourite}
     >

--- a/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.types.ts
+++ b/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.types.ts
@@ -1,3 +1,5 @@
+import { PhysicalAddressProps } from '../DirectoryService/DirectoryService.types';
+
 export interface DirectoryAddToShortListProps {
   /**
    * The unique identifier
@@ -28,4 +30,9 @@ export interface DirectoryAddToShortListProps {
    * The optional phone number
    */
   phone?: string;
+
+  /**
+   * The optional addresses
+   */
+  addresses?: PhysicalAddressProps[];
 }

--- a/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.types.ts
+++ b/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.types.ts
@@ -35,4 +35,9 @@ export interface DirectoryAddToShortListProps {
    * The optional addresses
    */
   addresses?: PhysicalAddressProps[];
+
+  /**
+   * The optional fees for the service
+   */
+  fees?: string;
 }

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -89,6 +89,9 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
                     email={email}
                     website={url}
                     phone={contacts?.[0]?.phones?.flatMap((phone) => phone.number).join(', ')}
+                    addresses={service_at_locations.flatMap((location) => {
+                      return location.physical_addresses;
+                    })}
                   />
                 </Styles.ShortListLinks>
               )}

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -92,6 +92,7 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
                     addresses={service_at_locations.flatMap((location) => {
                       return location.physical_addresses;
                     })}
+                    fees={fees}
                   />
                 </Styles.ShortListLinks>
               )}

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -452,6 +452,9 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                               email={service.email}
                               website={service.url}
                               phone={service.contacts?.[0]?.phones?.flatMap((phone) => phone.number).join(', ')}
+                              addresses={service.service_at_locations?.flatMap((location) => {
+                                return location.physical_addresses;
+                              })}
                             />
                           </Column>
                         </Row>

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -455,6 +455,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                               addresses={service.service_at_locations?.flatMap((location) => {
                                 return location.physical_addresses;
                               })}
+                              fees={service.fees}
                             />
                           </Column>
                         </Row>

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
@@ -108,3 +108,8 @@ export const AddContainer = styled.div`
     justify-content: flex-end;
   }
 `;
+
+export const AddressTitle = styled.p`
+  font-weight: bold;
+  margin-top: ${(props) => props.theme.theme_vars.spacingSizes.medium};
+`;

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
@@ -109,7 +109,7 @@ export const AddContainer = styled.div`
   }
 `;
 
-export const AddressTitle = styled.p`
+export const SubTitle = styled.p`
   font-weight: bold;
   margin-top: ${(props) => props.theme.theme_vars.spacingSizes.medium};
 `;

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
@@ -53,9 +53,15 @@ const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ 
                       </Column>
                       <Column small="full" medium="full" large="one-half">
                         <div>{favourite.snippet}</div>
+                        {favourite.fees && (
+                          <div>
+                            <Styles.SubTitle>Cost</Styles.SubTitle>
+                            <p>{favourite.fees}</p>
+                          </div>
+                        )}
                         {favourite.addresses?.length > 0 && (
                           <div>
-                            <Styles.AddressTitle>Address</Styles.AddressTitle>
+                            <Styles.SubTitle>Address</Styles.SubTitle>
                             <ul>
                               {favourite.addresses.map((address) => (
                                 <li key={address.id}>

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
@@ -8,6 +8,7 @@ import Column from '../../components/Column/Column';
 import SummaryList from '../../components/SummaryList/SummaryList';
 import { transformService } from '../DirectoryService/DirectoryServiceTransform';
 import QRCode from 'react-qr-code';
+import Heading from '../../components/Heading/Heading';
 
 const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ directoryPath }) => {
   const {
@@ -52,6 +53,20 @@ const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ 
                       </Column>
                       <Column small="full" medium="full" large="one-half">
                         <div>{favourite.snippet}</div>
+                        {favourite.addresses?.length > 0 && (
+                          <div>
+                            <Styles.AddressTitle>Address</Styles.AddressTitle>
+                            <ul>
+                              {favourite.addresses.map((address) => (
+                                <li key={address.id}>
+                                  {Object.values(address)
+                                    .filter((item) => item !== '' && item !== address.id)
+                                    .join(',')}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
                       </Column>
                       <Column small="full" medium="full" large="one-half">
                         <SummaryList
@@ -68,6 +83,7 @@ const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ 
                             email={favourite.email}
                             website={favourite.website}
                             phone={favourite.phone}
+                            addresses={favourite.addresses}
                           />
                         </Styles.AddContainer>
                       </Column>

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
@@ -81,7 +81,9 @@ const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ 
                           terms={transformService(favourite.email, favourite.website, favourite.phone)}
                           hasMargin={false}
                         />
-                        <SummaryList terms={[{ term: 'Cost', detail: favourite.fees }]} hasMargin={false} />
+                        {favourite.fees && (
+                          <SummaryList terms={[{ term: 'Cost', detail: favourite.fees }]} hasMargin={false} />
+                        )}
                       </Column>
                       <Column small="full" medium="full" large="full">
                         <Styles.AddContainer>

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
@@ -53,24 +53,26 @@ const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ 
                       </Column>
                       <Column small="full" medium="full" large="one-half">
                         <div>{favourite.snippet}</div>
-                        {favourite.fees && (
-                          <div>
-                            <Styles.SubTitle>Cost</Styles.SubTitle>
-                            <p>{favourite.fees}</p>
-                          </div>
-                        )}
                         {favourite.addresses?.length > 0 && (
                           <div>
                             <Styles.SubTitle>Address</Styles.SubTitle>
-                            <ul>
-                              {favourite.addresses.map((address) => (
-                                <li key={address.id}>
-                                  {Object.values(address)
-                                    .filter((item) => item !== '' && item !== address.id)
-                                    .join(',')}
-                                </li>
-                              ))}
-                            </ul>
+                            {favourite.addresses?.length === 1 ? (
+                              <p>
+                                {Object.values(favourite.addresses[0])
+                                  .filter((item) => item !== '' && item !== favourite.addresses[0].id)
+                                  .join(', ')}
+                              </p>
+                            ) : (
+                              <ul>
+                                {favourite.addresses.map((address) => (
+                                  <li key={address.id}>
+                                    {Object.values(address)
+                                      .filter((item) => item !== '' && item !== address.id)
+                                      .join(', ')}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
                           </div>
                         )}
                       </Column>
@@ -79,6 +81,7 @@ const DirectoryShortList: React.FunctionComponent<DirectoryShortListProps> = ({ 
                           terms={transformService(favourite.email, favourite.website, favourite.phone)}
                           hasMargin={false}
                         />
+                        <SummaryList terms={[{ term: 'Cost', detail: favourite.fees }]} hasMargin={false} />
                       </Column>
                       <Column small="full" medium="full" large="full">
                         <Styles.AddContainer>


### PR DESCRIPTION
Add address(es) to the shortlist. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Directory/DirectoryShortList and clear all favourites. 
- View the Directory/DirectoryServiceList and add a service as a favourite
- View the Directory/DirectoryShortList again and it should now show the address for the service

## Frontend Testing
- Run `yalc publish` then in the frontend run `yalc add northants-design-system && yarn install && yarn dev`
- View a directory shortlist page and clear your favourites
- View a directory search page and then add a service with an address as a favourite
- View the shortlist and the address should now show
- Try the same with a service without any addresses to ensure the shortlist functionality still works as expected