### PR TITLE
Add types to theme files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,8 @@ export * from './library/structure/PageStructures';
 export { GDS_theme, north_theme, west_theme, lb_theme_north, lb_theme_west } from './themes/theme_generator';
 
 // CSS reset/common to all
-export { GlobalStyleReset } from './themes/GlobalStyleReset.jsx';
+export { GlobalStyleReset } from './themes/GlobalStyleReset';
+export { ThemeVars } from './themes/ThemeVars.types';
 
 // Directory
 import DirectoryService from './library/directory/DirectoryService/DirectoryService';

--- a/src/themes/GlobalStyleReset.tsx
+++ b/src/themes/GlobalStyleReset.tsx
@@ -5,7 +5,7 @@ import { createGlobalStyle } from 'styled-components';
  * Based upon http://meyerweb.com/eric/tools/css/reset/ with additions to return
  * lists to sane settings. Use for styles common to all themes.
  */
-export const GlobalStyleReset = createGlobalStyle`
+export const GlobalStyleReset: any = createGlobalStyle<any>`
   html {
     box-sizing: border-box;
   }

--- a/src/themes/ThemeVars.types.ts
+++ b/src/themes/ThemeVars.types.ts
@@ -1,0 +1,63 @@
+export interface ThemeVars {
+  theme_name: string;
+  full_name: string;
+  cardinal_name: string;
+  is_memorial: boolean;
+  council_link?: string;
+  other_council_link?: string;
+  other_council_name?: string;
+  other_council_action?: string;
+  twitter_link?: string;
+  linkedin_link?: string;
+  facebook_link?: string;
+  instagram_link?: string;
+  youtube_link?: string;
+  breakpointsVals: ThemeBreakpointTypes;
+  breakpoints: ThemeBreakpointTypes;
+  fontstack: string;
+  colours: ThemeColourTypes;
+  fontSizes: ThemeSizeTypes;
+  border_width: string;
+  border_width_error: string;
+  border_width_thin: string;
+  border_radius: string;
+  border_radius_large: string;
+  spacingSizes: ThemeSizeTypes;
+  h1: string;
+  h2: string;
+  h3: string;
+  h4: string;
+}
+
+export interface ThemeBreakpointTypes {
+  s: string;
+  m: string;
+  l: string;
+  xl: string;
+}
+
+export interface ThemeColourTypes {
+  black: string;
+  grey_darkest: string;
+  grey_dark: string;
+  grey: string;
+  grey_light: string;
+  white: string;
+  action: string;
+  action_light: string;
+  action_dark: string;
+  positive: string;
+  negative: string;
+  visited?: string;
+  focus: string;
+  placeholder: string;
+  secondary?: string;
+}
+
+export interface ThemeSizeTypes {
+  extra_small: string;
+  small: string;
+  medium: string;
+  large: string;
+  x_large?: string;
+}

