### PR TITLE
Add Streaming Video slice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/jest": "^29.2.5",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
+        "@types/video.js": "^7.3.56",
         "@typescript-eslint/eslint-plugin": "^6.0",
         "@typescript-eslint/parser": "^6.0",
         "axios": "^1",
@@ -72,6 +73,7 @@
         "styled-components": "^6.1.1",
         "ts-jest": "^29",
         "typescript": "^5.0.0",
+        "video.js": "^8.10.0",
         "webpack": "^5.69.0"
       },
       "peerDependencies": {
@@ -7391,6 +7393,12 @@
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
       "dev": true
     },
+    "node_modules/@types/video.js": {
+      "version": "7.3.56",
+      "resolved": "https://registry.npmjs.org/@types/video.js/-/video.js-7.3.56.tgz",
+      "integrity": "sha512-T3cp/kDuNj8scIzK87u0uomUDKnYQE1uHAA0zFPNGc0qCF3aLxZmMtpWvGxofEPNOpUfvtbsQMvwbjU42q8omw==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -7700,6 +7708,55 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@videojs/http-streaming": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.10.0.tgz",
+      "integrity": "sha512-Lf1rmhTalV4Gw0bJqHmH4lfk/FlepUDs9smuMtorblAYnqDlE2tbUOb7sBXVYoXGdbWbdTW8jH2cnS+6HWYJ4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "4.0.0",
+        "aes-decrypter": "4.0.1",
+        "global": "^4.4.0",
+        "m3u8-parser": "^7.1.0",
+        "mpd-parser": "^1.3.0",
+        "mux.js": "7.0.2",
+        "video.js": "^7 || ^8"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "video.js": "^7 || ^8"
+      }
+    },
+    "node_modules/@videojs/vhs-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
+      "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "node_modules/@videojs/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
@@ -7844,6 +7901,15 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -8014,6 +8080,33 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aes-decrypter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
+      "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
+      }
+    },
+    "node_modules/aes-decrypter/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "node_modules/agent-base": {
@@ -10837,6 +10930,12 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -13220,6 +13319,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -13941,6 +14050,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/individual": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
+      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g==",
+      "dev": true
+    },
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -14210,6 +14325,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -16797,6 +16918,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha512-ps3I9jAdNtRpJrbBvQjpzyFbss/skHqzS+eu4RxKLaEAtFqkjZaB6TZMSivPbLxf4K7VI4SjR0P5mRCX5+Q25A==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -17071,6 +17198,32 @@
       "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/m3u8-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
