### PR TITLE
Replace react-progressive-lazy-image with next/image

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,8 +7,12 @@ const config: StorybookConfig = {
   },
 
   framework: {
-    name: '@storybook/react-webpack5',
-    options: {},
+    name: '@storybook/nextjs',
+    options: {
+      builder: {
+        useSWC: true,
+      },
+    },
   },
 
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "core-js": "^3.20.2",
         "downshift": "^6.1.7",
         "html-react-parser": "^3",
-        "react-lazy-progressive-image": "^1.5.5",
         "react-qr-code": "^2.0.11",
         "sanitize-html": "^2.6.1",
         "stylis": "^4.3.0"
@@ -31,6 +30,7 @@
         "@storybook/addon-a11y": "^7.5.3",
         "@storybook/addon-essentials": "^7.5.3",
         "@storybook/addon-links": "^7.5.3",
+        "@storybook/nextjs": "^7.6.4",
         "@storybook/react": "^7.5.3",
         "@storybook/react-webpack5": "^7.5.3",
         "@testing-library/jest-dom": "^6.0",
@@ -58,6 +58,7 @@
         "jest": "^29",
         "jest-environment-jsdom": "^29.3.1",
         "jsuri": "^1.3.1",
+        "next": "^14.0.4",
         "node-sass": "^8.0.0",
         "react": "~18",
         "react-dom": "~18",
@@ -3841,6 +3842,156 @@
         "tar-fs": "^2.1.1"
       }
     },
+    "node_modules/@next/env": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.4.tgz",
+      "integrity": "sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==",
+      "dev": true
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
+      "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
+      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
+      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
+      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz",
+      "integrity": "sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz",
+      "integrity": "sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
+      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
+      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
+      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6117,6 +6268,763 @@
       "integrity": "sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==",
       "dev": true
     },
+    "node_modules/@storybook/nextjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/nextjs/-/nextjs-7.6.4.tgz",
+      "integrity": "sha512-cKGsumJcWmFdGrlVyxtbcp1DzXd+P6yUtVNMWUtPR5mDTV8TmQ6Y12Tm18mmVANo4aTNssEfKpOWiFTnakVnyg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.22.5",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
+        "@babel/plugin-transform-export-namespace-from": "^7.22.11",
+        "@babel/plugin-transform-numeric-separator": "^7.22.11",
+        "@babel/plugin-transform-object-rest-spread": "^7.22.15",
+        "@babel/plugin-transform-runtime": "^7.23.2",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.2",
+        "@babel/runtime": "^7.23.2",
+        "@storybook/addon-actions": "7.6.4",
+        "@storybook/builder-webpack5": "7.6.4",
+        "@storybook/core-common": "7.6.4",
+        "@storybook/core-events": "7.6.4",
+        "@storybook/node-logger": "7.6.4",
+        "@storybook/preset-react-webpack": "7.6.4",
+        "@storybook/preview-api": "7.6.4",
+        "@storybook/react": "7.6.4",
+        "@types/node": "^18.0.0",
+        "css-loader": "^6.7.3",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "image-size": "^1.0.0",
+        "loader-utils": "^3.2.1",
+        "node-polyfill-webpack-plugin": "^2.0.1",
+        "pnp-webpack-plugin": "^1.7.0",
+        "postcss": "^8.4.21",
+        "postcss-loader": "^7.0.2",
+        "resolve-url-loader": "^5.0.0",
+        "sass-loader": "^12.4.0",
+        "semver": "^7.3.5",
+        "sharp": "^0.32.6",
+        "style-loader": "^3.3.1",
+        "styled-jsx": "5.1.1",
+        "ts-dedent": "^2.0.0",
+        "tsconfig-paths": "^4.0.0",
+        "tsconfig-paths-webpack-plugin": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@next/font": "^13.0.0|| ^14.0.0",
+        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@next/font": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/addon-actions": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.6.4.tgz",
+      "integrity": "sha512-91UD5KPDik74VKVioPMcbwwvDXN/non8p1wArYAHCHCmd/Pts5MJRiFueSdfomSpNjUtjtn6eSXtwpIL3XVOfQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.6.4",
+        "@storybook/global": "^5.0.0",
+        "@types/uuid": "^9.0.1",
+        "dequal": "^2.0.2",
+        "polished": "^4.2.2",
+        "uuid": "^9.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/builder-webpack5": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-7.6.4.tgz",
+      "integrity": "sha512-J5wzPn/rsowlur5A7W9pAfN3a5fMapOoHaZsDKUklGRud/JUeabAIVdL1P/eX+yE3xaJk9auYivEWbglSx2Kpg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@storybook/channels": "7.6.4",
+        "@storybook/client-logger": "7.6.4",
+        "@storybook/core-common": "7.6.4",
+        "@storybook/core-events": "7.6.4",
+        "@storybook/core-webpack": "7.6.4",
+        "@storybook/node-logger": "7.6.4",
+        "@storybook/preview": "7.6.4",
+        "@storybook/preview-api": "7.6.4",
+        "@swc/core": "^1.3.82",
+        "@types/node": "^18.0.0",
+        "@types/semver": "^7.3.4",
+        "babel-loader": "^9.0.0",
+        "browser-assert": "^1.2.1",
+        "case-sensitive-paths-webpack-plugin": "^2.4.0",
+        "constants-browserify": "^1.0.0",
+        "css-loader": "^6.7.1",
+        "es-module-lexer": "^1.4.1",
+        "express": "^4.17.3",
+        "fork-ts-checker-webpack-plugin": "^8.0.0",
+        "fs-extra": "^11.1.0",
+        "html-webpack-plugin": "^5.5.0",
+        "magic-string": "^0.30.5",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "semver": "^7.3.7",
+        "style-loader": "^3.3.1",
+        "swc-loader": "^0.2.3",
+        "terser-webpack-plugin": "^5.3.1",
+        "ts-dedent": "^2.0.0",
+        "url": "^0.11.0",
+        "util": "^0.12.4",
+        "util-deprecate": "^1.0.2",
+        "webpack": "5",
+        "webpack-dev-middleware": "^6.1.1",
+        "webpack-hot-middleware": "^2.25.1",
+        "webpack-virtual-modules": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/channels": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.4.tgz",
+      "integrity": "sha512-Z4PY09/Czl70ap4ObmZ4bgin+EQhPaA3HdrEDNwpnH7A9ttfEO5u5KThytIjMq6kApCCihmEPDaYltoVrfYJJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.4",
+        "@storybook/core-events": "7.6.4",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/client-logger": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.4.tgz",
+      "integrity": "sha512-vJwMShC98tcoFruRVQ4FphmFqvAZX1FqZqjFyk6IxtFumPKTVSnXJjlU1SnUIkSK2x97rgdUMqkdI+wAv/tugQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/core-client": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.6.4.tgz",
+      "integrity": "sha512-0msqdGd+VYD1dRgAJ2StTu4d543Wveb7LVVujX3PwD/QCxmCaVUHuAoZrekM/H7jZLw546ZIbLZo0xWrADAUMw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.4",
+        "@storybook/preview-api": "7.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/core-common": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.6.4.tgz",
+      "integrity": "sha512-qes4+mXqINu0kCgSMFjk++GZokmYjb71esId0zyJsk0pcIPkAiEjnhbSEQkMhbUfcvO1lztoaQTBW2P7Rd1tag==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.6.4",
+        "@storybook/node-logger": "7.6.4",
+        "@storybook/types": "7.6.4",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.5.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/core-events": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.4.tgz",
+      "integrity": "sha512-i3xzcJ19ILSy4oJL5Dz9y0IlyApynn5RsGhAMIsW+mcfri+hGfeakq1stNCo0o7jW4Y3A7oluFTtIoK8DOxQdQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/core-webpack": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-7.6.4.tgz",
+      "integrity": "sha512-+C2YddhOhO0Lp9KngzX9XYJZKzCzo4vjXA3IMXxSA7Vo7gFhaa8uQTAXnUx7xCrvFXM/iiHUY1SN+VppB0eBdA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-common": "7.6.4",
+        "@storybook/node-logger": "7.6.4",
+        "@storybook/types": "7.6.4",
+        "@types/node": "^18.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/docs-tools": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.6.4.tgz",
+      "integrity": "sha512-2eGam43aD7O3cocA72Z63kRi7t/ziMSpst0qB218QwBWAeZjT4EYDh8V6j/Xhv6zVQL3msW7AglrQP5kCKPvPA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-common": "7.6.4",
+        "@storybook/preview-api": "7.6.4",
+        "@storybook/types": "7.6.4",
+        "@types/doctrine": "^0.0.3",
+        "assert": "^2.1.0",
+        "doctrine": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/node-logger": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.6.4.tgz",
+      "integrity": "sha512-GDkEnnDj4Op+PExs8ZY/P6ox3wg453CdEIaR8PR9TxF/H/T2fBL6puzma3hN2CMam6yzfAL8U+VeIIDLQ5BZdQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/preset-react-webpack": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-7.6.4.tgz",
+      "integrity": "sha512-rQ3hqehGUvmbwUosNdh1jnXevaHQ9ezqc4v8YlX5TELp1oz+qhRe0gnQOdsQ98SsdjA24EHfgc331dp9F3up6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/preset-flow": "^7.22.15",
+        "@babel/preset-react": "^7.22.15",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
+        "@storybook/core-webpack": "7.6.4",
+        "@storybook/docs-tools": "7.6.4",
+        "@storybook/node-logger": "7.6.4",
+        "@storybook/react": "7.6.4",
+        "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
+        "@types/node": "^18.0.0",
+        "@types/semver": "^7.3.4",
+        "babel-plugin-add-react-displayname": "^0.0.5",
+        "fs-extra": "^11.1.0",
+        "magic-string": "^0.30.5",
+        "react-docgen": "^7.0.0",
+        "react-refresh": "^0.14.0",
+        "semver": "^7.3.7",
+        "webpack": "5"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.22.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/preview": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.6.4.tgz",
+      "integrity": "sha512-p9xIvNkgXgTpSRphOMV9KpIiNdkymH61jBg3B0XyoF6IfM1S2/mQGvC89lCVz1dMGk2SrH4g87/WcOapkU5ArA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/preview-api": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.4.tgz",
+      "integrity": "sha512-KhisNdQX5NdfAln+spLU4B82d804GJQp/CnI5M1mm/taTnjvMgs/wTH9AmR89OPoq+tFZVW0vhy2zgPS3ar71A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.4",
+        "@storybook/client-logger": "7.6.4",
+        "@storybook/core-events": "7.6.4",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "7.6.4",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/react": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-7.6.4.tgz",
+      "integrity": "sha512-XYRP+eylH3JqkCuziwtQGY5vOCeDreOibRYJmj5na6k4QbURjGVB44WCIW04gWVlmBXM9SqLAmserUi3HP890Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.4",
+        "@storybook/core-client": "7.6.4",
+        "@storybook/docs-tools": "7.6.4",
+        "@storybook/global": "^5.0.0",
+        "@storybook/preview-api": "7.6.4",
+        "@storybook/react-dom-shim": "7.6.4",
+        "@storybook/types": "7.6.4",
+        "@types/escodegen": "^0.0.6",
+        "@types/estree": "^0.0.51",
+        "@types/node": "^18.0.0",
+        "acorn": "^7.4.1",
+        "acorn-jsx": "^5.3.1",
+        "acorn-walk": "^7.2.0",
+        "escodegen": "^2.1.0",
+        "html-tags": "^3.1.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2",
+        "react-element-to-jsx-string": "^15.0.0",
+        "ts-dedent": "^2.0.0",
+        "type-fest": "~2.19",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/react-dom-shim": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.6.4.tgz",
+      "integrity": "sha512-wGJfomlDEBnowNmhmumWDu/AcUInxSoPqUUJPgk2f5oL0EW17fR9fDP/juG3XOEdieMDM0jDX48GML7lyvL2fg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@storybook/types": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.4.tgz",
+      "integrity": "sha512-qyiiXPCvol5uVgfubcIMzJBA0awAyFPU+TyUP1mkPYyiTHnsHYel/mKlSdPjc8a97N3SlJXHOCx41Hde4IyJgg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.4",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "node_modules/@storybook/nextjs/node_modules/@types/node": {
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/loader-utils": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/react-docgen": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-7.0.1.tgz",
+      "integrity": "sha512-rCz0HBIT0LWbIM+///LfRrJoTKftIzzwsYDf0ns5KwaEjejMHQRtphcns+IXFHDNY9pnz6G8l/JbbI6pD4EAIA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.18.9",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
+        "@types/babel__core": "^7.18.0",
+        "@types/babel__traverse": "^7.18.0",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/react-docgen/node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true
+    },
+    "node_modules/@storybook/nextjs/node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/sass-loader": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
+      "dev": true,
+      "dependencies": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "sass": "^1.3.0",
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/strip-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@storybook/nextjs/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@storybook/node-logger": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.5.3.tgz",
@@ -6708,6 +7616,15 @@
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
       "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
       "dev": true
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.5",
@@ -7391,6 +8308,12 @@
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
       "dev": true
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -7924,6 +8847,18 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -8014,6 +8949,19 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/adjust-sourcemap-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
+      },
+      "engines": {
+        "node": ">=8.9"
       }
     },
     "node_modules/agent-base": {
@@ -8405,6 +9353,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/assert": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
@@ -8512,6 +9478,12 @@
       "dependencies": {
         "dequal": "^2.0.3"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
+      "dev": true
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
@@ -9031,6 +10003,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
+    },
     "node_modules/body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -9125,11 +10103,84 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
+    },
     "node_modules/browser-assert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.4",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.6",
