### PR TITLE
Inform user the search field is required

### DIFF
--- a/src/library/components/Autocomplete/Autocomplete.styles.js
+++ b/src/library/components/Autocomplete/Autocomplete.styles.js
@@ -109,3 +109,19 @@ export const AutocompleteSuggestionText = styled.span`
 export const AutocompleteSuggestionTextMatch = styled.span`
   font-weight: bold;
 `;
+
+export const LightErrorText = styled.p`
+  ${(props) => props.theme.fontStyles}
+  color: ${(props) => props.theme.theme_vars.colours.white};
+  font-weight: bold;
+  margin-bottom: 5px;
+  font-size: 14px;
+  font-size: 0.8rem;
+  line-height: 1.1;
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    font-size: 18px;
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+`;

--- a/src/library/components/Autocomplete/Autocomplete.tsx
+++ b/src/library/components/Autocomplete/Autocomplete.tsx
@@ -27,6 +27,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
   hasAdjacentButton = false,
   onSelect,
   onChange,
+  required = false,
 }) => {
   /**
    * We save the input value in state or we can't cope with leaving the input
@@ -131,6 +132,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
                   hasAdjacentButton: hasAdjacentButton,
                   size: size,
                 })}
+                aria-required={required ? 'true' : 'false'}
               />
             </div>
             {

--- a/src/library/components/Autocomplete/Autocomplete.tsx
+++ b/src/library/components/Autocomplete/Autocomplete.tsx
@@ -142,6 +142,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
                   size: size,
                 })}
                 aria-required={required ? 'true' : 'false'}
+                aria-invalid={isErrored ? 'true' : 'false'}
               />
             </div>
             {

--- a/src/library/components/Autocomplete/Autocomplete.tsx
+++ b/src/library/components/Autocomplete/Autocomplete.tsx
@@ -28,6 +28,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
   onSelect,
   onChange,
   required = false,
+  isLight = true,
 }) => {
   /**
    * We save the input value in state or we can't cope with leaving the input
@@ -119,7 +120,15 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
             <Styles.AutocompleteLabel {...getLabelProps()} hasHiddenLabel={hasHiddenLabel}>
               {labelText ? labelText : placeholder}
             </Styles.AutocompleteLabel>
-            {isErrored && errorText ? <ErrorText>{errorText}</ErrorText> : ''}
+            {isErrored && errorText && (
+              <>
+                {isLight ? (
+                  <ErrorText>{errorText}</ErrorText>
+                ) : (
+                  <Styles.LightErrorText>{errorText}</Styles.LightErrorText>
+                )}
+              </>
+            )}
             <div {...getRootProps(undefined, { suppressRefError: true })}>
               <Styles.AutocompleteTextInput
                 {...getInputProps({

--- a/src/library/components/Autocomplete/Autocomplete.tsx
+++ b/src/library/components/Autocomplete/Autocomplete.tsx
@@ -28,7 +28,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
   onSelect,
   onChange,
   required = false,
-  isLight = true,
+  hasLightBackground = true,
 }) => {
   /**
    * We save the input value in state or we can't cope with leaving the input
@@ -122,7 +122,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
             </Styles.AutocompleteLabel>
             {isErrored && errorText && (
               <>
-                {isLight ? (
+                {hasLightBackground ? (
                   <ErrorText>{errorText}</ErrorText>
                 ) : (
                   <Styles.LightErrorText>{errorText}</Styles.LightErrorText>

--- a/src/library/components/Autocomplete/Autocomplete.types.ts
+++ b/src/library/components/Autocomplete/Autocomplete.types.ts
@@ -88,4 +88,9 @@ export interface AutocompleteProps {
    * Is the field required?
    */
   required?: boolean;
+
+  /**
+   * Is the autocomplete on a dark background?
+   */
+  isLight?: boolean;
 }

--- a/src/library/components/Autocomplete/Autocomplete.types.ts
+++ b/src/library/components/Autocomplete/Autocomplete.types.ts
@@ -83,4 +83,9 @@ export interface AutocompleteProps {
    * Callback function for when input value changes
    */
   onChange?: (inputValue: string) => void;
+
+  /**
+   * Is the field required?
+   */
+  required?: boolean;
 }

--- a/src/library/components/Autocomplete/Autocomplete.types.ts
+++ b/src/library/components/Autocomplete/Autocomplete.types.ts
@@ -90,7 +90,7 @@ export interface AutocompleteProps {
   required?: boolean;
 
   /**
-   * Is the autocomplete on a dark background?
+   * Is the autocomplete on a light background?
    */
-  isLight?: boolean;
+  hasLightBackground?: boolean;
 }

--- a/src/library/structure/Searchbar/Searchbar.styles.js
+++ b/src/library/structure/Searchbar/Searchbar.styles.js
@@ -1,8 +1,8 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Container = styled.div`
-  ${props => props.theme.fontStyles}
-  width: calc(100% - ${ props => props.isLarge ? "5rem" : "3rem"});
+  ${(props) => props.theme.fontStyles}
+  width: calc(100% - ${(props) => (props.isLarge ? '5rem' : '3rem')});
 `;
 
 export const Label = styled.label`
