### PR TITLE
Increase link sizes for WCAG 2.1 AAA 2.5.5

### DIFF
--- a/src/library/structure/Breadcrumbs/Breadcrumbs.styles.js
+++ b/src/library/structure/Breadcrumbs/Breadcrumbs.styles.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  padding-top: 20px;
+  padding-top: 15px;
   border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey}80;
   margin-bottom: ${(props) => (props.$hasMargin ? props.theme.theme_vars.spacingSizes.large : 0)};
 `;
@@ -17,7 +17,7 @@ export const List = styled.ol`
 
 export const Crumb = styled.li`
   margin-right: ${(props) => props.theme.theme_vars.spacingSizes.small};
-  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  margin-bottom: 0;
   display: none;
   left: 0;
   padding-right: 0;
@@ -46,6 +46,7 @@ export const BreadcrumbLink = styled.a`
   ${(props) => props.theme.linkStyles}
   font-weight: 400;
   display: inline-block;
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small} 0;
 
   svg {
     fill: ${(props) => props.theme.theme_vars.colours.action};

--- a/src/library/structure/Footer/Footer.stories.tsx
+++ b/src/library/structure/Footer/Footer.stories.tsx
@@ -18,15 +18,7 @@ export const ExampleFooter = Template.bind({});
 ExampleFooter.args = {
   footerLinksArray: [
     {
-      title: 'About',
-      url: '/',
-    },
-    {
       title: 'Accessibility',
-      url: '/',
-    },
-    {
-      title: 'Cookies',
       url: '/',
     },
     {
@@ -34,11 +26,19 @@ ExampleFooter.args = {
       url: '/',
     },
     {
-      title: 'Jobs',
+      title: 'Copyright',
       url: '/',
     },
     {
-      title: 'Newsletter',
+      title: 'Payments',
+      url: '/',
+    },
+    {
+      title: 'Privacy',
+      url: '/',
+    },
+    {
+      title: 'Website Feedback',
       url: '/',
     },
   ],

--- a/src/library/structure/Footer/Footer.styles.js
+++ b/src/library/structure/Footer/Footer.styles.js
@@ -84,8 +84,8 @@ export const FooterLink = styled.a`
   ${(props) => props.theme.linkStyles}
   color: ${(props) => props.theme.theme_vars.colours.white};
   font-weight: 400;
-  padding: ${(props) => props.theme.theme_vars.spacingSizes.small}
-    ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
+  padding: ${(props) =>
+    `${props.theme.theme_vars.spacingSizes.small} ${props.theme.theme_vars.spacingSizes.extra_small}`};
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     display: inline-block;

--- a/src/library/structure/Footer/Footer.styles.js
+++ b/src/library/structure/Footer/Footer.styles.js
@@ -16,10 +16,6 @@ export const FooterList = styled.ul`
   margin-bottom: 25px;
   list-style-type: none;
 
-  li:last-of-type {
-    margin-bottom: 0;
-  }
-
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
     margin-bottom: 0px;
   }
@@ -29,8 +25,15 @@ export const FooterListItem = styled.li`
   display: inline-block;
   left: 0;
   padding-right: 0;
-  margin-right: 25px;
-  margin-bottom: 15px;
+  margin-right: 0;
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  width: 100%;
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    width: auto;
+    margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.medium};
+    margin-right: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  }
 `;
 
 export const SocialLinks = styled.ul`
@@ -44,8 +47,8 @@ export const SocialLinkItem = styled.li`
 `;
 
 export const SocialLinkSingle = styled.a`
-  display: inline-block;
-  height: 36px;
+  display: block;
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
 
   &:hover {
     opacity: 0.8;
@@ -77,9 +80,16 @@ export const SocialLinkSingle = styled.a`
 `;
 
 export const FooterLink = styled.a`
+  display: block;
   ${(props) => props.theme.linkStyles}
   color: ${(props) => props.theme.theme_vars.colours.white};
   font-weight: 400;
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small}
+    ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    display: inline-block;
+  }
 
   &:hover {
     ${(props) => props.theme.linkStylesHover}

--- a/src/library/structure/Header/Header.tsx
+++ b/src/library/structure/Header/Header.tsx
@@ -103,6 +103,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
             <Styles.SearchWrapper>
               <Searchbar
                 isLight={themeContext.cardinal_name === 'north' ? true : false}
+                isLarge
                 submitInfo={{
                   postTo: '/search',
                   params: {


### PR DESCRIPTION
This is to help meet the 'Aim for large interactive controls' (WCAG 2.1 AAA 2.5.5) for the elements in the header and footer. This was picked up on the [Silktide report](https://app.index.silktide.com/silktide-index/everything/inspector?checkId=ensure-reasonable-target-size&device=mobile&pointId=9cec3a9e0515d6eff004ee2d1f0f1955&scId=11872587389b460442eaa4957668e1b6&websiteId=3742). The minimum size to aim for to reach AAA is 44px by 44px. I have tried to add padding to the links and then removed the same amount from the containers so they still look the same to the end user. 

The footer links are now stacked on mobile (block instead of inline-block) so that they are easier to read and click. 

This branch is based on the [storybook 7 branch](https://github.com/FutureNorthants/northants-design-system/pull/388) so needs node v18. 

## Testing
- Checkout this branch and run `npm run dev` 
- View the Header, Footer and Breadcrumbs components and test in various screen sizes to test the responsiveness
- Ensure that the links are now all a minimum of 44px x 44px.