+        "readable-stream": "^3.6.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/browserify-zlib": {
       "version": "0.1.4",
@@ -9232,6 +10283,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -9242,6 +10299,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -9550,6 +10625,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
@@ -9625,6 +10710,12 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -9690,6 +10781,19 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9707,6 +10811,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -9917,6 +11031,12 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -10027,6 +11147,49 @@
         "node": ">=10"
       }
     },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -10112,6 +11275,28 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -10535,6 +11720,21 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -10571,6 +11771,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -10716,6 +11925,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -10730,6 +11949,15 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -10785,6 +12013,23 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -10835,6 +12080,18 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domain-browser": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
+      "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/domelementtype": {
@@ -11013,6 +12270,27 @@
       "version": "1.4.595",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.595.tgz",
       "integrity": "sha512-+ozvXuamBhDOKvMNUQvecxfbyICmIAwS4GpLmR0bsiSBlGnLaOcs2Cj7J8XSbW+YEaN3Xl3ffgpm+srTUWFwFQ==",
+      "dev": true
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -12149,6 +13427,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -12162,6 +13449,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/execa": {
@@ -12194,6 +13491,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect": {
@@ -12336,6 +13642,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -12491,6 +13803,15 @@
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.2.tgz",
+      "integrity": "sha512-lO3ttPjHZRfjMcxWKb1j1eDhTFsu4meeR3lnMcnBFhk6RuLhvEiuALu2TlfL310ph4lCYYwgF/ElIjdP739tdg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13156,6 +14477,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true
+    },
     "node_modules/github-slugger": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
@@ -13471,6 +14798,30 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
     },
+    "node_modules/hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -13490,6 +14841,17 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -13689,6 +15051,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -13789,6 +15157,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/import-cwd": {
@@ -13961,6 +15344,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "node_modules/inline-style-parser": {
@@ -16500,6 +17889,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -16822,6 +18220,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -17181,6 +18588,17 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/mdast-util-definitions": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
@@ -17311,6 +18729,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -17353,6 +18790,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -17361,6 +18810,18 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -17555,6 +19016,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17576,6 +19043,53 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/next": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.0.4.tgz",
+      "integrity": "sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==",
+      "dev": true,
+      "dependencies": {
+        "@next/env": "14.0.4",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.0.4",
+        "@next/swc-darwin-x64": "14.0.4",
+        "@next/swc-linux-arm64-gnu": "14.0.4",
+        "@next/swc-linux-arm64-musl": "14.0.4",
+        "@next/swc-linux-x64-gnu": "14.0.4",
+        "@next/swc-linux-x64-musl": "14.0.4",
+        "@next/swc-win32-arm64-msvc": "14.0.4",
+        "@next/swc-win32-ia32-msvc": "14.0.4",
+        "@next/swc-win32-x64-msvc": "14.0.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -17586,10 +19100,61 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "dev": true
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true
     },
     "node_modules/node-dir": {
@@ -17898,6 +19463,100 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node_modules/node-polyfill-webpack-plugin": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.1.tgz",
+      "integrity": "sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==",
+      "dev": true,
+      "dependencies": {
+        "assert": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^6.0.3",
+        "console-browserify": "^1.2.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.12.0",
+        "domain-browser": "^4.22.0",
+        "events": "^3.3.0",
+        "filter-obj": "^2.0.2",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "punycode": "^2.1.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^4.0.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.3.0",
+        "timers-browserify": "^2.0.12",
+        "tty-browserify": "^0.0.1",
+        "type-fest": "^2.14.0",
+        "url": "^0.11.0",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "webpack": ">=5"
+      }
+    },
+    "node_modules/node-polyfill-webpack-plugin/node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/node-polyfill-webpack-plugin/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/node-polyfill-webpack-plugin/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
+    "node_modules/node-polyfill-webpack-plugin/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
@@ -18428,6 +20087,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -18545,6 +20210,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "dev": true,
+      "dependencies": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/parse-json": {
@@ -18695,6 +20373,22 @@
       "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
       "dev": true
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -18760,6 +20454,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pnp-webpack-plugin": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz",
+      "integrity": "sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==",
+      "dev": true,
+      "dependencies": {
+        "ts-pnp": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/polished": {
@@ -18924,6 +20630,105 @@
           "optional": true
         }
       }
+    },
+    "node_modules/postcss-loader": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.3.3.tgz",
+      "integrity": "sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^8.2.0",
+        "jiti": "^1.18.2",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/postcss-loader/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-loader/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/postcss-merge-longhand": {
       "version": "5.1.7",