@@ -27,41 +27,44 @@ export const InputWrapper = styled.div`
 export const Button = styled.button`
   position: absolute;
   top: 0;
-  right: ${ props => props.isLarge ? "-5rem" : "-3rem"};
+  right: ${(props) => (props.isLarge ? '-5rem' : '-3rem')};
   cursor: pointer;
   margin: 0;
-  padding: ${props => props.theme.theme_vars.spacingSizes.small};
-  background: ${props => props.isLight ? props.theme.theme_vars.colours.action : props.theme.theme_vars.colours.grey_darkest};
-  color: ${props => props.theme.theme_vars.colours.white};
+  margin-top: ${(props) => (props.isErrored ? '25px' : 0)};
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  background: ${(props) =>
+    props.isLight ? props.theme.theme_vars.colours.action : props.theme.theme_vars.colours.grey_darkest};
+  color: ${(props) => props.theme.theme_vars.colours.white};
   border: 1px solid transparent;
-  border-top-right-radius: calc(${props => props.theme.theme_vars.border_radius} * 2);
-  border-bottom-right-radius: calc(${props => props.theme.theme_vars.border_radius} * 2);
-  width: ${props => props.isLarge ? "5rem" : "3rem"};
+  border-top-right-radius: calc(${(props) => props.theme.theme_vars.border_radius} * 2);
+  border-bottom-right-radius: calc(${(props) => props.theme.theme_vars.border_radius} * 2);
+  width: ${(props) => (props.isLarge ? '5rem' : '3rem')};
   text-align: center;
