### PR TITLE
Fix type declarations missing in rollup build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+    "rootDir": "src",
     "declaration": true,
-    "declarationDir": "build",
+    "declarationDir": "./build",
     "module": "esnext",
     "target": "es5",
     "lib": ["es6", "dom", "es2016", "es2017"],
@@ -12,7 +13,7 @@
     "esModuleInterop": true,
     "types": ["node", "jest", "@testing-library/jest-dom", "@testing-library/jest-dom/jest-globals"]
   },
-  "include": ["src/**/*", "custom.d.ts", "jest.setup.ts"],
+  "include": ["./src/**/*", "custom.d.ts"],
   "files": ["custom.d.ts"],
   "exclude": ["node_modules", "build", "storybook-static", "src/**/*.stories.tsx"]
 }


### PR DESCRIPTION
After publishing v1 it seems the type declarations are missing. I think this was working when I tested before as I had a previous build with the types included and they were not removed by the build. When I deleted the build folder and published, the type declarations are missing. 

This reverts changes to the tsconfig that were made due to issues I was having with jest not finding the types. This doesn't seem to be an issue anymore after removing the 'src/**/*.test.tsx' from the exclude array. This means other changes can be reverted. 

## Testing
- Checkout this branch and run `npm install` (using node 18)
- Delete the `build` folder so it creates it all from scratch
- Run `yalc publish`
- Use [this branch](https://github.com/FutureNorthants/northants-website/pull/872) in the frontend and run `yalc add northants-design-system` then `npm install` and `npm run build`. 
- The frontend build should now work without type declarations missing from the build