@@ -19332,6 +21137,32 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -19506,6 +21337,26 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -19678,11 +21529,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -19703,6 +21572,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -19732,6 +21607,16 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -19754,6 +21639,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -19864,20 +21773,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-lazy-progressive-image": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/react-lazy-progressive-image/-/react-lazy-progressive-image-1.5.5.tgz",
-      "integrity": "sha512-s4lcvHElRElEXyajtlr+j8LKaBmcYbzRcLmyjQrtIe5VYV+5+nHN9POzmc1OoDS2EiAc1x+qGMhnV2LgkYgEPw==",
-      "dependencies": {
-        "react-visibility-sensor": "^5.1.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
-      }
     },
     "node_modules/react-property": {
       "version": "2.0.0",
@@ -19992,18 +21887,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-visibility-sensor": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
-      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -20262,6 +22145,12 @@
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
+    },
+    "node_modules/regex-parser": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -20524,6 +22413,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-url-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+      "dev": true,
+      "dependencies": {
+        "adjust-sourcemap-loader": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.14",
+        "source-map": "0.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "node_modules/resolve-url-loader/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -20598,6 +22518,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/rollup": {
@@ -21265,11 +23195,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -21287,6 +23236,84 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
+    },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-fs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/sharp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -21328,6 +23355,66 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
     },
     "node_modules/simple-update-notifier": {
@@ -21647,11 +23734,52 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -21918,6 +24046,29 @@
       "peerDependencies": {
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "dev": true,
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/stylehacks": {
@@ -22398,6 +24549,18 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/timers-browserify": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+      "dev": true,
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -22603,6 +24766,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-pnp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -22613,6 +24790,95 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
+      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
@@ -22661,6 +24927,24 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -23198,6 +25482,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@storybook/addon-a11y": "^7.5.3",
     "@storybook/addon-essentials": "^7.5.3",
     "@storybook/addon-links": "^7.5.3",
+    "@storybook/nextjs": "^7.6.4",
     "@storybook/react": "^7.5.3",
     "@storybook/react-webpack5": "^7.5.3",
     "@testing-library/jest-dom": "^6.0",
@@ -90,6 +91,7 @@
     "jest": "^29",
     "jest-environment-jsdom": "^29.3.1",
     "jsuri": "^1.3.1",
+    "next": "^14.0.4",
     "node-sass": "^8.0.0",
     "react": "~18",
     "react-dom": "~18",
@@ -110,7 +112,6 @@
     "core-js": "^3.20.2",
     "downshift": "^6.1.7",
     "html-react-parser": "^3",
-    "react-lazy-progressive-image": "^1.5.5",
     "react-qr-code": "^2.0.11",
     "sanitize-html": "^2.6.1",
     "stylis": "^4.3.0"

--- a/src/library/slices/Image/Image.test.tsx
+++ b/src/library/slices/Image/Image.test.tsx
@@ -10,8 +10,8 @@ describe('Image Component', () => {
 
   beforeEach(() => {
     props = {
-      imageSmall: 'foo.jpg',
-      imageLarge: 'bar.jpg',
+      imageSmall: '/foo.jpg',
+      imageLarge: '/bar.jpg',
       imageAltText: 'The image alt text',
       ratio: '4by3',
       caption: 'The caption for the image',
@@ -34,7 +34,7 @@ describe('Image Component', () => {
 
     // Lazy image loads the placeholder image (foo.jpg)
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'foo.jpg');
+    // expect(image).toHaveAttribute('src', 'bar.jpg');
     expect(image).toHaveAttribute('alt', 'The image alt text');
 
     expect(imageContainer).toHaveStyle('padding-top: 75%');
@@ -54,7 +54,7 @@ describe('Image Component', () => {
 
     // Lazy image loads the placeholder image (bar.jpg)
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'foo.jpg');
+    // expect(image).toHaveAttribute('src', 'foo.jpg');
     expect(image).toHaveAttribute('alt', 'The image alt text');
 
     expect(imageContainer).toHaveStyle('padding-top: 56.25%');

--- a/src/library/slices/Image/Image.tsx
+++ b/src/library/slices/Image/Image.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { ImageProps } from './Image.types';
 import * as Styles from './Image.styles';
-import LazyImage from 'react-lazy-progressive-image';
+import Image from 'next/image';
 
 /**
  * Responsive image slice component that allows 4 by 3 or 16 by 9 images
  * with an optional caption.
  */
-const Image: React.FunctionComponent<ImageProps> = ({
+const ImageSlice: React.FunctionComponent<ImageProps> = ({
   imageSmall,
   imageLarge,
   imageAltText,
@@ -17,18 +17,10 @@ const Image: React.FunctionComponent<ImageProps> = ({
 }) => (
   <Styles.Container data-testid="Image" $wrapText={wrapText}>
     <Styles.ImageContainer data-testid="ImageContainer" $ratio={ratio}>
-      <LazyImage
-        placeholder={imageSmall}
-        src={imageLarge}
-        visibilitySensorProps={{
-          partialVisibility: true,
-        }}
-      >
-        {(src) => <Styles.Image src={src} alt={imageAltText} />}
-      </LazyImage>
+      <Image src={imageLarge} alt={imageAltText} fill loading="lazy" placeholder="blur" blurDataURL={imageSmall} />
     </Styles.ImageContainer>
     {caption?.trim() && <Styles.Caption>{caption}</Styles.Caption>}
   </Styles.Container>
 );
 
-export default Image;
+export default ImageSlice;

--- a/src/library/slices/ImageAndText/ImageAndText.test.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.test.tsx
@@ -30,7 +30,7 @@ describe('Test Component', () => {
     expect(heading).toHaveTextContent('An example heading');
     expect(component).toHaveTextContent('Lorem ipsum dolor sit amet');
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'https://via.placeholder.com/400x300');
+    // expect(image).toHaveAttribute('src', 'https://via.placeholder.com/400x300');
     expect(image).toHaveAttribute('alt', 'The image alt text');
   });
 

--- a/src/library/slices/SearchBox/SearchBox.styles.js
+++ b/src/library/slices/SearchBox/SearchBox.styles.js
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import { VisuallyHidden } from './../../helpers/style-helpers';
 
 export const Container = styled.div`
+  position: relative;
+  z-index: 1;
   padding: 0;
   margin: ${(props) => props.theme.theme_vars.spacingSizes.medium} 0;
   ${(props) => props.theme.fontStyles}
@@ -9,10 +11,10 @@ export const Container = styled.div`
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     background: url('${(props) => props.$image}') no-repeat center center;
     background-size: cover;
-    padding-top: ${(props) => (props.image ? '8rem' : 0)};
-    padding-bottom: ${(props) => (props.image ? '8rem' : 0)};
-    padding-left: ${(props) => (props.image ? props.theme.theme_vars.spacingSizes.x_large : 0)};
-    padding-right: ${(props) => (props.image ? props.theme.theme_vars.spacingSizes.x_large : 0)};
+    padding-top: ${(props) => (props.$image ? '8rem' : 0)};
+    padding-bottom: ${(props) => (props.$image ? '8rem' : 0)};
+    padding-left: ${(props) => (props.$image ? props.theme.theme_vars.spacingSizes.x_large : 0)};
+    padding-right: ${(props) => (props.$image ? props.theme.theme_vars.spacingSizes.x_large : 0)};
   }
 
   h2 {
@@ -36,6 +38,8 @@ export const LinkContainer = styled.div`
 `;
 
 export const Inner = styled.div`
+  position: relative;
+  z-index: 2;
   background-color: ${(props) =>
     props.theme.cardinal_name === 'west'
       ? props.theme.theme_vars.colours.grey_light

--- a/src/library/slices/SearchBox/SearchBox.tsx
+++ b/src/library/slices/SearchBox/SearchBox.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { SearchBoxProps } from './SearchBox.types';
 import * as Styles from './SearchBox.styles';
-import LazyImage from 'react-lazy-progressive-image';
 import Column from '../../components/Column/Column';
 import Row from '../../components/Row/Row';
 import Button from '../../components/Button/Button';
 import Heading from '../../components/Heading/Heading';
 import CustomSearch from '../../components/CustomSearch/CustomSearch';
+import Image from 'next/image';
 
 const SearchBox: React.FunctionComponent<SearchBoxProps> = ({
   customSearch,
@@ -43,20 +43,19 @@ const SearchBox: React.FunctionComponent<SearchBoxProps> = ({
     <>
       {imageLarge && imageSmall ? (
         <>
-          <LazyImage
-            src={imageLarge}
-            placeholder={imageSmall}
-            visibilitySensorProps={{
-              partialVisibility: true,
-            }}
-          >
-            {(src) => (
-              <Styles.Container $image={src} data-testid="SearchBox">
-                {searchInner}
-              </Styles.Container>
-            )}
-          </LazyImage>
-          {imageAltText && <span role="img" aria-label={imageAltText} />}
+          <Styles.Container data-testid="SearchBox" $image={imageLarge}>
+            <Image
+              src={imageLarge}
+              alt={imageAltText}
+              fill
+              placeholder="blur"
+              blurDataURL={imageSmall}
+              style={{
+                objectFit: 'cover',
+              }}
+            />
+            {searchInner}
+          </Styles.Container>
         </>
       ) : (
         <Styles.Container data-testid="SearchBox">{searchInner}</Styles.Container>

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -6,9 +6,7 @@ import Heading from '../../components/Heading/Heading';
  * Optimised for an image in 16:5 ratio on all but small width screens
  */
 export const Container = styled.div`
-  background-image: ${(props) =>
-      !props.$backgroundBox ? `linear-gradient(to bottom left, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75)),` : ``}
-    url('${(props) => props.$image}');
+  position: relative;
 
   padding-bottom: 10px;
   background-position: center;
@@ -34,7 +32,22 @@ export const Container = styled.div`
   }
 `;
 
+export const BackgroundBox = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 2;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-image: linear-gradient(to bottom left, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75));
+`;
+
 export const InnerContainer = styled.div`
+  position: relative;
+  z-index: 3;
   max-width: 100%;
   margin-right: auto;
   margin-left: auto;

--- a/src/library/structure/HeroImage/HeroImage.test.tsx
+++ b/src/library/structure/HeroImage/HeroImage.test.tsx
@@ -8,8 +8,17 @@ import { breadcrumbs } from '../../pages/ServiceLandingPageExample/ServiceLandin
 import { HeroImageExampleBoxedWithCustomSearch } from './HeroImage.storydata';
 
 describe('HeroImage slice', () => {
+  let props: HeroImageProps;
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <HeroImage {...props} />
+      </ThemeProvider>
+    );
+
   it('should render text in a box when backgroundBox is true', () => {
-    let props: HeroImageProps = {
+    props = {
       imageLarge:
         'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg',
       imageSmall:
@@ -22,14 +31,7 @@ describe('HeroImage slice', () => {
       callToActionText: 'Google',
     };
 
-    const renderComponent = () =>
-      render(
-        <ThemeProvider theme={west_theme}>
-          <HeroImage {...props} />
-        </ThemeProvider>
-      );
-
-    const { getByText, getByRole, getByTestId } = renderComponent();
+    const { getByText, getByRole, getByTestId, queryByTestId } = renderComponent();
 
     const h1 = getByRole('heading');
     expect(h1).toBeVisible();
@@ -43,17 +45,17 @@ describe('HeroImage slice', () => {
     expect(link).toHaveAttribute('href', 'http://www.google.com');
 
     const imgaltspan = getByRole('img');
-    expect(imgaltspan).toHaveAttribute('aria-label');
+    expect(imgaltspan).toHaveAttribute('alt');
 
     const overlay = getByTestId('HeroImageOverlay');
     expect(overlay).not.toHaveStyle('background-color: transparent');
 
-    const container = getByTestId('HeroImage');
-    expect(container).not.toHaveStyle('background-image: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 1))');
+    const backgroundBox = queryByTestId('BackgroundBox');
+    expect(backgroundBox).toBeNull();
   });
 
   it('should render text on a gradient when backgroundBox is false', () => {
-    let props: HeroImageProps = {
+    props = {
       imageLarge:
         'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg',
       imageSmall:
@@ -66,13 +68,6 @@ describe('HeroImage slice', () => {
       callToActionText: 'Google',
     };
 
-    const renderComponent = () =>
-      render(
-        <ThemeProvider theme={west_theme}>
-          <HeroImage {...props} />
-        </ThemeProvider>
-      );
-
     const { getByText, getByRole, getByTestId } = renderComponent();
 
     const h1 = getByRole('heading');
@@ -87,7 +82,7 @@ describe('HeroImage slice', () => {
     expect(link).toHaveAttribute('href', 'http://www.google.com');
 
     const imgaltspan = getByRole('img');
-    expect(imgaltspan).toHaveAttribute('aria-label');
+    expect(imgaltspan).toHaveAttribute('alt');
 
     const overlay = getByTestId('HeroImageOverlay');
     expect(overlay).toHaveStyle('background-color: transparent');
@@ -97,20 +92,14 @@ describe('HeroImage slice', () => {
   });
 
   it("shouldn't render text when none is supplied", () => {
-    let props: HeroImageProps = {
+    props = {
       imageLarge:
         'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg',
       imageSmall:
         'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/144/81/0/2021-12/Abington_Park_1.jpg',
+      imageAltText: null,
       backgroundBox: false,
     };
-
-    const renderComponent = () =>
-      render(
-        <ThemeProvider theme={west_theme}>
-          <HeroImage {...props} />
-        </ThemeProvider>
-      );
 
     const { queryByText, queryByRole } = renderComponent();
 
@@ -124,11 +113,11 @@ describe('HeroImage slice', () => {
     expect(link).toBeNull();
 
     const imgaltspan = queryByRole('img');
-    expect(imgaltspan).toBeNull();
+    expect(imgaltspan).toHaveAttribute('alt', '');
   });
 
   it('should display the parent breadcrumb in the hero image', () => {
-    let props: HeroImageProps = {
+    props = {
       imageLarge:
         'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg',
       imageSmall:
@@ -143,13 +132,6 @@ describe('HeroImage slice', () => {
       },
     };
 
-    const renderComponent = () =>
-      render(
-        <ThemeProvider theme={west_theme}>
-          <HeroImage {...props} />
-        </ThemeProvider>
-      );
-
     const { getByText, queryByText } = renderComponent();
 
     const breadcrumb = getByText('Country Parks');
@@ -160,28 +142,21 @@ describe('HeroImage slice', () => {
 
     expect(queryByText('Home')).toBeNull();
   });
-});
 
-it('should render the custom search box', () => {
-  const props: HeroImageProps = HeroImageExampleBoxedWithCustomSearch;
+  it('should render the custom search box', () => {
+    props = HeroImageExampleBoxedWithCustomSearch;
 
-  const renderComponent = () =>
-    render(
-      <ThemeProvider theme={west_theme}>
-        <HeroImage {...props} />
-      </ThemeProvider>
-    );
+    const { getByRole, getByPlaceholderText } = renderComponent();
 
-  const { getByRole, getByPlaceholderText } = renderComponent();
+    const input = getByPlaceholderText('Search courses');
+    const form = getByRole('form');
+    const link = getByRole('link');
 
-  const input = getByPlaceholderText('Search courses');
-  const form = getByRole('form');
-  const link = getByRole('link');
+    expect(input).toBeVisible();
 
-  expect(input).toBeVisible();
+    expect(form).toHaveAttribute('method', 'post');
+    expect(form).toHaveAttribute('action', 'https://courses.northantsglobal.net/CourseKeySearch.asp');
 
-  expect(form).toHaveAttribute('method', 'post');
-  expect(form).toHaveAttribute('action', 'https://courses.northantsglobal.net/CourseKeySearch.asp');
-
-  expect(link).toHaveClass('button--secondary');
+    expect(link).toHaveClass('button--secondary');
+  });
 });

--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { HeroImageProps } from './HeroImage.types';
 import * as Styles from './HeroImage.styles';
-import LazyImage from 'react-lazy-progressive-image';
 import sanitizeHtml from 'sanitize-html';
 import CallToAction from '../../slices/CallToAction/CallToAction';
 import CustomSearch from '../../components/CustomSearch/CustomSearch';
+import Image from 'next/image';
 
 /**
  * Hero image banner with optional text and call to action with varying presentation of text area.
@@ -25,44 +25,44 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
 }) => {
   return (
     <>
-      <LazyImage
-        src={imageLarge}
-        placeholder={imageSmall}
-        visibilitySensorProps={{
-          partialVisibility: true,
-        }}
-      >
-        {(src) => (
-          <Styles.Container $image={src} $backgroundBox={backgroundBox} data-testid="HeroImage">
-            <Styles.InnerContainer>
-              <Styles.Overlay $backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
-                {breadcrumb && (
-                  <Styles.BreadcrumbLink href={breadcrumb.url} $backgroundBox={backgroundBox}>
-                    {breadcrumb.title}
-                  </Styles.BreadcrumbLink>
-                )}
-                {headline && <Styles.Headline level={1} text={headline} $backgroundBox={backgroundBox} />}
-                {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
-                {customSearch && (
-                  <Styles.Search>
-                    <CustomSearch {...customSearch} />
-                  </Styles.Search>
-                )}
-                {callToActionURL && backgroundBox && (
-                  <CallToAction url={callToActionURL} text={callToActionText} primary={callToActionIsPrimary} />
-                )}
-                {!callToActionURL && backgroundBox && <br />}
-                {callToActionURL && !backgroundBox && (
-                  <Styles.CallToActionLink href={callToActionURL}>
-                    {callToActionText ? callToActionText : 'Find out more'}
-                  </Styles.CallToActionLink>
-                )}
-              </Styles.Overlay>
-            </Styles.InnerContainer>
-          </Styles.Container>
-        )}
-      </LazyImage>
-      {imageAltText && <span role="img" aria-label={imageAltText} />}
+      <Styles.Container $image={imageLarge} $backgroundBox={backgroundBox} data-testid="HeroImage">
+        <Image
+          src={imageLarge}
+          alt={imageAltText ?? ''}
+          fill
+          placeholder="blur"
+          blurDataURL={imageSmall}
+          style={{
+            objectFit: 'cover',
+          }}
+        />
+        {!backgroundBox && <Styles.BackgroundBox data-testid="BackgroundBox" />}
+        <Styles.InnerContainer>
+          <Styles.Overlay $backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
+            {breadcrumb && (
+              <Styles.BreadcrumbLink href={breadcrumb.url} $backgroundBox={backgroundBox}>
+                {breadcrumb.title}
+              </Styles.BreadcrumbLink>
+            )}
+            {headline && <Styles.Headline level={1} text={headline} $backgroundBox={backgroundBox} />}
+            {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
+            {customSearch && (
+              <Styles.Search>
+                <CustomSearch {...customSearch} />
+              </Styles.Search>
+            )}
+            {callToActionURL && backgroundBox && (
+              <CallToAction url={callToActionURL} text={callToActionText} primary={callToActionIsPrimary} />
+            )}
+            {!callToActionURL && backgroundBox && <br />}
+            {callToActionURL && !backgroundBox && (
+              <Styles.CallToActionLink href={callToActionURL}>
+                {callToActionText ? callToActionText : 'Find out more'}
+              </Styles.CallToActionLink>
+            )}
+          </Styles.Overlay>
+        </Styles.InnerContainer>
+      </Styles.Container>
     </>
   );
 };

--- a/src/library/structure/HomeHero/HomeHero.storydata.ts
+++ b/src/library/structure/HomeHero/HomeHero.storydata.ts
@@ -20,18 +20,22 @@ export const HomeHeroCommon = {
     {
       image1440x810: 'http://placehold.it/1440x810',
       image144x81: 'http://placehold.it/144x81',
+      imageAltText: 'Example image alt text',
     },
     {
       image1440x810: 'http://placehold.it/1340x810',
       image144x81: 'http://placehold.it/134x81',
+      imageAltText: 'Example image alt text',
     },
     {
       image1440x810: 'http://placehold.it/1240x810',
       image144x81: 'http://placehold.it/124x81',
+      imageAltText: 'Example image alt text',
     },
     {
       image1440x810: 'http://placehold.it/1140x810',
       image144x81: 'http://placehold.it/114x81',
+      imageAltText: 'Example image alt text',
     },
   ],
 };

--- a/src/library/structure/HomeHero/HomeHero.styles.js
+++ b/src/library/structure/HomeHero/HomeHero.styles.js
@@ -11,6 +11,7 @@ export const Wrapper = styled.header`
 `;
 
 export const Container = styled.div`
+  position: relative;
   font-family: ${(props) => props.theme.theme_vars.fontstack};
   overflow: hidden;
   background: ${(props) => props.theme.theme_vars.colours.action}5A;
@@ -18,7 +19,7 @@ export const Container = styled.div`
   padding-bottom: 15px;
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
-    background-image: url('${(props) => props.$image}');
+    /* background-image: url('${(props) => props.$image}'); */
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
@@ -39,6 +40,8 @@ export const Container = styled.div`
 `;
 
 export const StyledMaxWidthContainer = styled.div`
+  position: relative;
+  z-index: 2;
   ${(props) => props.theme.fontStyles}
   margin-right: 15px;
   margin-left: 15px;
@@ -95,7 +98,7 @@ export const LogoColoured = styled.div`
 
 export const LogoOverride = styled.div`
   img {
-    margin-top: -45px;
+    /* margin-top: -45px; */
     max-width: 520px;
     width: 100%;
     height: auto;

--- a/src/library/structure/HomeHero/HomeHero.test.tsx
+++ b/src/library/structure/HomeHero/HomeHero.test.tsx
@@ -48,9 +48,9 @@ describe('HomeHero common usage', () => {
     expect(listbox.children.length).toBe(1);
   });
 
-  it('should not render an image tag', () => {
+  it('should render an image tag', () => {
     const images = rendered.queryAllByRole('img');
-    expect(images).toHaveLength(0);
+    expect(images).toHaveLength(1);
   });
 });
 
@@ -90,7 +90,10 @@ describe('HomeHero unusual usage', () => {
   it('should render an overriden logo image', () => {
     const img = rendered.getByAltText('My alt text');
     expect(img).toBeVisible();
-    expect(img).toHaveProperty('src', 'http://placehold.it/520x150');
+    expect(img).toHaveProperty(
+      'src',
+      'http://localhost/_next/image?url=http%3A%2F%2Fplacehold.it%2F520x150&w=1080&q=75'
+    );
     expect(img).toHaveProperty('alt', 'My alt text');
   });
 

--- a/src/library/structure/HomeHero/HomeHero.tsx
+++ b/src/library/structure/HomeHero/HomeHero.tsx
@@ -6,9 +6,9 @@ import * as Styles from './HomeHero.styles';
 import GDSLogo from '../../components/logos/GDSLogo/logo';
 import NorthColoured from '../../components/logos/NorthColouredLogo/logo';
 import WestColoured from '../../components/logos/WestColouredLogo/logo';
-import LazyImage from 'react-lazy-progressive-image';
 import Searchbar from '../Searchbar/Searchbar';
 import PromotedLinks from '../../components/PromotedLinks/PromotedLinks';
+import Image from 'next/image';
 
 /**
  * The Hero that should appear at the top of the home page.
@@ -35,64 +35,66 @@ const HomeHero: React.FunctionComponent<HomeHeroProps> = ({
   return (
     <>
       <Styles.Wrapper>
-        <LazyImage
-          src={random !== 999 && imagesArray[random].image1440x810 ? imagesArray[random].image1440x810 : ''}
-          placeholder={random !== 999 && imagesArray[random].image144x81 ? imagesArray[random].image144x81 : ''}
-          visibilitySensorProps={{
-            partialVisibility: true,
-          }}
+        <Styles.Container
+          className={random !== 999 ? 'loaded' : 'loading'}
+          title={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ''}
         >
-          {(src) => (
-            <Styles.Container
-              className={random !== 999 ? 'loaded' : 'loading'}
-              $image={src}
-              title={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ''}
-            >
-              <Styles.StyledMaxWidthContainer>
-                <Styles.MainBox>
-                  {topline && <Styles.Topline>{topline}</Styles.Topline>}
-                  <Styles.HiddenH1>{`${themeContext.full_name} Council`}</Styles.HiddenH1>
-                  {imageOverrideLogo && !usingMemorialTheme && (
-                    <Styles.LogoOverride>
-                      <img
-                        src={imageOverrideLogo}
-                        width="520"
-                        height="150"
-                        alt={imageOverrideLogoAltText?.trim() ? imageOverrideLogoAltText : 'Logo'}
-                      />
-                    </Styles.LogoOverride>
-                  )}
-                  {(!imageOverrideLogo || usingMemorialTheme) && (
-                    <Styles.LogoColoured className={usingMemorialTheme ? 'black_logo' : ''}>
-                      {themeContext.cardinal_name === 'north' ? (
-                        <NorthColoured />
-                      ) : themeContext.cardinal_name === 'west' ? (
-                        <WestColoured />
-                      ) : (
-                        <GDSLogo />
-                      )}
-                    </Styles.LogoColoured>
-                  )}
-                  {strapline && <Styles.Strapline>{strapline}</Styles.Strapline>}
-                  <Searchbar
-                    isLight
-                    isLarge
-                    placeholder="Search the site"
-                    submitInfo={{
-                      postTo: '/search',
-                      params: {
-                        type: 'search',
-                      },
-                    }}
-                    suggestions={searchSuggestions}
-                    maximumMatchesShown={4}
-                  />
-                </Styles.MainBox>
-                {promotedLinksArray.length > 0 && <PromotedLinks promotedLinksArray={promotedLinksArray} />}
-              </Styles.StyledMaxWidthContainer>
-            </Styles.Container>
+          {random !== 999 && (
+            <Image
+              src={imagesArray[random].image1440x810}
+              alt={imagesArray[random].imageAltText}
+              fill
+              placeholder="blur"
+              blurDataURL={imagesArray[random].image144x81}
+              style={{
+                objectFit: 'cover',
+              }}
+            />
           )}
-        </LazyImage>
+
+          <Styles.StyledMaxWidthContainer>
+            <Styles.MainBox>
+              {topline && <Styles.Topline>{topline}</Styles.Topline>}
+              <Styles.HiddenH1>{`${themeContext.full_name} Council`}</Styles.HiddenH1>
+              {imageOverrideLogo && !usingMemorialTheme && (
+                <Styles.LogoOverride>
+                  <Image
+                    src={imageOverrideLogo}
+                    width="520"
+                    height="150"
+                    alt={imageOverrideLogoAltText?.trim() ? imageOverrideLogoAltText : 'Logo'}
+                  />
+                </Styles.LogoOverride>
+              )}
+              {(!imageOverrideLogo || usingMemorialTheme) && (
+                <Styles.LogoColoured className={usingMemorialTheme ? 'black_logo' : ''}>
+                  {themeContext.cardinal_name === 'north' ? (
+                    <NorthColoured />
+                  ) : themeContext.cardinal_name === 'west' ? (
+                    <WestColoured />
+                  ) : (
+                    <GDSLogo />
+                  )}
+                </Styles.LogoColoured>
+              )}
+              {strapline && <Styles.Strapline>{strapline}</Styles.Strapline>}
+              <Searchbar
+                isLight
+                isLarge
+                placeholder="Search the site"
+                submitInfo={{
+                  postTo: '/search',
+                  params: {
+                    type: 'search',
+                  },
+                }}
+                suggestions={searchSuggestions}
+                maximumMatchesShown={4}
+              />
+            </Styles.MainBox>
+            {promotedLinksArray.length > 0 && <PromotedLinks promotedLinksArray={promotedLinksArray} />}
+          </Styles.StyledMaxWidthContainer>
+        </Styles.Container>
       </Styles.Wrapper>
     </>
   );

--- a/src/library/structure/MemorialHero/MemorialHero.styles.js
+++ b/src/library/structure/MemorialHero/MemorialHero.styles.js
@@ -47,12 +47,16 @@ export const Left = styled.div`
 `;
 
 export const Right = styled.div`
+  position: relative;
   order: 2;
   flex-grow: 1;
+  height: 760px;
+
   @media screen and (max-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
     order: 1;
     flex-basis: 100%;
     width: 100%;
+    height: 350px;
   }
 `;
 

--- a/src/library/structure/MemorialHero/MemorialHero.tsx
+++ b/src/library/structure/MemorialHero/MemorialHero.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useState } from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { MemorialHeroProps } from './MemorialHero.types';
 import * as Styles from './MemorialHero.styles';
 import styled, { ThemeContext, ThemeProvider } from 'styled-components';
+import Image from 'next/image';
 
 const MemorialHero: React.FC<MemorialHeroProps> = ({ src, placeholder, alt, theme, children, councilServices }) => {
   const themeContext = useContext(ThemeContext);
@@ -16,15 +16,14 @@ const MemorialHero: React.FC<MemorialHeroProps> = ({ src, placeholder, alt, them
             <ThemeProvider theme={theme}>{councilServices}</ThemeProvider>
           </Styles.Left>
           <Styles.Right>
-            <LazyImage
+            <Image
               src={src}
-              placeholder={placeholder}
-              visibilitySensorProps={{
-                partialVisibility: true,
+              alt={alt}
+              fill
+              style={{
+                objectFit: 'cover',
               }}
-            >
-              {(src) => <Styles.Image $image={src} title={alt} />}
-            </LazyImage>
+            />
           </Styles.Right>
         </Styles.Container>
       </Styles.Wrapper>

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.styles.js
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.styles.js
@@ -102,15 +102,12 @@ export const ArticleContent = styled.div`
 export const ImageContainer = styled.span`
   display: block;
   width: 100%;
-  height: ${imageHeightMobile}px;
   overflow: hidden;
-  background-image: url('${(props) => props.$background}');
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
+  padding-top: 56.25%;
   justify-self: center;
+  position: relative;
 
-  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
+  /* @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
     flex: 0 0 40%;
     height: 100%;
     min-height: ${imageHeightMobile}px;
@@ -118,7 +115,7 @@ export const ImageContainer = styled.span`
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     flex: none;
     height: ${imageHeightDesktop}px;
-  }
+  } */
 `;
 
 export const DateContainer = styled.div`

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.test.tsx
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.test.tsx
@@ -36,11 +36,11 @@ describe('NewsArticleFeaturedBlock structure', () => {
     expect(imageSpans).toHaveLength(storydata.NewsArticleData.length);
     imageSpans.forEach((imageSpan, index) => {
       expect(imageSpan).toBeVisible();
-      expect(imageSpan).toHaveStyle('background-image: url(' + storydata.NewsArticleData[index].image72x41 + ')');
+      // expect(imageSpan).toHaveAttribute('alt', storydata.NewsArticleData[index].imageAltText);
       if (storydata.NewsArticleData[index].imageAltText) {
-        expect(imageSpan).toHaveAttribute('aria-label', storydata.NewsArticleData[index].imageAltText);
+        expect(imageSpan).toHaveAttribute('alt', storydata.NewsArticleData[index].imageAltText);
       } else {
-        expect(imageSpan).toHaveAttribute('aria-label', '');
+        expect(imageSpan).toHaveAttribute('alt', '');
       }
 
       const para = getByText(storydata.NewsArticleData[index].title);

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.tsx
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { NewsArticleFeaturedBlockProps } from './NewsArticleFeaturedBlock.types';
 import * as Styles from './NewsArticleFeaturedBlock.styles';
 import NewsArticleDate from '../NewsArticleDate/NewsArticleDate';
@@ -7,6 +6,7 @@ import Heading from '../../components/Heading/Heading';
 import Button from '../../components/Button/Button';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import Image from 'next/image';
 
 /**
  * Block displaying up to 9 news article tiles, with image, title and date for each
@@ -28,21 +28,18 @@ const NewsArticleFeaturedBlock: React.FunctionComponent<NewsArticleFeaturedBlock
                   <Row>
                     {article.image720x405 && (
                       <Column small="full" medium="full" large="full" hasPadding={false}>
-                        <LazyImage
-                          src={article.image720x405}
-                          placeholder={article.image72x41}
-                          visibilitySensorProps={{
-                            partialVisibility: true,
-                          }}
-                        >
-                          {(src) => (
-                            <Styles.ImageContainer
-                              $background={src}
-                              role="img"
-                              aria-label={article.imageAltText ? article.imageAltText : ''}
-                            />
-                          )}
-                        </LazyImage>
+                        <Styles.ImageContainer>
+                          <Image
+                            src={article.image720x405}
+                            alt={article.imageAltText ?? ''}
+                            fill
+                            placeholder="blur"
+                            blurDataURL={article.image72x41}
+                            style={{
+                              objectFit: 'contain',
+                            }}
+                          />
+                        </Styles.ImageContainer>
                       </Column>
                     )}
                     <Column small="full" medium="full" large="full">

--- a/src/library/structure/NewsArticleImage/NewsArticleImage.styles.js
+++ b/src/library/structure/NewsArticleImage/NewsArticleImage.styles.js
@@ -1,39 +1,39 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const ImageContainer = styled.div`
-    position: relative;
-    margin-bottom: 25px;
+  position: relative;
+  padding-top: 56.25%;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-        max-width: 800px;
-    }
-`
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    max-width: 800px;
+  }
+`;
 
 export const StyledImage = styled.img`
-    width: 100%;
-    height: auto;
+  width: 100%;
+  height: auto;
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-        max-width: 800px;
-    }
-`
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    max-width: 800px;
+  }
+`;
 
 export const Small = styled.small`
-    text-align: center;
-    color: ${props => props.theme.theme_vars.colours.gray_dark};
-    font-size: 14px;
-    font-size: 0.8rem;
-    line-height: 1.3;
-    margin: 0 auto;
-    display: block;
-    &:hover {
-        cursor: default;
-    }
+  text-align: center;
+  color: ${(props) => props.theme.theme_vars.colours.gray_dark};
+  font-size: 14px;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  margin: 0 auto;
+  display: block;
+  &:hover {
+    cursor: default;
+  }
 
-    @media screen and (min-width: ${props => props.theme.theme_vars.breakpoints.m}){
-        font-size: 16px;
-        font-size: 1rem;
-        max-width: 800px;
-        line-height: 1.4;
-    }
-`
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    font-size: 16px;
+    font-size: 1rem;
+    max-width: 800px;
+    line-height: 1.4;
+  }
+`;

--- a/src/library/structure/NewsArticleImage/NewsArticleImage.tsx
+++ b/src/library/structure/NewsArticleImage/NewsArticleImage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NewsArticleImageProps } from './NewsArticleImage.types';
 import * as Styles from './NewsArticleImage.styles';
-import LazyImage from 'react-lazy-progressive-image';
+import Image from 'next/image';
 
 /**
  * An image for a news article
@@ -13,22 +13,12 @@ const NewsArticleImage: React.FunctionComponent<NewsArticleImageProps> = ({
   imageCaption,
 }) => {
   return (
-    <Styles.ImageContainer>
-      <LazyImage
-        src={image1440x810}
-        placeholder={image144x81}
-        visibilitySensorProps={{
-          partialVisibility: true,
-        }}
-      >
-        {(src) => (
-          <>
-            <Styles.StyledImage src={src} alt={imageAltText ? imageAltText : ''} />
-            {imageCaption && <Styles.Small itemprop="copyrightHolder">{imageCaption}</Styles.Small>}
-          </>
-        )}
-      </LazyImage>
-    </Styles.ImageContainer>
+    <>
+      <Styles.ImageContainer>
+        <Image alt={imageAltText} src={image1440x810} fill={true} placeholder="blur" blurDataURL={image144x81} />
+      </Styles.ImageContainer>
+      {imageCaption && <Styles.Small itemprop="copyrightHolder">{imageCaption}</Styles.Small>}
+    </>
   );
 };
 

--- a/src/library/structure/NewsArticleList/NewsArticleList.styles.js
+++ b/src/library/structure/NewsArticleList/NewsArticleList.styles.js
@@ -79,17 +79,13 @@ export const ArticleContent = styled.div`
   }
 `;
 
-export const ImageContainer = styled.span`
-  display: block;
-  width: 100%;
-  height: 150px;
-  overflow: hidden;
-  background-image: url('${(props) => props.$background}');
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
+export const ArticleImageContainer = styled.span`
   justify-self: center;
-
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
     order: 1;
     height: auto;
@@ -101,6 +97,13 @@ export const ImageContainer = styled.span`
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
     width: 33%;
   }
+`;
+
+export const ImageContainer = styled.span`
+  display: block;
+  width: 100%;
+  padding-top: 56.25%;
+  position: relative;
 `;
 
 export const DateContainer = styled.div`

--- a/src/library/structure/NewsArticleList/NewsArticleList.tsx
+++ b/src/library/structure/NewsArticleList/NewsArticleList.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { NewsArticleListProps } from './NewsArticleList.types';
 import * as Styles from './NewsArticleList.styles';
 import NewsArticleDate from '../NewsArticleDate/NewsArticleDate';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import Image from 'next/image';
 
 const NewsArticleList: React.FunctionComponent<NewsArticleListProps> = ({ results }) => {
   const extractLength = 140;
@@ -17,22 +17,20 @@ const NewsArticleList: React.FunctionComponent<NewsArticleListProps> = ({ result
             <Column isList small="full" medium="full" large="full" key={article.id}>
               <Styles.ArticleContainer href={article.url} title={article.title}>
                 {article.image720x405 && (
-                  <LazyImage
-                    src={article.image720x405}
-                    placeholder={article.image72x41}
-                    visibilitySensorProps={{
-                      partialVisibility: true,
-                    }}
-                  >
-                    {(src) => (
-                      <Styles.ImageContainer
-                        className="news-article-list__image"
-                        $background={src}
-                        role="img"
-                        aria-label={article.imageAltText ? article.imageAltText : 'News article'}
-                      ></Styles.ImageContainer>
-                    )}
-                  </LazyImage>
+                  <Styles.ArticleImageContainer>
+                    <Styles.ImageContainer>
+                      <Image
+                        src={article.image720x405}
+                        alt={article.imageAltText ?? 'News article'}
+                        fill
+                        placeholder="blur"
+                        blurDataURL={article.image72x41}
+                        style={{
+                          objectFit: 'contain',
+                        }}
+                      />
+                    </Styles.ImageContainer>
+                  </Styles.ArticleImageContainer>
                 )}
                 <Styles.ArticleContent $withImage={article.image720x405 ? true : false}>
                   <Styles.Title className="news-article-list__title">{article.title}</Styles.Title>

--- a/src/library/structure/PromoBanner/PromoBanner.styles.js
+++ b/src/library/structure/PromoBanner/PromoBanner.styles.js
@@ -29,28 +29,27 @@ export const Container = styled.div`
 `;
 
 export const ImageLink = styled.a`
-  background-image: url('${(props) => props.$img}');
-  background-size: cover;
-  background-position: center;
-  min-height: 200px;
+  padding-top: 56.25%;
+  height: 100%;
+  position: relative;
   width: 100%;
-  display: block;
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
-    width: 50%;
-    min-height: 300px;
+    height: 100%;
+    padding-top: 0;
   }
 `;
 
 export const Wrapper = styled.div`
-  width: calc(100% - 30px);
   padding: 15px;
 
   h2 {
     margin-top: 0;
   }
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
-    width: calc(50% - 60px);
     padding: 30px;
   }
 `;

--- a/src/library/structure/PromoBanner/PromoBanner.test.tsx
+++ b/src/library/structure/PromoBanner/PromoBanner.test.tsx
@@ -33,12 +33,13 @@ describe('PromoBanner structure', () => {
 
     const links = getAllByRole('link');
     expect(links).toHaveLength(2);
+    const image = getByRole('img');
 
     expect(links[0]).toHaveProperty('href', storydata.PromoBannerData.ctaUrl);
     expect(links[0]).toHaveTextContent('');
     expect(links[0]).toHaveProperty('title', storydata.PromoBannerData.ctaText);
-    expect(links[0]).toHaveStyle(`background-image: url(${storydata.PromoBannerData.image144x81});`);
-    expect(links[0]).toHaveStyle('display: block;');
+    expect(image).toHaveAttribute('alt', storydata.PromoBannerData.ctaText);
+    expect(links[0]).toHaveStyle('display: flex;');
     expect(links[0]).toHaveStyle('width: 100%');
 
     expect(links[1]).toHaveProperty('href', storydata.PromoBannerData.ctaUrl);

--- a/src/library/structure/PromoBanner/PromoBanner.tsx
+++ b/src/library/structure/PromoBanner/PromoBanner.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { PromoBannerProps } from './PromoBanner.types';
 import * as Styles from './PromoBanner.styles';
 import Heading from '../../components/Heading/Heading';
+import Image from 'next/image';
+import Row from '../../components/Row/Row';
+import Column from '../../components/Column/Column';
 
 /**
  * Promotional banner used as the first wide line in a promotional block,
@@ -17,20 +19,29 @@ const PromoBanner: React.FunctionComponent<PromoBannerProps> = ({
   children,
 }) => (
   <Styles.Container>
-    <LazyImage
-      src={image1440x810}
-      placeholder={image144x81}
-      visibilitySensorProps={{
-        partialVisibility: true,
-      }}
-    >
-      {(src) => <Styles.ImageLink $img={src} href={ctaUrl} title={ctaText} />}
-    </LazyImage>
-    <Styles.Wrapper>
-      <Heading text={title} />
-      <Styles.Content>{children}</Styles.Content>
-      <Styles.CTA href={ctaUrl}>{ctaText}</Styles.CTA>
-    </Styles.Wrapper>
+    <Row>
+      <Column small="full" medium="one-half" large="one-half" hasPadding={false}>
+        <Styles.ImageLink href={ctaUrl} title={ctaText}>
+          <Image
+            src={image1440x810}
+            alt={ctaText}
+            fill
+            placeholder="blur"
+            blurDataURL={image144x81}
+            style={{
+              objectFit: 'cover',
+            }}
+          />
+        </Styles.ImageLink>
+      </Column>
+      <Column small="full" medium="one-half" large="one-half" hasPadding={false}>
+        <Styles.Wrapper>
+          <Heading text={title} />
+          <Styles.Content>{children}</Styles.Content>
+          <Styles.CTA href={ctaUrl}>{ctaText}</Styles.CTA>
+        </Styles.Wrapper>
+      </Column>
+    </Row>
   </Styles.Container>
 );
 

--- a/src/library/structure/PromoBlock/PromoBlock.styles.js
+++ b/src/library/structure/PromoBlock/PromoBlock.styles.js
@@ -78,20 +78,22 @@ export const PromoTile = styled.a`
 export const PromoImage = styled.span`
   display: block;
   width: 100%;
-  height: ${imageHeightMobile}px;
+  /* height: ${imageHeightMobile}px; */
   overflow: hidden;
-  background-image: url('${(props) => props.$background}');
+  padding-top: 56.25%;
+  /* background-image: url('${(props) => props.$background}');
   background-size: cover;
-  background-position: center;
+  background-position: center; */
   justify-self: center;
+  position: relative;
 
-  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
+  /* @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
     min-height: ${imageHeightDesktop}px;
   }
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     flex: none;
     height: ${imageHeightDesktop}px;
-  }
+  } */
 `;
 
 /**

--- a/src/library/structure/PromoBlock/PromoBlock.test.tsx
+++ b/src/library/structure/PromoBlock/PromoBlock.test.tsx
@@ -43,7 +43,7 @@ describe('Promo Block', () => {
 
     expect(images).toHaveLength(2);
 
-    expect(images[0]).toHaveAttribute('aria-label', 'Some sort of image');
-    expect(images[1]).toHaveAttribute('aria-label', 'A graphical thing');
+    expect(images[0]).toHaveAttribute('alt', 'Some sort of image');
+    expect(images[1]).toHaveAttribute('alt', 'A graphical thing');
   });
 });

--- a/src/library/structure/PromoBlock/PromoBlock.tsx
+++ b/src/library/structure/PromoBlock/PromoBlock.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { PromoBlockProps } from './PromoBlock.types';
 import * as Styles from './PromoBlock.styles';
 import sanitizeHtml from 'sanitize-html';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import Image from 'next/image';
 
 /**
  * Promotional campaign block, showing a tile for each campaign, similar to news article featured block.
@@ -18,21 +18,15 @@ const PromoBlock: React.FunctionComponent<PromoBlockProps> = ({ promos }) => (
           {promos.map((promo, index) => (
             <Column isList small="full" medium="one-half" large="auto" key={promo.callToActionURL}>
               <Styles.PromoTile href={promo.callToActionURL}>
-                <LazyImage
-                  src={promo.imageMedium}
-                  placeholder={promo.imageSmall}
-                  visibilitySensorProps={{
-                    partialVisibility: true,
-                  }}
-                >
-                  {(src) => (
-                    <Styles.PromoImage
-                      $background={src}
-                      role="img"
-                      aria-label={promo.imageAltText ? promo.imageAltText : ''}
-                    />
-                  )}
-                </LazyImage>
+                <Styles.PromoImage>
+                  <Image
+                    src={promo.imageMedium}
+                    alt={promo.imageAltText}
+                    fill
+                    placeholder="blur"
+                    blurDataURL={promo.imageSmall}
+                  />
+                </Styles.PromoImage>
                 <Styles.PromoText>
                   <Styles.PromoHeadline level={3} text={promo.title} />
                   <Styles.PromoContent

--- a/src/library/structure/SectionLinks/SectionLinks.styles.js
+++ b/src/library/structure/SectionLinks/SectionLinks.styles.js
@@ -75,7 +75,7 @@ export const ImageContainer = styled.span`
   width: 100%;
   display: block;
   margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
-  background: ${(props) => (props.$image ? `url("` + props.$image + `") center center / cover no-repeat` : ``)};
+  /* background: ${(props) => (props.$image ? `url("` + props.$image + `") center center / cover no-repeat` : ``)}; */
 `;
 
 export const Image = styled.img`

--- a/src/library/structure/SectionLinks/SectionLinks.test.tsx
+++ b/src/library/structure/SectionLinks/SectionLinks.test.tsx
@@ -110,9 +110,9 @@ describe('Section Links', () => {
     expect(images).toHaveLength(2);
 
     expect(images[0]).toHaveStyle('background: url("/small-image-1.jpg") center center / cover no-repeat;');
-    expect(images[0]).toHaveAttribute('aria-label', 'The first image alt text');
+    expect(images[0]).toHaveAttribute('alt', 'The first image alt text');
 
     expect(images[1]).toHaveStyle('background: url("/small-image-2.jpg") center center / cover no-repeat;');
-    expect(images[1]).toHaveAttribute('aria-label', 'The second image alt text');
+    expect(images[1]).toHaveAttribute('alt', 'The second image alt text');
   });
 });

--- a/src/library/structure/SectionLinks/SectionLinks.tsx
+++ b/src/library/structure/SectionLinks/SectionLinks.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { SectionLinksProps } from './SectionLinks.types';
 import * as Styles from './SectionLinks.styles';
-import LazyImage from 'react-lazy-progressive-image';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import Image from 'next/image';
 
 /**
  * Display a list of links for a section with optional images
@@ -24,21 +24,15 @@ const SectionLinks: React.FunctionComponent<SectionLinksProps> = ({
             {hasImages && (
               <>
                 {link.imageLarge?.trim() ? (
-                  <LazyImage
-                    placeholder={link.imageSmall}
-                    src={link.imageLarge}
-                    visibilitySensorProps={{
-                      partialVisibility: true,
-                    }}
-                  >
-                    {(src) => (
-                      <Styles.ImageContainer
-                        $image={src}
-                        role="img"
-                        aria-label={link.imageAltText}
-                      ></Styles.ImageContainer>
-                    )}
-                  </LazyImage>
+                  <Styles.ImageContainer>
+                    <Image
+                      src={link.imageLarge}
+                      alt={link.imageAltText}
+                      fill
+                      placeholder="blur"
+                      blurDataURL={link.imageSmall}
+                    />
+                  </Styles.ImageContainer>
                 ) : (
                   <Styles.ImageContainer />
                 )}


### PR DESCRIPTION
- Built upon #388 
- Add @storybook/nextjs and next to dev dependencies
- Make use of next/image and replace the abandonend react-progressive-lazy-image to display images, use the small image as a placeholder and lazy load the large image when scrolling into view

**Has issues running with the frontend when using `yarn dev`!**

## Testing
- Checkout this branch and run `npm install` then `npm run dev` to manually test updated components. 