--- a/src/themes/theme_gds.tsx
+++ b/src/themes/theme_gds.tsx
@@ -1,25 +1,17 @@
-const breakpointsVals = {
+import { ThemeBreakpointTypes, ThemeVars } from './ThemeVars.types';
+
+const breakpointsVals: ThemeBreakpointTypes = {
   s: '550',
   m: '768', // tablets and larger
   l: '1160', // desktops and larger
   xl: '1440', // large desktops only
 };
 
-export const west_vars = {
-  theme_name: 'West Northants theme',
-  full_name: 'West Northamptonshire',
-  cardinal_name: 'west',
+export const gds_vars: ThemeVars = {
+  theme_name: 'GDS theme',
+  cardinal_name: 'gds',
   is_memorial: false,
-  council_link: 'https://www.westnorthants.gov.uk',
-  other_council_link: 'https://www.northnorthants.gov.uk',
-  other_council_name: 'North Northamptonshire',
-  other_council_action: '#016200',
-  twitter_link: 'https://twitter.com/WestNorthants',
-  linkedin_link: 'https://www.linkedin.com/company/west-northamptonshire-council',
-  facebook_link: 'https://www.facebook.com/WestNorthants',
-  instagram_link: 'https://www.instagram.com/westnorthants/',
-  youtube_link: 'https://www.youtube.com/channel/UCDyc2cNcl19OvcGOCuZDTBQ',
-
+  full_name: 'FutureGov Template',
   breakpointsVals: {
     s: breakpointsVals.s,
     m: breakpointsVals.m, // tablets and larger
@@ -40,18 +32,17 @@ export const west_vars = {
     grey_light: '#F5F5F5',
     white: '#FFFFFF',
 
-    action: '#385889',
-    action_light: '#E9EEF3',
-    action_dark: '#0E335B',
+    action: '#1d70b8',
+    action_light: '#FAFAFA',
+    action_dark: '#003078',
     positive: '#6C9A36',
-    negative: '#9D0B1D',
+    negative: '#d4351c',
 
-    focus: '#E2CA76',
+    visited: '#4c2c92',
+    focus: '#fd0',
     placeholder: '#585656',
-
-    secondary: '#6CC7E1',
   },
-  fontstack: 'Roboto, Helvetica, Arial, sans-serif',
+  fontstack: 'GDS Transport, Helvetica, Arial, sans-serif',
   fontSizes: {
     extra_small: '.9em',
     small: '1em',
@@ -61,8 +52,8 @@ export const west_vars = {
   border_width: '2px',
   border_width_error: '3px',
   border_width_thin: '1px',
-  border_radius: '3px',
-  border_radius_large: '6px',
+  border_radius: '0px',
+  border_radius_large: '0px',
   spacingSizes: {
     extra_small: '5px',
     small: '10px',

--- a/src/themes/theme_generator.tsx
+++ b/src/themes/theme_generator.tsx
@@ -4,8 +4,9 @@ import { west_vars } from './theme_west';
 import { lb_vars_north } from './theme_london_bridge_north';
 import { lb_vars_west } from './theme_london_bridge_west';
 import { css } from 'styled-components';
+import { ThemeVars } from './ThemeVars.types';
 
-const generate_theme = (theme_vars) => {
+const generate_theme = (theme_vars: ThemeVars) => {
   return {
     name: theme_vars.theme_name,
     full_name: theme_vars.full_name,

--- a/src/themes/theme_london_bridge_north.tsx
+++ b/src/themes/theme_london_bridge_north.tsx
@@ -1,15 +1,27 @@
-const breakpointsVals = {
+import { ThemeBreakpointTypes, ThemeVars } from './ThemeVars.types';
+
+const breakpointsVals: ThemeBreakpointTypes = {
   s: '550',
   m: '768', // tablets and larger
   l: '1160', // desktops and larger
   xl: '1440', // large desktops only
 };
 
-export const gds_vars = {
-  theme_name: 'GDS theme',
-  cardinal_name: 'gds',
-  is_memorial: false,
-  full_name: 'FutureGov Template',
+export const lb_vars_north: ThemeVars = {
+  theme_name: 'Memorial theme North',
+  full_name: 'North Northamptonshire',
+  cardinal_name: 'north',
+  is_memorial: true,
+  council_link: 'https://www.northnorthants.gov.uk',
+  other_council_link: 'https://www.westnorthants.gov.uk',
+  other_council_name: 'West Northamptonshire',
+  other_council_action: '#385889',
+  twitter_link: 'https://twitter.com/NNorthantsC',
+  linkedin_link: 'https://www.linkedin.com/company/north-northamptonshire-council',
+  facebook_link: 'https://www.facebook.com/NorthNorthants',
+  instagram_link: 'https://www.instagram.com/northnorthantscouncil/',
+  youtube_link: 'https://www.youtube.com/channel/UCnng5JhKCm4lUbvuzZM07sA',
+
   breakpointsVals: {
     s: breakpointsVals.s,
     m: breakpointsVals.m, // tablets and larger
@@ -30,17 +42,17 @@ export const gds_vars = {
     grey_light: '#F5F5F5',
     white: '#FFFFFF',
 
-    action: '#1d70b8',
-    action_light: '#FAFAFA',
-    action_dark: '#003078',
-    positive: '#6C9A36',
-    negative: '#d4351c',
+    action: '#000000',
+    action_light: '#C6C6C6',
+    action_dark: '#333333',
+    positive: '#147DAD',
+    negative: '#B73131',
 
-    visited: '#4c2c92',
-    focus: '#fd0',
+    focus: '#E2CA76',
     placeholder: '#585656',
+    secondary: '#1A9DD9',
   },
-  fontstack: 'GDS Transport, Helvetica, Arial, sans-serif',
+  fontstack: 'Arial, Helvetica, sans-serif',
   fontSizes: {
     extra_small: '.9em',
     small: '1em',
@@ -50,8 +62,8 @@ export const gds_vars = {
   border_width: '2px',
   border_width_error: '3px',
   border_width_thin: '1px',
-  border_radius: '0px',
-  border_radius_large: '0px',
+  border_radius: '3px',
+  border_radius_large: '6px',
   spacingSizes: {
     extra_small: '5px',
     small: '10px',

--- a/src/themes/theme_london_bridge_west.tsx
+++ b/src/themes/theme_london_bridge_west.tsx
@@ -1,24 +1,26 @@
-const breakpointsVals = {
+import { ThemeBreakpointTypes, ThemeVars } from './ThemeVars.types';
+
+const breakpointsVals: ThemeBreakpointTypes = {
   s: '550',
   m: '768', // tablets and larger
   l: '1160', // desktops and larger
   xl: '1440', // large desktops only
 };
 
-export const lb_vars_north = {
-  theme_name: 'Memorial theme North',
-  full_name: 'North Northamptonshire',
-  cardinal_name: 'north',
+export const lb_vars_west: ThemeVars = {
+  theme_name: 'Memorial theme West',
+  full_name: 'West Northamptonshire',
+  cardinal_name: 'west',
   is_memorial: true,
-  council_link: 'https://www.northnorthants.gov.uk',
-  other_council_link: 'https://www.westnorthants.gov.uk',
-  other_council_name: 'West Northamptonshire',
-  other_council_action: '#385889',
-  twitter_link: 'https://twitter.com/NNorthantsC',
-  linkedin_link: 'https://www.linkedin.com/company/north-northamptonshire-council',
-  facebook_link: 'https://www.facebook.com/NorthNorthants',
-  instagram_link: 'https://www.instagram.com/northnorthantscouncil/',
-  youtube_link: 'https://www.youtube.com/channel/UCnng5JhKCm4lUbvuzZM07sA',
+  council_link: 'https://www.westnorthants.gov.uk',
+  other_council_link: 'https://www.northnorthants.gov.uk',
+  other_council_name: 'North Northamptonshire',
+  other_council_action: '#016200',
+  twitter_link: 'https://twitter.com/WestNorthants',
+  linkedin_link: 'https://www.linkedin.com/company/west-northamptonshire-council',
+  facebook_link: 'https://www.facebook.com/WestNorthants',
+  instagram_link: 'https://www.instagram.com/westnorthants/',
+  youtube_link: 'https://www.youtube.com/channel/UCDyc2cNcl19OvcGOCuZDTBQ',
 
   breakpointsVals: {
     s: breakpointsVals.s,
@@ -40,17 +42,18 @@ export const lb_vars_north = {
     grey_light: '#F5F5F5',
     white: '#FFFFFF',
 
-    action: '#000000',
+    action: '#3C3C3B',
     action_light: '#C6C6C6',
     action_dark: '#333333',
-    positive: '#147DAD',
-    negative: '#B73131',
+    positive: '#6C9A36',
+    negative: '#9D0B1D',
 
     focus: '#E2CA76',
     placeholder: '#585656',
-    secondary: '#1A9DD9',
+
+    secondary: '#6CC7E1',
   },
-  fontstack: 'Arial, Helvetica, sans-serif',
+  fontstack: 'Roboto, Helvetica, Arial, sans-serif',
   fontSizes: {
     extra_small: '.9em',
     small: '1em',

--- a/src/themes/theme_north.tsx
+++ b/src/themes/theme_north.tsx
@@ -1,11 +1,13 @@
-const breakpointsVals = {
+import { ThemeBreakpointTypes, ThemeVars } from './ThemeVars.types';
+
+const breakpointsVals: ThemeBreakpointTypes = {
   s: '550',
   m: '768', // tablets and larger
   l: '1160', // desktops and larger
   xl: '1440', // large desktops only
 };
 
-export const north_vars = {
+export const north_vars: ThemeVars = {
   theme_name: 'North Northants theme',
   full_name: 'North Northamptonshire',
   cardinal_name: 'north',

--- a/src/themes/theme_west.tsx
+++ b/src/themes/theme_west.tsx
@@ -1,15 +1,17 @@
-const breakpointsVals = {
+import { ThemeBreakpointTypes, ThemeVars } from './ThemeVars.types';
+
+const breakpointsVals: ThemeBreakpointTypes = {
   s: '550',
   m: '768', // tablets and larger
   l: '1160', // desktops and larger
   xl: '1440', // large desktops only
 };
 
-export const lb_vars_west = {
-  theme_name: 'Memorial theme West',
+export const west_vars: ThemeVars = {
+  theme_name: 'West Northants theme',
   full_name: 'West Northamptonshire',
   cardinal_name: 'west',
-  is_memorial: true,
+  is_memorial: false,
   council_link: 'https://www.westnorthants.gov.uk',
   other_council_link: 'https://www.northnorthants.gov.uk',
   other_council_name: 'North Northamptonshire',
@@ -40,9 +42,9 @@ export const lb_vars_west = {
     grey_light: '#F5F5F5',
     white: '#FFFFFF',
 
-    action: '#3C3C3B',
-    action_light: '#C6C6C6',
-    action_dark: '#333333',
+    action: '#385889',
+    action_light: '#E9EEF3',
+    action_dark: '#0E335B',
     positive: '#6C9A36',
     negative: '#9D0B1D',
 


### PR DESCRIPTION
Updated the themes to .ts files instead of .js and then added the types to the theme files. 

This should create the missing type files for the theme_generator and GlobalStyleReset that are imported, (but previously missing) from the 'build/index.d.ts' file. 

## Testing
- Checkout this branch and run `npm install`
- Delete the `build` directory
- Run `npm run build` and inspect the `build/index.d.ts` file. It should no longer have missing imports.
- The build directory should now have a 'themes' directory with the relevant type declarations.