-  height: ${ props => props.isLarge ? "2.9rem" : "2.28rem"};
-  @media screen and (min-width: ${ props => props.theme.theme_vars.breakpoints.m}) {
-    height: ${ props => props.isLarge ? "3.22rem" : "2.6rem"};
+  height: ${(props) => (props.isLarge ? '2.9rem' : '2.28rem')};
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    height: ${(props) => (props.isLarge ? '3.22rem' : '2.6rem')};
   }
 
   &:hover {
-    background: ${props => props.isLight? props.theme.theme_vars.colours.action_dark : props.theme.theme_vars.colours.black};
+    background: ${(props) =>
+      props.isLight ? props.theme.theme_vars.colours.action_dark : props.theme.theme_vars.colours.black};
   }
 
   &:focus {
     outline: none;
-    background: ${props => props.theme.theme_vars.colours.focus};
+    background: ${(props) => props.theme.theme_vars.colours.focus};
     svg {
-      path{
-        fill: ${props => props.theme.theme_vars.colours.black};
+      path {
+        fill: ${(props) => props.theme.theme_vars.colours.black};
       }
     }
   }
 
   &:active {
     transform: translateY(1px);
-    background-color: ${props => props.theme.theme_vars.colours.focus};
-    box-shadow: 0px -1px 0px 0px ${props => props.theme.theme_vars.colours.black};
-    border-top-color: ${props => props.theme.theme_vars.colours.black};
+    background-color: ${(props) => props.theme.theme_vars.colours.focus};
+    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black};
+    border-top-color: ${(props) => props.theme.theme_vars.colours.black};
     border-bottom-color: transparent;
   }
 `;

--- a/src/library/structure/Searchbar/Searchbar.test.tsx
+++ b/src/library/structure/Searchbar/Searchbar.test.tsx
@@ -1,26 +1,18 @@
-import React from "react";
-import {
-  render,
-  fireEvent,
-  getByPlaceholderText,
-  getByRole,
-  getByTestId,
-  waitFor,
-  queryByText,
-} from "@testing-library/react";
-import Searchbar from "./Searchbar";
-import { SearchbarProps } from "./Searchbar.types";
-import { ThemeProvider } from "styled-components";
-import { west_theme } from "../../../themes/theme_generator";
+import React from 'react';
+import { render, fireEvent, getByRole } from '@testing-library/react';
+import Searchbar from './Searchbar';
+import { SearchbarProps } from './Searchbar.types';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
 
-describe("Searchbar", () => {
+describe('Searchbar', () => {
   let component: HTMLElement;
   let searchInput: HTMLElement;
   let searchButton: HTMLElement;
 
   let props: SearchbarProps = {
-    suggestions: ["red", "reddish", "blue", "green", "orange", "grey", "black"],
-    placeholder: "Enter search text",
+    suggestions: ['red', 'reddish', 'blue', 'green', 'orange', 'grey', 'black'],
+    placeholder: 'Enter search text',
     minimumMatchLength: 2,
   };
 
@@ -33,47 +25,45 @@ describe("Searchbar", () => {
       );
 
     const { getByTestId, getByPlaceholderText } = renderComponent();
-    component = getByTestId("Searchbar");
-    searchInput = getByPlaceholderText("Enter search text");
-    searchButton = getByTestId("SearchButton");
+    component = getByTestId('Searchbar');
+    searchInput = getByPlaceholderText('Enter search text');
+    searchButton = getByTestId('SearchButton');
   });
 
-  it("should display the search bar", () => {
+  it('should display the search bar', () => {
     expect(component).toBeVisible();
   });
 
-  it("should display the 4 matching results in suggestions", () => {
-    fireEvent.change(searchInput, { target: { value: "re" } });
-    const listbox: HTMLElement = getByRole(component, "listbox");
+  it('should display the 4 matching results in suggestions', () => {
+    fireEvent.change(searchInput, { target: { value: 're' } });
+    const listbox: HTMLElement = getByRole(component, 'listbox');
 
     expect(listbox).toBeVisible();
     expect(listbox.children.length).toBe(4);
   });
 
-  it("should display the single matching result in suggestions", () => {
-    fireEvent.change(searchInput, { target: { value: "blue" } });
-    const listbox: HTMLElement = getByRole(component, "listbox");
+  it('should display the single matching result in suggestions', () => {
+    fireEvent.change(searchInput, { target: { value: 'blue' } });
+    const listbox: HTMLElement = getByRole(component, 'listbox');
 
     expect(listbox.children.length).toBe(1);
   });
 
-  it("should display the error state when no search term provided", () => {
+  it('should display the error state when no search term provided', () => {
     fireEvent.click(searchButton);
 
-    expect(searchInput).toHaveStyle(
-      `border: solid ${west_theme.theme_vars.colours.negative}`
-    );
+    expect(searchInput).toHaveStyle(`border: solid ${west_theme.theme_vars.colours.negative}`);
   });
 
-  it("should clear the error state when the user enters a search term", async () => {
+  it('should clear the error state when the user enters a search term', async () => {
     fireEvent.click(searchButton);
 
-    expect(searchInput).toHaveStyle(
-      `border: solid ${west_theme.theme_vars.colours.negative}`
-    );
+    expect(searchInput).toHaveStyle(`border: solid ${west_theme.theme_vars.colours.negative}`);
+    expect(component).toHaveTextContent('The search field is required.');
 
-    fireEvent.change(searchInput, { target: { value: "b" } });
+    fireEvent.change(searchInput, { target: { value: 'b' } });
 
-    expect(searchInput).toHaveStyle("border: solid #000000");
+    expect(searchInput).toHaveStyle('border: solid #000000');
+    expect(component).not.toHaveTextContent('The search field is required.');
   });
 });

--- a/src/library/structure/Searchbar/Searchbar.tsx
+++ b/src/library/structure/Searchbar/Searchbar.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect } from "react";
-import { SearchbarProps } from "./Searchbar.types";
-import * as Styles from "./Searchbar.styles";
-import { handleParams } from "./../../helpers/url-helpers.js";
-import SearchIcon from "../../components/icons/SearchIcon/SearchIcon";
-import { NewsArticleFilterFields } from "./../NewsArticleFilterAccordion/NewsArticleFilterAccordionText";
-import Autocomplete from "../../components/Autocomplete/Autocomplete";
+import React, { useState, useEffect } from 'react';
+import { SearchbarProps } from './Searchbar.types';
+import * as Styles from './Searchbar.styles';
+import { handleParams } from './../../helpers/url-helpers.js';
+import SearchIcon from '../../components/icons/SearchIcon/SearchIcon';
+import { NewsArticleFilterFields } from './../NewsArticleFilterAccordion/NewsArticleFilterAccordionText';
+import Autocomplete from '../../components/Autocomplete/Autocomplete';
 
 const Searchbar: React.FunctionComponent<SearchbarProps> = ({
-  placeholder = "Search",
+  placeholder = 'Search',
   isLight,
   isLarge,
-  searchTerm = "",
+  searchTerm = '',
   submitInfo,
-  id = "search",
+  id = 'search',
   suggestions = [],
   minimumMatchLength = 2,
   maximumMatchesShown = 5,
@@ -53,15 +53,12 @@ const Searchbar: React.FunctionComponent<SearchbarProps> = ({
       setSubmit(false);
 
       let submitParams = submitInfo.params;
-      if (
-        initialSearchTerm !== inputSearchTerm ||
-        !(NewsArticleFilterFields.search.queryParamKey in submitParams)
-      ) {
+      if (initialSearchTerm !== inputSearchTerm || !(NewsArticleFilterFields.search.queryParamKey in submitParams)) {
         submitParams = { ...submitParams, searchTerm: inputSearchTerm };
         let keyValueFormat = Object.keys(submitParams).map(function (key) {
           return { key, value: submitParams[key] };
         });
-        handleParams(submitInfo.postTo, keyValueFormat, ["page"]);
+        handleParams(submitInfo.postTo, keyValueFormat, ['page']);
       }
     },
     [submit, submitInfo, initialSearchTerm, inputSearchTerm, handleParams] // dependencies that this function relies upon
@@ -74,7 +71,7 @@ const Searchbar: React.FunctionComponent<SearchbarProps> = ({
   const handleSubmit = (event) => {
     if (event) event.preventDefault();
 
-    if (inputSearchTerm == "") {
+    if (inputSearchTerm == '') {
       if (!isErrored) {
         setIsErrored(true);
       }
@@ -107,12 +104,15 @@ const Searchbar: React.FunctionComponent<SearchbarProps> = ({
               hasAdjacentButton
               isErrored={isErrored}
               hasHiddenLabel={true}
+              required={true}
+              errorText="The search field is required."
             />
             <Styles.Button
               type="submit"
               value="Search"
               isLarge={isLarge}
               isLight={isLight}
+              isErrored={isErrored}
               data-testid="SearchButton"
             >
               <SearchIcon colourFill="#fff" />

--- a/src/library/structure/Searchbar/Searchbar.tsx
+++ b/src/library/structure/Searchbar/Searchbar.tsx
@@ -106,7 +106,7 @@ const Searchbar: React.FunctionComponent<SearchbarProps> = ({
               hasHiddenLabel={true}
               required={true}
               errorText="The search field is required."
-              isLight={isLight}
+              hasLightBackground={isLight}
             />
             <Styles.Button
               type="submit"

--- a/src/library/structure/Searchbar/Searchbar.tsx
+++ b/src/library/structure/Searchbar/Searchbar.tsx
@@ -106,6 +106,7 @@ const Searchbar: React.FunctionComponent<SearchbarProps> = ({
               hasHiddenLabel={true}
               required={true}
               errorText="The search field is required."
+              isLight={isLight}
             />
             <Styles.Button
               type="submit"


### PR DESCRIPTION
Two new accessibility issue has been flagged by Monsido for the search bar throughout the site:
- All form fields that are required are indicated to the user as required. (WCAG 2.0 - 3.3)
- All form submission error messages identify any empty required fields.

This PR adds the following:
- The [aria-required](https://www.w3.org/TR/WCAG20-TECHS/ARIA2.html) to the autocomplete input
- The error text when submitting an empty value

## Testing
- Checkout this branch and run `npm run dev`
- Visit the Pages -> Homepage and click on the search button. Error text should now display. Inspect the input and it should also now have `aria-required="true"`
- Visit the Pages -> Content page and do the same test
- Visit the Pages -> News landing page and do the same test for the search in the 'Search articles' accordion
- Run tests with `npm run test`