### PR TITLE
Update help text on directory postcode search

### DIFF
--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -218,7 +218,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                 </Column>
                 <Column small="full" medium="one-half" large="one-third">
                   <Styles.Label htmlFor="postcode">Postcode (optional)</Styles.Label>
-                  <HintText text="Enter a postcode" />
+                  <HintText text="Enter a postcode to see results within 2 miles" />
                   <Input
                     name="postcode"
                     type="text"


### PR DESCRIPTION
Make the help text for the postcode search more informative to explain to users that it filters results to within 2 miles of the postcode that has been entered. 

Part of an initial fix for FIS-53 (which requires further development). 

## Testing
- Checkout this branch and run `npm run dev` and view the Directory Service List component
- Check the updated help text for the postcode search