### PR TITLE
Fix search bar alignment with error message

### DIFF
--- a/src/library/structure/Searchbar/Searchbar.stories.tsx
+++ b/src/library/structure/Searchbar/Searchbar.stories.tsx
@@ -3,6 +3,8 @@ import { StoryFn } from '@storybook/react';
 import Searchbar from './Searchbar';
 import { SearchbarProps } from './Searchbar.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
+import MaxWidthContainer from '../MaxWidthContainer/MaxWidthContainer';
+import PageMain from '../PageMain/PageMain';
 
 export default {
   title: 'Library/structure/Searchbar',
@@ -82,6 +84,16 @@ const Template: StoryFn<SearchbarProps> = (args) => (
   </SBPadding>
 );
 
+const TemplatePage: StoryFn<SearchbarProps> = (args) => (
+  <SBPadding>
+    <MaxWidthContainer>
+      <PageMain>
+        <Searchbar {...args} />
+      </PageMain>
+    </MaxWidthContainer>
+  </SBPadding>
+);
+
 export const ExampleSearchbarDefaultNorth = Template.bind({});
 ExampleSearchbarDefaultNorth.parameters = {
   backgrounds: { default: 'north' },
@@ -104,14 +116,21 @@ ExampleSearchbarWhiteBackground.args = {
   isLight: true,
 };
 
-export const ExampleSearchPage = Template.bind({});
+export const ExampleSearchPage = TemplatePage.bind({});
 ExampleSearchPage.args = {
   ...CommonArgs,
   isLight: true,
   isLarge: true,
 };
 
-export const ExampleSearchPageWithTerm = Template.bind({});
+export const ExampleSearchPageSmall = TemplatePage.bind({});
+ExampleSearchPageSmall.args = {
+  ...CommonArgs,
+  isLight: true,
+  isLarge: false,
+};
+
+export const ExampleSearchPageWithTerm = TemplatePage.bind({});
 ExampleSearchPageWithTerm.args = {
   ...CommonArgs,
   isLight: true,

--- a/src/library/structure/Searchbar/Searchbar.styles.js
+++ b/src/library/structure/Searchbar/Searchbar.styles.js
@@ -22,6 +22,10 @@ export const InputWrapper = styled.div`
   position: relative;
   width: auto;
   max-width: 750px;
+
+  p {
+    margin-bottom: 5px !important;
+  }
 `;
 
 export const Button = styled.button`
@@ -30,7 +34,7 @@ export const Button = styled.button`
   right: ${(props) => (props.$isLarge ? '-5rem' : '-3rem')};
   cursor: pointer;
   margin: 0;
-  margin-top: ${(props) => (props.$isErrored ? '25px' : 0)};
+  margin-top: ${(props) => (props.$isErrored ? (props.$isLarge ? '20px' : '20px') : 0)};
   padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
   background: ${(props) =>
     props.$isLight ? props.theme.theme_vars.colours.action : props.theme.theme_vars.colours.grey_darkest};
@@ -44,6 +48,7 @@ export const Button = styled.button`
   height: ${(props) => (props.$isLarge ? '2.9rem' : '2.28rem')};
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     height: ${(props) => (props.$isLarge ? '3.22rem' : '2.6rem')};
+    margin-top: ${(props) => (props.$isErrored ? (props.$isLarge ? '26px' : '26px') : 0)};
   }
 
   &:hover {


### PR DESCRIPTION
When the search bar was within PageMain, the error message had more margin. This overrides the margin so it is fixed. The margin also needed to be changed based on the screen width as the error text changes size too. 

## Testing
- Checkout this branch and run `npm run dev`
- Test out the stories for the search bar. Some use page main and others don't. 
- Test different screen sizes to ensure the button aligns correctly when the error message is shown (search without a term). 