### PR TITLE
Add clear filters button next to search

### DIFF
--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
@@ -41,22 +41,34 @@ export const ButtonContainer = styled.div`
 `;
 
 export const Button = styled.button`
-  border: 1px solid ${(props) => props.theme.theme_vars.colours.white};
-  background: ${(props) => props.theme.theme_vars.colours.action};
-  color: ${(props) => props.theme.theme_vars.colours.white};
+  border: ${(props) => (props.$isWarning ? `3px` : `1px`)} solid
+    ${(props) => (props.$isWarning ? props.theme.theme_vars.colours.negative : props.theme.theme_vars.colours.white)};
+  background: ${(props) =>
+    props.$isWarning ? props.theme.theme_vars.colours.white : props.theme.theme_vars.colours.action};
+  color: ${(props) =>
+    props.$isWarning ? props.theme.theme_vars.colours.negative : props.theme.theme_vars.colours.white};
   padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
   cursor: pointer;
   border-radius: ${(props) => props.theme.theme_vars.border_radius};
   min-height: 42px;
   margin-right: ${(props) => props.theme.theme_vars.spacingSizes.medium};
+  font-weight: bold;
 
   &:hover {
-    background: ${(props) => props.theme.theme_vars.colours.action_dark};
+    background: ${(props) =>
+      props.$isWarning ? props.theme.theme_vars.colours.action_light : props.theme.theme_vars.colours.action_dark};
+    color: ${(props) =>
+      props.$isWarning ? props.theme.theme_vars.colours.action_dark : props.theme.theme_vars.colours.white};
+    text-decoration: underline;
+    text-decoration-style: dotted;
   }
 
   &:focus {
-    outline: none;
-    background: ${(props) => props.theme.theme_vars.colours.focus};
+    ${(props) => props.theme.linkStylesFocus}
+  }
+
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
   }
 `;
 

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
@@ -187,4 +187,30 @@ describe('Test Component', () => {
 
     expect(component).toHaveTextContent('Sorry, there was a problem fetching results. Please try again later.');
   });
+
+  it('should show the clear filters button when only search term is set', () => {
+    props.categories = [];
+    props.maximumAge = '';
+    props.minimumAge = '';
+    props.search = 'test';
+
+    const { getByRole } = renderComponent();
+    const clearSearch = getByRole('button', { name: 'Clear all filters' });
+
+    expect(clearSearch).toBeVisible();
+    expect(clearSearch).toHaveStyle(`border: 3px solid ${west_theme.theme_vars.colours.negative}`);
+  });
+
+  it('should show the clear filters button when only postcode is set', () => {
+    props.categories = [];
+    props.maximumAge = '';
+    props.minimumAge = '';
+    props.postcode = 'nn1';
+
+    const { getByRole } = renderComponent();
+    const clearSearch = getByRole('button', { name: 'Clear all filters' });
+
+    expect(clearSearch).toBeVisible();
+    expect(clearSearch).toHaveStyle(`border: 3px solid ${west_theme.theme_vars.colours.negative}`);
+  });
 });

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
@@ -195,7 +195,7 @@ describe('Test Component', () => {
     props.search = 'test';
 
     const { getByRole } = renderComponent();
-    const clearSearch = getByRole('button', { name: 'Clear all filters' });
+    const clearSearch = getByRole('button', { name: 'Clear search' });
 
     expect(clearSearch).toBeVisible();
     expect(clearSearch).toHaveStyle(`border: 3px solid ${west_theme.theme_vars.colours.negative}`);
@@ -208,7 +208,7 @@ describe('Test Component', () => {
     props.postcode = 'nn1';
 
     const { getByRole } = renderComponent();
-    const clearSearch = getByRole('button', { name: 'Clear all filters' });
+    const clearSearch = getByRole('button', { name: 'Clear search' });
 
     expect(clearSearch).toBeVisible();
     expect(clearSearch).toHaveStyle(`border: 3px solid ${west_theme.theme_vars.colours.negative}`);

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -238,7 +238,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
 
                     {filtersActive && (
                       <Styles.Button onClick={clearSearch} type="button" $isWarning={true}>
-                        <Styles.ButtonText>Clear all filters</Styles.ButtonText>
+                        <Styles.ButtonText>Clear search</Styles.ButtonText>
                       </Styles.Button>
                     )}
                   </Styles.ButtonContainer>

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -70,7 +70,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
 
   useEffect(() => {
     setFiltersActive(hasActiveFilters());
-  }, [minimumAge, maximumAge, categories]);
+  }, [minimumAge, maximumAge, categories, search, postcode]);
 
   if (accordions.length === 0) {
     const tempAccordions = [];
@@ -186,6 +186,8 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
 
   const hasActiveFilters = () => {
     return (
+      search !== '' ||
+      postcode !== '' ||
       maximumAge !== '' ||
       minimumAge !== '' ||
       categories.some((category) => {
@@ -233,6 +235,12 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                       <Styles.ButtonText>Search</Styles.ButtonText>
                       <SearchIcon colourFill="#fff" />
                     </Styles.Button>
+
+                    {filtersActive && (
+                      <Styles.Button onClick={clearSearch} type="button" $isWarning={true}>
+                        <Styles.ButtonText>Clear all filters</Styles.ButtonText>
+                      </Styles.Button>
+                    )}
                   </Styles.ButtonContainer>
                 </Column>
                 {hasDocuments && (


### PR DESCRIPTION
- Add a clear all filters button next to the search to make it easier and more obvious to reset the whole search. 
- Make the button appear when search, postcode or any of the filters are active
- Update button styles to match standard buttons focus and active states

See [acceptance criteria](https://odaniels.atlassian.net/browse/LOP2-22) for this issue. 

## Testing
- Checkout this branch and run `yalc publish`
- Checkout the preprod_frontend branch and run `yalc add northants-design-system` then `npm install` and then `npm run dev`
- Visit the Local Offer directory page and test the clear all filters button appears when you enter a search term and press the search button
- Test the clear all filters button resets the results
- Test entering a postcode and then pressing search. The clear all filters button should now appear. 
- Press the Clear all filters button again
- Test the clear all filters button appears when you select a filter in the left hand filters