### PR TITLE
Format directory age in years an months when relevant

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.test.tsx
@@ -126,6 +126,18 @@ describe('Directory Service', () => {
     expect(component).toHaveTextContent('Suitable for ages from 0 to 18 years');
   });
 
+  it('should show the age in years and months when not exactly a year', () => {
+    props.eligibilitys[0].minimum_age = 24;
+    props.eligibilitys[0].maximum_age = 47;
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('DirectoryService');
+
+    expect(component).toHaveTextContent('Age range');
+    expect(component).toHaveTextContent('Suitable for ages from 24 months to 3 years and 11 months');
+  });
+
   it('should show the opening hours', () => {
     const { getByTestId, getByText } = renderComponent();
     const component = getByTestId('DirectoryService');

--- a/src/library/directory/DirectoryService/DirectoryServiceTransform.test.tsx
+++ b/src/library/directory/DirectoryService/DirectoryServiceTransform.test.tsx
@@ -1,0 +1,23 @@
+import { transformAge } from './DirectoryServiceTransform';
+
+describe('DirectoryServiceTransform', () => {
+  describe('transformAge', () => {
+    const ageDataSet = [
+      { age: 25, ageInMonths: false, expected: '25 years' },
+      { age: 35, ageInMonths: true, expected: '35 months' },
+      { age: 36, ageInMonths: true, expected: '36 months' },
+      { age: 37, ageInMonths: true, expected: '3 years and 1 month' },
+      { age: 38, ageInMonths: true, expected: '3 years and 2 months' },
+      { age: 0, ageInMonths: true, expected: '0' },
+      { age: 47, ageInMonths: true, expected: '3 years and 11 months' },
+      { age: 48, ageInMonths: true, expected: '4 years' },
+    ];
+
+    it.each(ageDataSet)(
+      'should return the correctly formatted age ($age, $ageInMonths, $expected)',
+      ({ age, ageInMonths, expected }) => {
+        expect(transformAge(age, ageInMonths)).toBe(expected);
+      }
+    );
+  });
+});

--- a/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
+++ b/src/library/directory/DirectoryService/DirectoryServiceTransform.ts
@@ -198,13 +198,16 @@ export const transformTaxonomies = (service_taxonomys: ServiceTaxonomy[], taxono
   return details;
 };
 
-export const transformAge = (age: number, ageInMonths: boolean = false) => {
+export const transformAge = (age: number, ageInMonths: boolean = false): string => {
   if (age === 0) {
-    return age;
+    return age.toString();
   }
   if (ageInMonths) {
     if (age > 36) {
-      return Math.ceil(age / 12) + ' years';
+      if (age % 12 === 0) {
+        return Math.ceil(age / 12) + ' years';
+      }
+      return Math.floor(age / 12) + ' years and ' + (age % 12) + (age % 12 === 1 ? ' month' : ' months');
     }
     return `${age} months`;
   }

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
@@ -48,9 +48,9 @@ export const ExampleDirectoryServiceList = Template.bind({});
 ExampleDirectoryServiceList.args = {
   services: [
     { ...ExampleService, ...{ id: 'abc123' } },
-    { ...ExampleService, ...{ id: 'abc124' } },
-    { ...ExampleService, ...{ id: 'abc125' } },
-    { ...ExampleService, ...{ id: 'abc126' } },
+    { ...ExampleService, ...{ id: 'abc124', eligibilitys: [{ minimum_age: 47, maximum_age: 60 }] } },
+    { ...ExampleService, ...{ id: 'abc125', eligibilitys: [{ minimum_age: 12, maximum_age: 37 }] } },
+    { ...ExampleService, ...{ id: 'abc126', eligibilitys: [{ minimum_age: 12, maximum_age: 38 }] } },
     { ...ExampleService, ...{ id: 'abc127' } },
   ],
   totalResults: 156,


### PR DESCRIPTION
- Update the transformAge function to show the months when it is not an exact age in years. 
- Added tests

## Testing
- Checkout this branch and run `npm run dev` and view the Directory Service List to test how the various ages appear.
- Under 36 months should still show as month
- Over 36 months but not an exact year should show the years and months. If it is 1 month it should show '1 month', but if it is more it should be plural, such as '2 months'
- Over 36 months and an exact year should show the years but not months
- Run the tests manually with `npm run test`