### PR TITLE
Fix/breadcrumbs list when multiple

### DIFF
--- a/src/library/structure/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.test.tsx
@@ -76,4 +76,25 @@ describe('Breadcrumbs', () => {
     expect(links[2]).toHaveAttribute('href', '/service-landing-page/service-page');
     expect(links[2]).toHaveTextContent('Service page');
   });
+
+  it('should not be a list when has one breadcrumb', () => {
+    props.breadcrumbsArray = [
+      {
+        title: 'Home',
+        url: '/',
+      },
+    ];
+
+    const { queryByRole } = renderComponent();
+    const list = queryByRole('list');
+    const listItem = queryByRole('listitem');
+    const link = queryByRole('link');
+
+    expect(list).toBeNull();
+    expect(listItem).toBeNull();
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', '/');
+    expect(link).toHaveTextContent('Home');
+  });
 });

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.tsx
@@ -5,9 +5,25 @@ import ChevronIcon from '../../components/icons/ChevronIcon/ChevronIcon';
 
 const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ breadcrumbsArray, hasMargin = false }) => (
   <Styles.Container hasMargin={hasMargin} data-testid="Breadcrumbs">
-    <Styles.List>
+    {/* {breadcrumbsArray.length === 1 ? (
+      <Styles.List as="div">
+        <Styles.Crumb as="span">
+          {
+            <>
+              <Styles.BreadcrumbLink href={breadcrumbsArray[0].url} title={breadcrumbsArray[0].title}>
+                {breadcrumbsArray[0].title}
+              </Styles.BreadcrumbLink>
+              <Styles.IconWrapper>
+                <ChevronIcon direction={'right'} colourFill="#C6C6C6" />
+              </Styles.IconWrapper>
+            </>
+          }
+        </Styles.Crumb>
+      </Styles.List>
+    ) : ( */}
+    <Styles.List as={breadcrumbsArray.length === 1 ? 'div' : 'ol'}>
       {breadcrumbsArray.map((crumb) => (
-        <Styles.Crumb key={crumb.title}>
+        <Styles.Crumb key={crumb.title} as={breadcrumbsArray.length === 1 ? 'span' : 'li'}>
           {
             <>
               <Styles.BreadcrumbLink href={crumb.url} title={crumb.title}>
@@ -21,6 +37,7 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ breadcrumbsArr
         </Styles.Crumb>
       ))}
     </Styles.List>
+    {/* )} */}
   </Styles.Container>
 );
 

--- a/src/library/structure/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.tsx
@@ -5,22 +5,6 @@ import ChevronIcon from '../../components/icons/ChevronIcon/ChevronIcon';
 
 const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ breadcrumbsArray, hasMargin = false }) => (
   <Styles.Container hasMargin={hasMargin} data-testid="Breadcrumbs">
-    {/* {breadcrumbsArray.length === 1 ? (
-      <Styles.List as="div">
-        <Styles.Crumb as="span">
-          {
-            <>
-              <Styles.BreadcrumbLink href={breadcrumbsArray[0].url} title={breadcrumbsArray[0].title}>
-                {breadcrumbsArray[0].title}
-              </Styles.BreadcrumbLink>
-              <Styles.IconWrapper>
-                <ChevronIcon direction={'right'} colourFill="#C6C6C6" />
-              </Styles.IconWrapper>
-            </>
-          }
-        </Styles.Crumb>
-      </Styles.List>
-    ) : ( */}
     <Styles.List as={breadcrumbsArray.length === 1 ? 'div' : 'ol'}>
       {breadcrumbsArray.map((crumb) => (
         <Styles.Crumb key={crumb.title} as={breadcrumbsArray.length === 1 ? 'span' : 'li'}>
@@ -37,7 +21,6 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ breadcrumbsArr
         </Styles.Crumb>
       ))}
     </Styles.List>
-    {/* )} */}
   </Styles.Container>
 );
 


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/874

Monsido is warning that you should not have a single link as a list, so this checks if there is only one and makes it a div and span instead of ol and li. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Structure -> Breadcrumbs stories and inspect the code. 
- When there is only one breadcrumb it should not be a list (div and span).
- When there are multiple breadcrumbs it should be a list. 