+      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
+    "node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "node_modules/magic-string": {
@@ -17353,6 +17506,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dev": true,
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -17517,6 +17679,21 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mpd-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
+      "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^4.0.0",
+        "@xmldom/xmldom": "^0.8.3",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "mpd-to-m3u8-json": "bin/parse.js"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -17531,6 +17708,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/mux.js": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
+      "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
     },
     "node_modules/nan": {
       "version": "2.18.0",
@@ -18748,6 +18942,18 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkcs7": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
+      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.5.5"
+      },
+      "bin": {
+        "pkcs7": "bin/cli.js"
       }
     },
     "node_modules/pkg-dir": {
@@ -20940,6 +21146,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rust-result": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
+      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
+      "dev": true,
+      "dependencies": {
+        "individual": "^2.0.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -20983,6 +21198,15 @@
       "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
       "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
       "dev": true
+    },
+    "node_modules/safe-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
+      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
+      "dev": true,
+      "dependencies": {
+        "rust-result": "^1.0.0"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -23057,6 +23281,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/url-toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg==",
+      "dev": true
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -23197,6 +23427,59 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/video.js": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.10.0.tgz",
+      "integrity": "sha512-7UeG/flj/pp8tNGW8WKPP1VJb3x2FgLoqUWzpZqkoq5YIyf6MNzmIrKtxprl438T5RVkcj+OzV8IX4jYSAn4Sw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/http-streaming": "3.10.0",
+        "@videojs/vhs-utils": "^4.0.0",
+        "@videojs/xhr": "2.6.0",
+        "aes-decrypter": "^4.0.1",
+        "global": "4.4.0",
+        "keycode": "2.2.0",
+        "m3u8-parser": "^7.1.0",
+        "mpd-parser": "^1.2.2",
+        "mux.js": "^7.0.1",
+        "safe-json-parse": "4.0.0",
+        "videojs-contrib-quality-levels": "4.0.0",
+        "videojs-font": "4.1.0",
+        "videojs-vtt.js": "0.15.5"
+      }
+    },
+    "node_modules/videojs-contrib-quality-levels": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.0.0.tgz",
+      "integrity": "sha512-u5rmd8BjLwANp7XwuQ0Q/me34bMe6zg9PQdHfTS7aXgiVRbNTb4djcmfG7aeSrkpZjg+XCLezFNenlJaCjBHKw==",
+      "dev": true,
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "video.js": "^8"
+      }
+    },
+    "node_modules/videojs-font": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-4.1.0.tgz",
+      "integrity": "sha512-X1LuPfLZPisPLrANIAKCknZbZu5obVM/ylfd1CN+SsCmPZQ3UMDPcvLTpPBJxcBuTpHQq2MO1QCFt7p8spnZ/w==",
+      "dev": true
+    },
+    "node_modules/videojs-vtt.js": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.5.tgz",
+      "integrity": "sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==",
+      "dev": true,
+      "dependencies": {
+        "global": "^4.3.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "axios": "^1",
     "react": ">=18.2.0",
     "react-dom": ">=18.2.0",
-    "styled-components": "^6.1.1"
+    "styled-components": "^6.1.1",
+    "video.js": "^8.10.0"
   },
   "resolutions": {
     "@storybook/react/webpack": "^5"
@@ -71,6 +72,7 @@
     "@types/jest": "^29.2.5",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
+    "@types/video.js": "^7.3.56",
     "@typescript-eslint/eslint-plugin": "^6.0",
     "@typescript-eslint/parser": "^6.0",
     "axios": "^1",
@@ -104,6 +106,7 @@
     "styled-components": "^6.1.1",
     "ts-jest": "^29",
     "typescript": "^5.0.0",
+    "video.js": "^8.10.0",
     "webpack": "^5.69.0"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import ImageAndText from './library/slices/ImageAndText/ImageAndText';
 import InquestSchedule from './library/slices/InquestSchedule/InquestSchedule';
 import Promotions from './library/slices/Promotions/Promotions';
 import SearchBox from './library/slices/SearchBox/SearchBox';
+import StreamingVideo from './library/slices/StreamingVideo/StreamingVideo';
 import Video from './library/slices/Video/Video';
 import WarningText from './library/slices/WarningText/WarningText';
 import WarningTextDisclaimer from './library/slices/WarningTextDisclaimer/WarningTextDisclaimer';
@@ -63,6 +64,7 @@ export {
   InquestSchedule,
   Promotions,
   SearchBox,
+  StreamingVideo,
   Video,
   WarningText,
   WarningTextDisclaimer,

--- a/src/library/slices/StreamingVideo/StreamingVideo.stories.tsx
+++ b/src/library/slices/StreamingVideo/StreamingVideo.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import StreamingVideo from './StreamingVideo';
+import { StreamingVideoProps } from './StreamingVideo.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
+import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
+import PageMain from '../../structure/PageMain/PageMain';
+
+export default {
+  title: 'Library/Slices/StreamingVideo',
+  component: StreamingVideo,
+  parameters: {
+    status: {
+      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+    },
+  },
+};
+
+const Template: StoryFn<StreamingVideoProps> = (args) => (
+  <SBPadding>
+    <MaxWidthContainer>
+      <PageMain>
+        <StreamingVideo {...args} />
+      </PageMain>
+    </MaxWidthContainer>
+  </SBPadding>
+);
+
+// TODO: Replace the src with a council video feed
+
+export const ExampleStreamingVideo = Template.bind({});
+ExampleStreamingVideo.args = {
+  src: 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8',
+  type: 'application/x-mpegURL',
+  title: 'An example streaming video',
+  autoplay: false,
+};
+
+export const ExampleStreamingVideoNoTitle = Template.bind({});
+ExampleStreamingVideoNoTitle.args = {
+  src: 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8',
+  type: 'application/x-mpegURL',
+};

--- a/src/library/slices/StreamingVideo/StreamingVideo.styles.js
+++ b/src/library/slices/StreamingVideo/StreamingVideo.styles.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Container = styled.figure`
+  display: block;
+`;

--- a/src/library/slices/StreamingVideo/StreamingVideo.test.tsx
+++ b/src/library/slices/StreamingVideo/StreamingVideo.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
+
+import StreamingVideo from './StreamingVideo';
+import { StreamingVideoProps } from './StreamingVideo.types';
+
+describe('StreamingVideo', () => {
+  let props: StreamingVideoProps;
+
+  beforeEach(() => {
+    props = {
+      src: 'http://localhost/video/output.m3u8',
+      title: 'Test title',
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <StreamingVideo {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render foo text correctly', () => {
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('StreamingVideo');
+    const video = component.getElementsByClassName('video-js');
+
+    expect(component).toBeVisible();
+    expect(component).toHaveTextContent('Test title');
+    expect(video.length).toBe(1);
+  });
+});

--- a/src/library/slices/StreamingVideo/StreamingVideo.tsx
+++ b/src/library/slices/StreamingVideo/StreamingVideo.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { StreamingVideoProps } from './StreamingVideo.types';
+import * as Styles from './StreamingVideo.styles';
+import videojs from 'video.js';
+import 'video.js/dist/video-js.css';
+import Heading from '../../components/Heading/Heading';
+
+/**
+ * A component to stream live video feeds, such as HLS, using video.js
+ */
+const StreamingVideo: React.FunctionComponent<StreamingVideoProps> = ({
+  src,
+  type = 'application/x-mpegURL',
+  title = null,
+  autoplay = false,
+  controls = true,
+  responsive = true,
+  fluid = true,
+  onReady = null,
+}) => {
+  const videoRef = useRef(null);
+  const [player, setPlayer] = useState<ReturnType<typeof videojs>>();
+
+  useEffect(() => {
+    // make sure Video.js player is only initialized once
+    if (!player) {
+      const videoElement = videoRef.current;
+      if (!videoElement) return;
+
+      setPlayer(
+        videojs(
+          videoElement,
+          {
+            autoplay,
+            controls,
+            responsive,
+            fluid,
+          },
+          () => {
+            onReady && onReady;
+          }
+        )
+      );
+    }
+  }, [videoRef]);
+
+  useEffect(() => {
+    return () => {
+      if (player) {
+        player.dispose();
+      }
+    };
+  }, [player]);
+
+  return (
+    <Styles.Container data-testid="StreamingVideo">
+      {title && <Heading text={title} level={2} />}
+      <video className="video-js" ref={videoRef} controls>
+        <source src={src} type={type} />
+      </video>
+    </Styles.Container>
+  );
+};
+
+export default StreamingVideo;

--- a/src/library/slices/StreamingVideo/StreamingVideo.types.ts
+++ b/src/library/slices/StreamingVideo/StreamingVideo.types.ts
@@ -1,0 +1,41 @@
+export interface StreamingVideoProps {
+  /**
+   * The video source url
+   */
+  src: string;
+
+  /**
+   * The format type of the video (defaults to HLS)
+   */
+  type?: string;
+
+  /**
+   * An optional title
+   */
+  title?: string;
+
+  /**
+   * Should the video autoplay (false by default)
+   */
+  autoplay?: boolean;
+
+  /**
+   * Should the controls be shown (true by default)
+   */
+  controls?: boolean;
+
+  /**
+   * Should the controls vary based on the screen size (true by default)
+   */
+  responsive?: boolean;
+
+  /**
+   * Should the video fill the users screen (true by default)
+   */
+  fluid?: boolean;
+
+  /**
+   * An optional on ready method
+   */
+  onReady?: (player) => {};
+}

--- a/util/templates/component.js
+++ b/util/templates/component.js
@@ -5,12 +5,12 @@ import React from "react";
 import { ${componentName}Props } from "./${componentName}.types";
 import * as Styles from "./${componentName}.styles";
 
-const ${componentName}: React.FC<${componentName}Props> = ({ foo }) => (
+const ${componentName}: React.FunctionComponent<${componentName}Props> = ({ foo }) => (
     <Styles.Container data-testid="${componentName}">{foo}</Styles.Container>
 );
 
 export default ${componentName};
 
 `,
-  extension: `.tsx`
+  extension: `.tsx`,
 });

--- a/util/templates/component.stories.js
+++ b/util/templates/component.stories.js
@@ -1,7 +1,7 @@
 module.exports = (componentName) => ({
   content: `
 import React from "react";
-import { Story } from '@storybook/react/types-6-0';
+import { StoryFn } from '@storybook/react';
 import ${componentName} from "./${componentName}";
 import { ${componentName}Props } from "./${componentName}.types";
 import { SBPadding } from '../../../../.storybook/SBPadding';
@@ -16,7 +16,7 @@ export default {
     },
 };
 
-const Template: Story<${componentName}Props> = (args) => <SBPadding><${componentName} {...args} /></SBPadding>;
+const Template: StoryFn<${componentName}Props> = (args) => <SBPadding><${componentName} {...args} /></SBPadding>;
 
 export const Example${componentName} = Template.bind({});    
 Example${componentName}.args = {
@@ -28,5 +28,5 @@ AnotherExample${componentName}.args = {
   foo: "foo"
 };
 `,
-  extension: `.stories.tsx`
+  extension: `.stories.tsx`,
 });

--- a/util/templates/component.test.js
+++ b/util/templates/component.test.js
@@ -2,6 +2,8 @@ module.exports = (componentName) => ({
   content: `
 import React from "react";
 import { render } from "@testing-library/react";
+import { west_theme } from '../../../themes/theme_generator';
+import { ThemeProvider } from 'styled-components';
 
 import ${componentName} from "./${componentName}";
 import { ${componentName}Props } from "./${componentName}.types";
@@ -15,7 +17,12 @@ describe("Test Component", () => {
     };
   });
 
-  const renderComponent = () => render(<${componentName} {...props} />);
+  const renderComponent = () => 
+    render(
+      <ThemeProvider theme={west_theme}>
+        <${componentName} {...props} />
+      </ThemeProvider>
+    );
 
   it("should render foo text correctly", () => {
     props.foo = "example content";
@@ -27,5 +34,5 @@ describe("Test Component", () => {
   });
 });
 `,
-  extension: `.test.tsx`
+  extension: `.test.tsx`,
 });


### PR DESCRIPTION
Add a slice for viewing streaming video feeds in preparation for the HWRC video feeds. This uses [video.js](https://videojs.com/getting-started) to support browsers that are not natively compatible with Http Live Stream by default. 

The StreamingVideo component is based on [this article](https://medium.com/cisco-fpie/how-to-render-rtsp-streams-within-a-react-app-e7957e591075) with a few modifications. 