### PR TITLE
Replace LazyImage with ResponsiveImage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "core-js": "^3.20.2",
         "downshift": "^6.1.7",
         "html-react-parser": "^3",
-        "react-lazy-progressive-image": "^1.5.5",
         "react-qr-code": "^2.0.11",
         "sanitize-html": "^2.6.1",
         "stylis": "^4.3.0"
@@ -19865,20 +19864,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-lazy-progressive-image": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/react-lazy-progressive-image/-/react-lazy-progressive-image-1.5.5.tgz",
-      "integrity": "sha512-s4lcvHElRElEXyajtlr+j8LKaBmcYbzRcLmyjQrtIe5VYV+5+nHN9POzmc1OoDS2EiAc1x+qGMhnV2LgkYgEPw==",
-      "dependencies": {
-        "react-visibility-sensor": "^5.1.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
-      }
-    },
     "node_modules/react-property": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
@@ -19992,18 +19977,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-visibility-sensor": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
-      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "core-js": "^3.20.2",
     "downshift": "^6.1.7",
     "html-react-parser": "^3",
-    "react-lazy-progressive-image": "^1.5.5",
     "react-qr-code": "^2.0.11",
     "sanitize-html": "^2.6.1",
     "stylis": "^4.3.0"

--- a/src/library/components/ResponsiveImage/ResponsiveImage.stories.tsx
+++ b/src/library/components/ResponsiveImage/ResponsiveImage.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import ResponsiveImage from './ResponsiveImage';
+import { ResponsiveImageProps } from './ResponsiveImage.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
+
+export default {
+  title: 'Library/Components/Responsive Image',
+  component: ResponsiveImage,
+  parameters: {
+    status: {
+      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+    },
+  },
+};
+
+const Template: StoryFn<ResponsiveImageProps> = (args) => (
+  <SBPadding>
+    <ResponsiveImage {...args} />
+  </SBPadding>
+);
+
+export const ExampleResponsiveImageCover = Template.bind({});
+ExampleResponsiveImageCover.args = {
+  imageLarge: 'https://via.placeholder.com/800x600?text=4+by+3+image',
+  imageSmall: 'https://via.placeholder.com/400x300',
+  imageAltText: 'Parkland',
+  ratio: '16by9',
+  objectFit: 'cover',
+};
+
+export const ExampleResponsiveImageContain = Template.bind({});
+ExampleResponsiveImageContain.args = {
+  imageLarge: 'https://via.placeholder.com/800x600?text=4+by+3+image',
+  imageSmall: 'https://via.placeholder.com/400x300',
+  imageAltText: 'Parkland',
+  ratio: '4by3',
+  objectFit: 'contain',
+};
+
+const TemplateAuto: StoryFn<ResponsiveImageProps> = (args) => (
+  <SBPadding>
+    <p>
+      Auto makes the image position absolute to always fit the container, so the container needs `position: relative;`
+    </p>
+    <div style={{ width: '100%', height: '300px', position: 'relative' }}>
+      <ResponsiveImage {...args} />
+    </div>
+  </SBPadding>
+);
+
+export const ExampleResponsiveImageAutoRatio = TemplateAuto.bind({});
+ExampleResponsiveImageAutoRatio.args = {
+  imageLarge: 'https://via.placeholder.com/800x600?text=4+by+3+image',
+  imageSmall: 'https://via.placeholder.com/400x300',
+  imageAltText: 'Parkland',
+  ratio: 'auto',
+  objectFit: 'cover',
+};

--- a/src/library/components/ResponsiveImage/ResponsiveImage.styles.js
+++ b/src/library/components/ResponsiveImage/ResponsiveImage.styles.js
@@ -1,0 +1,47 @@
+import styled, { css } from 'styled-components';
+
+const imageRatio = (props) => {
+  switch (props.$ratio) {
+    case '4by3':
+      return css`
+        padding-top: 75%;
+      `;
+    case '4by1':
+      return css`
+        padding-top: 25%;
+      `;
+    case '16by9':
+      return css`
+        padding-top: 56.25%;
+      `;
+    case 'auto':
+      return css`
+        height: 100%;
+        width: 100%;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+      `;
+    default:
+      return css`
+        padding-top: 56.25%;
+      `;
+  }
+};
+
+export const Container = styled.div`
+  display: block;
+  position: ${(props) => (props.$ratio === 'auto' ? 'absolute' : 'relative')};
+  ${imageRatio}
+`;
+
+export const Image = styled.img`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: ${(props) => props.$objectFit};
+  object-position: center;
+`;

--- a/src/library/components/ResponsiveImage/ResponsiveImage.test.tsx
+++ b/src/library/components/ResponsiveImage/ResponsiveImage.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ResponsiveImage from './ResponsiveImage';
+import { ResponsiveImageProps } from './ResponsiveImage.types';
+
+describe('Responsive Image Component', () => {
+  let props: ResponsiveImageProps;
+
+  beforeEach(() => {
+    props = {
+      imageLarge: 'https://via.placeholder.com/800x600?text=4+by+3+image',
+      imageSmall: 'https://via.placeholder.com/400x300',
+      smallWidth: '400',
+      largeWidth: '800',
+      imageAltText: 'Parkland',
+      ratio: '4by3',
+      objectFit: 'cover',
+    };
+  });
+
+  const renderComponent = () => render(<ResponsiveImage {...props} />);
+
+  it('should render responsive image correctly', () => {
+    const { getByTestId, getByRole } = renderComponent();
+
+    const component = getByTestId('ResponsiveImage');
+    const image = getByRole('img');
+
+    expect(component).toBeVisible();
+    expect(component).toHaveStyle('padding-top: 75%;');
+
+    expect(image).toBeVisible();
+    expect(image).toHaveAttribute('src', 'https://via.placeholder.com/800x600?text=4+by+3+image');
+    expect(image).toHaveAttribute(
+      'srcset',
+      'https://via.placeholder.com/400x300 400w, https://via.placeholder.com/800x600?text=4+by+3+image 800w'
+    );
+    expect(image).toHaveAttribute('loading', 'lazy');
+    expect(image).toHaveStyle('object-fit: cover');
+  });
+
+  it('should render a 16by9 image', () => {
+    props.ratio = '16by9';
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('ResponsiveImage');
+    expect(component).toHaveStyle('padding-top: 56.25%');
+  });
+
+  it('should render a 4by1 image', () => {
+    props.ratio = '4by1';
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('ResponsiveImage');
+    expect(component).toHaveStyle('padding-top: 25%');
+  });
+
+  it('should render an auto image', () => {
+    props.ratio = 'auto';
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('ResponsiveImage');
+    expect(component).toHaveStyle('position: absolute;');
+    expect(component).toHaveStyle('top: 0;');
+    expect(component).toHaveStyle('left: 0;');
+    expect(component).toHaveStyle('bottom: 0;');
+    expect(component).toHaveStyle('right: 0;');
+  });
+
+  it('should render the image with object fit contain', () => {
+    props.objectFit = 'contain';
+
+    const { getByRole } = renderComponent();
+
+    const image = getByRole('img');
+    expect(image).toHaveStyle('object-fit: contain');
+  });
+});

--- a/src/library/components/ResponsiveImage/ResponsiveImage.tsx
+++ b/src/library/components/ResponsiveImage/ResponsiveImage.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ResponsiveImageProps } from './ResponsiveImage.types';
+import * as Styles from './ResponsiveImage.styles';
+
+const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
+  imageSmall,
+  imageLarge,
+  imageAltText,
+  smallWidth = '400',
+  largeWidth = '1200',
+  ratio,
+  objectFit = 'cover',
+}) => (
+  <Styles.Container data-testid="ResponsiveImage" $ratio={ratio}>
+    <Styles.Image
+      alt={imageAltText}
+      loading="lazy"
+      srcSet={`${imageSmall} ${smallWidth}w, ${imageLarge} ${largeWidth}w`}
+      sizes={`(max-width: 550px) 550px, ${largeWidth}px`}
+      src={imageLarge}
+      $objectFit={objectFit}
+    />
+  </Styles.Container>
+);
+
+export default ResponsiveImage;

--- a/src/library/components/ResponsiveImage/ResponsiveImage.types.ts
+++ b/src/library/components/ResponsiveImage/ResponsiveImage.types.ts
@@ -1,0 +1,36 @@
+export interface ResponsiveImageProps {
+  /**
+   * The small image url
+   */
+  imageSmall: string;
+
+  /**
+   * The large image url
+   */
+  imageLarge: string;
+
+  /**
+   * The image alt text
+   */
+  imageAltText: string;
+
+  /**
+   * The width of the small image in pixels
+   */
+  smallWidth: string;
+
+  /**
+   * The width of the large image in pixels
+   */
+  largeWidth: string;
+
+  /**
+   * The image ratio, either '4by3', '16by9', '4by1' or 'auto'
+   */
+  ratio: string;
+
+  /**
+   * The optional object fit. Defaults to cover
+   */
+  objectFit?: string;
+}

--- a/src/library/pages/Home/HomePage.stories.tsx
+++ b/src/library/pages/Home/HomePage.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { StoryFn, Meta } from '@storybook/react';
 import { HomePage } from './HomePage';
 import { HomePageProps } from './HomePage.types';
 import { NewsArticleData } from '../../structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.storydata';

--- a/src/library/slices/Image/Image.styles.js
+++ b/src/library/slices/Image/Image.styles.js
@@ -19,42 +19,6 @@ export const Container = styled.figure`
   }
 `;
 
-const imageRatio = (props) => {
-  switch (props.$ratio) {
-    case '4by3':
-      return css`
-        padding-top: 75%;
-      `;
-    case '4by1':
-      return css`
-        padding-top: 25%;
-      `;
-    case '16by9':
-      return css`
-        padding-top: 56.25%;
-      `;
-    default:
-      return css`
-        padding-top: 56.25%;
-      `;
-  }
-};
-
-export const ImageContainer = styled.div`
-  position: relative;
-  ${imageRatio}
-`;
-
-export const Image = styled.img`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`;
-
 export const Caption = styled.figcaption`
   ${(props) => props.theme.fontStyles};
   font-size: 0.9rem !important;

--- a/src/library/slices/Image/Image.test.tsx
+++ b/src/library/slices/Image/Image.test.tsx
@@ -28,14 +28,16 @@ describe('Image Component', () => {
   it('should display the image and caption', () => {
     const { getByRole, getByTestId, getByAltText, getByText } = renderComponent();
     const image = getByAltText('The image alt text');
-    const imageContainer = getByTestId('ImageContainer');
+    const imageContainer = getByTestId('ResponsiveImage');
     const figure = getByRole('figure');
     const caption = getByText('The caption for the image');
 
     // Lazy image loads the placeholder image (foo.jpg)
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'foo.jpg');
+    expect(image).toHaveAttribute('src', 'bar.jpg');
     expect(image).toHaveAttribute('alt', 'The image alt text');
+    expect(image).toHaveAttribute('loading', 'lazy');
+    expect(image).toHaveAttribute('srcset', 'foo.jpg 400w, bar.jpg 1200w');
 
     expect(imageContainer).toHaveStyle('padding-top: 75%');
 
@@ -48,13 +50,13 @@ describe('Image Component', () => {
     props.ratio = '16by9';
 
     const { getByRole, getByTestId, getByAltText } = renderComponent();
-    const imageContainer = getByTestId('ImageContainer');
+    const imageContainer = getByTestId('ResponsiveImage');
     const image = getByAltText('The image alt text');
     const figure = getByRole('figure');
 
     // Lazy image loads the placeholder image (bar.jpg)
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'foo.jpg');
+    expect(image).toHaveAttribute('src', 'bar.jpg');
     expect(image).toHaveAttribute('alt', 'The image alt text');
 
     expect(imageContainer).toHaveStyle('padding-top: 56.25%');
@@ -69,7 +71,7 @@ describe('Image Component', () => {
     const { getByTestId, getByAltText } = renderComponent();
 
     const image = getByAltText('The image alt text');
-    const imageContainer = getByTestId('ImageContainer');
+    const imageContainer = getByTestId('ResponsiveImage');
 
     expect(image).toBeVisible();
     expect(imageContainer).toHaveStyle('padding-top: 25%');

--- a/src/library/slices/Image/Image.tsx
+++ b/src/library/slices/Image/Image.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ImageProps } from './Image.types';
 import * as Styles from './Image.styles';
-import LazyImage from 'react-lazy-progressive-image';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * Responsive image slice component that allows 4 by 3 or 16 by 9 images
@@ -16,17 +16,14 @@ const Image: React.FunctionComponent<ImageProps> = ({
   wrapText,
 }) => (
   <Styles.Container data-testid="Image" $wrapText={wrapText}>
-    <Styles.ImageContainer data-testid="ImageContainer" $ratio={ratio}>
-      <LazyImage
-        placeholder={imageSmall}
-        src={imageLarge}
-        visibilitySensorProps={{
-          partialVisibility: true,
-        }}
-      >
-        {(src) => <Styles.Image src={src} alt={imageAltText} />}
-      </LazyImage>
-    </Styles.ImageContainer>
+    <ResponsiveImage
+      imageSmall={imageSmall}
+      imageLarge={imageLarge}
+      imageAltText={imageAltText}
+      ratio={ratio}
+      smallWidth="400"
+      largeWidth="1200"
+    />
     {caption?.trim() && <Styles.Caption>{caption}</Styles.Caption>}
   </Styles.Container>
 );

--- a/src/library/slices/Image/Image.types.ts
+++ b/src/library/slices/Image/Image.types.ts
@@ -15,7 +15,7 @@ export interface ImageProps {
   imageAltText?: string | null;
 
   /**
-   * The image ratio, either '4by3' or '16by9'
+   * The image ratio, either '4by3', '16by9' or '4by1'
    */
   ratio: string;
 

--- a/src/library/slices/ImageAndText/ImageAndText.test.tsx
+++ b/src/library/slices/ImageAndText/ImageAndText.test.tsx
@@ -30,7 +30,7 @@ describe('Test Component', () => {
     expect(heading).toHaveTextContent('An example heading');
     expect(component).toHaveTextContent('Lorem ipsum dolor sit amet');
     expect(image).toBeVisible();
-    expect(image).toHaveAttribute('src', 'https://via.placeholder.com/400x300');
+    expect(image).toHaveAttribute('src', 'https://via.placeholder.com/800x600?text=4+by+3+image');
     expect(image).toHaveAttribute('alt', 'The image alt text');
   });
 

--- a/src/library/slices/SearchBox/SearchBox.styles.js
+++ b/src/library/slices/SearchBox/SearchBox.styles.js
@@ -4,15 +4,14 @@ import { VisuallyHidden } from './../../helpers/style-helpers';
 export const Container = styled.div`
   padding: 0;
   margin: ${(props) => props.theme.theme_vars.spacingSizes.medium} 0;
+  position: relative;
   ${(props) => props.theme.fontStyles}
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
-    background: url('${(props) => props.$image}') no-repeat center center;
-    background-size: cover;
-    padding-top: ${(props) => (props.$image ? '8rem' : 0)};
-    padding-bottom: ${(props) => (props.$image ? '8rem' : 0)};
-    padding-left: ${(props) => (props.$image ? props.theme.theme_vars.spacingSizes.x_large : 0)};
-    padding-right: ${(props) => (props.$image ? props.theme.theme_vars.spacingSizes.x_large : 0)};
+    padding-top: ${(props) => (props.$hasImage ? '8rem' : 0)};
+    padding-bottom: ${(props) => (props.$hasImage ? '8rem' : 0)};
+    padding-left: ${(props) => (props.$hasImage ? props.theme.theme_vars.spacingSizes.x_large : 0)};
+    padding-right: ${(props) => (props.$hasImage ? props.theme.theme_vars.spacingSizes.x_large : 0)};
   }
 
   h2 {
@@ -36,6 +35,8 @@ export const LinkContainer = styled.div`
 `;
 
 export const Inner = styled.div`
+  z-index: 2;
+  position: relative;
   background-color: ${(props) =>
     props.theme.cardinal_name === 'west'
       ? props.theme.theme_vars.colours.grey_light

--- a/src/library/slices/SearchBox/SearchBox.tsx
+++ b/src/library/slices/SearchBox/SearchBox.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { SearchBoxProps } from './SearchBox.types';
 import * as Styles from './SearchBox.styles';
-import LazyImage from 'react-lazy-progressive-image';
 import Column from '../../components/Column/Column';
 import Row from '../../components/Row/Row';
 import Button from '../../components/Button/Button';
 import Heading from '../../components/Heading/Heading';
 import CustomSearch from '../../components/CustomSearch/CustomSearch';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 const SearchBox: React.FunctionComponent<SearchBoxProps> = ({
   customSearch,
@@ -40,28 +40,20 @@ const SearchBox: React.FunctionComponent<SearchBoxProps> = ({
   );
 
   return (
-    <>
-      {imageLarge && imageSmall ? (
-        <>
-          <LazyImage
-            src={imageLarge}
-            placeholder={imageSmall}
-            visibilitySensorProps={{
-              partialVisibility: true,
-            }}
-          >
-            {(src) => (
-              <Styles.Container $image={src} data-testid="SearchBox">
-                {searchInner}
-              </Styles.Container>
-            )}
-          </LazyImage>
-          {imageAltText && <span role="img" aria-label={imageAltText} />}
-        </>
-      ) : (
-        <Styles.Container data-testid="SearchBox">{searchInner}</Styles.Container>
+    <Styles.Container data-testid="SearchBox" $hasImage={imageSmall && imageLarge}>
+      {imageSmall && imageLarge && (
+        <ResponsiveImage
+          imageSmall={imageSmall}
+          imageLarge={imageLarge}
+          imageAltText={imageAltText}
+          smallWidth="400"
+          largeWidth="1200"
+          ratio="auto"
+          objectFit="cover"
+        />
       )}
-    </>
+      {searchInner}
+    </Styles.Container>
   );
 };
 

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -6,18 +6,12 @@ import Heading from '../../components/Heading/Heading';
  * Optimised for an image in 16:5 ratio on all but small width screens
  */
 export const Container = styled.div`
-  background-image: ${(props) =>
-      !props.$backgroundBox ? `linear-gradient(to bottom left, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75)),` : ``}
-    url('${(props) => props.$image}');
-
   padding-bottom: 10px;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
   display: flex;
   justify-content: center;
   flex-direction: row;
   align-items: flex-end;
+  position: relative;
 
   &::before {
     content: '';
@@ -34,11 +28,35 @@ export const Container = styled.div`
   }
 `;
 
+export const ImageContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+
+  &:after {
+    content: '';
+    background: ${(props) =>
+      !props.$backgroundBox ? `linear-gradient(to bottom left, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75))` : ``};
+    z-index: 2;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+  }
+`;
+
 export const InnerContainer = styled.div`
   max-width: 100%;
   margin-right: auto;
   margin-left: auto;
   flex-grow: 1;
+  position: relative;
+  z-index: 3;
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
     max-width: ${(props) => props.theme.theme_vars.breakpoints.l};

--- a/src/library/structure/HeroImage/HeroImage.test.tsx
+++ b/src/library/structure/HeroImage/HeroImage.test.tsx
@@ -42,14 +42,18 @@ describe('HeroImage slice', () => {
     expect(link).toHaveTextContent('Google');
     expect(link).toHaveAttribute('href', 'http://www.google.com');
 
-    const imgaltspan = getByRole('img');
-    expect(imgaltspan).toHaveAttribute('aria-label');
+    const img = getByRole('img');
+    expect(img).toHaveAttribute('alt', 'alt text');
+    expect(img).toHaveAttribute(
+      'src',
+      'https://cms.westnorthants.gov.uk/sites/default/files/styles/responsive/public/1440/810/0/2021-12/Abington_Park_1.jpg'
+    );
 
     const overlay = getByTestId('HeroImageOverlay');
     expect(overlay).not.toHaveStyle('background-color: transparent');
 
     const container = getByTestId('HeroImage');
-    expect(container).not.toHaveStyle('background-image: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 1))');
+    expect(container).toBeVisible();
   });
 
   it('should render text on a gradient when backgroundBox is false', () => {
@@ -86,8 +90,8 @@ describe('HeroImage slice', () => {
     expect(link).toHaveTextContent('Google');
     expect(link).toHaveAttribute('href', 'http://www.google.com');
 
-    const imgaltspan = getByRole('img');
-    expect(imgaltspan).toHaveAttribute('aria-label');
+    const img = getByRole('img');
+    expect(img).toHaveAttribute('alt', 'alt text');
 
     const overlay = getByTestId('HeroImageOverlay');
     expect(overlay).toHaveStyle('background-color: transparent');
@@ -123,8 +127,8 @@ describe('HeroImage slice', () => {
     const link = queryByRole('link');
     expect(link).toBeNull();
 
-    const imgaltspan = queryByRole('img');
-    expect(imgaltspan).toBeNull();
+    const img = queryByRole('img');
+    expect(img).not.toHaveAttribute('alt');
   });
 
   it('should display the parent breadcrumb in the hero image', () => {

--- a/src/library/structure/HeroImage/HeroImage.tsx
+++ b/src/library/structure/HeroImage/HeroImage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { HeroImageProps } from './HeroImage.types';
 import * as Styles from './HeroImage.styles';
-import LazyImage from 'react-lazy-progressive-image';
 import sanitizeHtml from 'sanitize-html';
 import CallToAction from '../../slices/CallToAction/CallToAction';
 import CustomSearch from '../../components/CustomSearch/CustomSearch';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * Hero image banner with optional text and call to action with varying presentation of text area.
@@ -24,46 +24,44 @@ const HeroImage: React.FunctionComponent<HeroImageProps> = ({
   customSearch,
 }) => {
   return (
-    <>
-      <LazyImage
-        src={imageLarge}
-        placeholder={imageSmall}
-        visibilitySensorProps={{
-          partialVisibility: true,
-        }}
-      >
-        {(src) => (
-          <Styles.Container $image={src} $backgroundBox={backgroundBox} data-testid="HeroImage">
-            <Styles.InnerContainer>
-              <Styles.Overlay $backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
-                {breadcrumb && (
-                  <Styles.BreadcrumbLink href={breadcrumb.url} $backgroundBox={backgroundBox}>
-                    {breadcrumb.title}
-                  </Styles.BreadcrumbLink>
-                )}
-                {headline && <Styles.Headline level={1} text={headline} $backgroundBox={backgroundBox} />}
-                {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
-                {customSearch && (
-                  <Styles.Search>
-                    <CustomSearch {...customSearch} />
-                  </Styles.Search>
-                )}
-                {callToActionURL && backgroundBox && (
-                  <CallToAction url={callToActionURL} text={callToActionText} primary={callToActionIsPrimary} />
-                )}
-                {!callToActionURL && backgroundBox && <br />}
-                {callToActionURL && !backgroundBox && (
-                  <Styles.CallToActionLink href={callToActionURL}>
-                    {callToActionText ? callToActionText : 'Find out more'}
-                  </Styles.CallToActionLink>
-                )}
-              </Styles.Overlay>
-            </Styles.InnerContainer>
-          </Styles.Container>
-        )}
-      </LazyImage>
-      {imageAltText && <span role="img" aria-label={imageAltText} />}
-    </>
+    <Styles.Container data-testid="HeroImage">
+      <Styles.ImageContainer $backgroundBox={backgroundBox}>
+        <ResponsiveImage
+          imageSmall={imageSmall}
+          imageLarge={imageLarge}
+          imageAltText={imageAltText}
+          smallWidth="144"
+          largeWidth="1440"
+          ratio="auto"
+          objectFit="cover"
+        />
+      </Styles.ImageContainer>
+      <Styles.InnerContainer>
+        <Styles.Overlay $backgroundBox={backgroundBox} data-testid="HeroImageOverlay">
+          {breadcrumb && (
+            <Styles.BreadcrumbLink href={breadcrumb.url} $backgroundBox={backgroundBox}>
+              {breadcrumb.title}
+            </Styles.BreadcrumbLink>
+          )}
+          {headline && <Styles.Headline level={1} text={headline} $backgroundBox={backgroundBox} />}
+          {content && <Styles.Content dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />}
+          {customSearch && (
+            <Styles.Search>
+              <CustomSearch {...customSearch} />
+            </Styles.Search>
+          )}
+          {callToActionURL && backgroundBox && (
+            <CallToAction url={callToActionURL} text={callToActionText} primary={callToActionIsPrimary} />
+          )}
+          {!callToActionURL && backgroundBox && <br />}
+          {callToActionURL && !backgroundBox && (
+            <Styles.CallToActionLink href={callToActionURL}>
+              {callToActionText ? callToActionText : 'Find out more'}
+            </Styles.CallToActionLink>
+          )}
+        </Styles.Overlay>
+      </Styles.InnerContainer>
+    </Styles.Container>
   );
 };
 

--- a/src/library/structure/HomeHero/HomeHero.styles.js
+++ b/src/library/structure/HomeHero/HomeHero.styles.js
@@ -16,17 +16,8 @@ export const Container = styled.div`
   background: ${(props) => props.theme.theme_vars.colours.action}5A;
   padding: 30px 0;
   padding-bottom: 15px;
+  position: relative;
 
-  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
-    background-image: url('${(props) => props.$image}');
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center;
-
-    &.loading {
-      background-image: none;
-    }
-  }
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {
     padding: 60px 0;
   }
@@ -42,6 +33,8 @@ export const StyledMaxWidthContainer = styled.div`
   ${(props) => props.theme.fontStyles}
   margin-right: 15px;
   margin-left: 15px;
+  z-index: 2;
+  position: relative;
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
     margin-right: 30px;

--- a/src/library/structure/HomeHero/HomeHero.test.tsx
+++ b/src/library/structure/HomeHero/HomeHero.test.tsx
@@ -48,9 +48,9 @@ describe('HomeHero common usage', () => {
     expect(listbox.children.length).toBe(1);
   });
 
-  it('should not render an image tag', () => {
+  it('should render an image tag', () => {
     const images = rendered.queryAllByRole('img');
-    expect(images).toHaveLength(0);
+    expect(images).toHaveLength(1);
   });
 });
 

--- a/src/library/structure/HomeHero/HomeHero.tsx
+++ b/src/library/structure/HomeHero/HomeHero.tsx
@@ -36,15 +36,17 @@ const HomeHero: React.FunctionComponent<HomeHeroProps> = ({
     <>
       <Styles.Wrapper>
         <Styles.Container className={random !== 999 ? 'loaded' : 'loading'}>
-          <ResponsiveImage
-            imageSmall={random !== 999 && imagesArray[random].image144x81 ? imagesArray[random].image144x81 : ''}
-            imageLarge={random !== 999 && imagesArray[random].image1440x810 ? imagesArray[random].image1440x810 : ''}
-            imageAltText={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ''}
-            smallWidth="144"
-            largeWidth="1440"
-            ratio="auto"
-            objectFit="cover"
-          />
+          {random !== 999 && (
+            <ResponsiveImage
+              imageSmall={imagesArray[random].image144x81 ?? ''}
+              imageLarge={imagesArray[random].image1440x810 ?? ''}
+              imageAltText={imagesArray[random].imageAltText ?? ''}
+              smallWidth="144"
+              largeWidth="1440"
+              ratio="auto"
+              objectFit="cover"
+            />
+          )}
 
           <Styles.StyledMaxWidthContainer>
             <Styles.MainBox>

--- a/src/library/structure/HomeHero/HomeHero.tsx
+++ b/src/library/structure/HomeHero/HomeHero.tsx
@@ -6,9 +6,9 @@ import * as Styles from './HomeHero.styles';
 import GDSLogo from '../../components/logos/GDSLogo/logo';
 import NorthColoured from '../../components/logos/NorthColouredLogo/logo';
 import WestColoured from '../../components/logos/WestColouredLogo/logo';
-import LazyImage from 'react-lazy-progressive-image';
 import Searchbar from '../Searchbar/Searchbar';
 import PromotedLinks from '../../components/PromotedLinks/PromotedLinks';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * The Hero that should appear at the top of the home page.
@@ -35,64 +35,60 @@ const HomeHero: React.FunctionComponent<HomeHeroProps> = ({
   return (
     <>
       <Styles.Wrapper>
-        <LazyImage
-          src={random !== 999 && imagesArray[random].image1440x810 ? imagesArray[random].image1440x810 : ''}
-          placeholder={random !== 999 && imagesArray[random].image144x81 ? imagesArray[random].image144x81 : ''}
-          visibilitySensorProps={{
-            partialVisibility: true,
-          }}
-        >
-          {(src) => (
-            <Styles.Container
-              className={random !== 999 ? 'loaded' : 'loading'}
-              $image={src}
-              title={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ''}
-            >
-              <Styles.StyledMaxWidthContainer>
-                <Styles.MainBox>
-                  {topline && <Styles.Topline>{topline}</Styles.Topline>}
-                  <Styles.HiddenH1>{`${themeContext.full_name} Council`}</Styles.HiddenH1>
-                  {imageOverrideLogo && !usingMemorialTheme && (
-                    <Styles.LogoOverride>
-                      <img
-                        src={imageOverrideLogo}
-                        width="520"
-                        height="150"
-                        alt={imageOverrideLogoAltText?.trim() ? imageOverrideLogoAltText : 'Logo'}
-                      />
-                    </Styles.LogoOverride>
-                  )}
-                  {(!imageOverrideLogo || usingMemorialTheme) && (
-                    <Styles.LogoColoured className={usingMemorialTheme ? 'black_logo' : ''}>
-                      {themeContext.cardinal_name === 'north' ? (
-                        <NorthColoured />
-                      ) : themeContext.cardinal_name === 'west' ? (
-                        <WestColoured />
-                      ) : (
-                        <GDSLogo />
-                      )}
-                    </Styles.LogoColoured>
-                  )}
-                  {strapline && <Styles.Strapline>{strapline}</Styles.Strapline>}
-                  <Searchbar
-                    isLight
-                    isLarge
-                    placeholder="Search the site"
-                    submitInfo={{
-                      postTo: '/search',
-                      params: {
-                        type: 'search',
-                      },
-                    }}
-                    suggestions={searchSuggestions}
-                    maximumMatchesShown={4}
+        <Styles.Container className={random !== 999 ? 'loaded' : 'loading'}>
+          <ResponsiveImage
+            imageSmall={random !== 999 && imagesArray[random].image144x81 ? imagesArray[random].image144x81 : ''}
+            imageLarge={random !== 999 && imagesArray[random].image1440x810 ? imagesArray[random].image1440x810 : ''}
+            imageAltText={random !== 999 && imagesArray[random].imageAltText ? imagesArray[random].imageAltText : ''}
+            smallWidth="144"
+            largeWidth="1440"
+            ratio="auto"
+            objectFit="cover"
+          />
+
+          <Styles.StyledMaxWidthContainer>
+            <Styles.MainBox>
+              {topline && <Styles.Topline>{topline}</Styles.Topline>}
+              <Styles.HiddenH1>{`${themeContext.full_name} Council`}</Styles.HiddenH1>
+              {imageOverrideLogo && !usingMemorialTheme && (
+                <Styles.LogoOverride>
+                  <img
+                    src={imageOverrideLogo}
+                    width="520"
+                    height="150"
+                    alt={imageOverrideLogoAltText?.trim() ? imageOverrideLogoAltText : 'Logo'}
                   />
-                </Styles.MainBox>
-                {promotedLinksArray.length > 0 && <PromotedLinks promotedLinksArray={promotedLinksArray} />}
-              </Styles.StyledMaxWidthContainer>
-            </Styles.Container>
-          )}
-        </LazyImage>
+                </Styles.LogoOverride>
+              )}
+              {(!imageOverrideLogo || usingMemorialTheme) && (
+                <Styles.LogoColoured className={usingMemorialTheme ? 'black_logo' : ''}>
+                  {themeContext.cardinal_name === 'north' ? (
+                    <NorthColoured />
+                  ) : themeContext.cardinal_name === 'west' ? (
+                    <WestColoured />
+                  ) : (
+                    <GDSLogo />
+                  )}
+                </Styles.LogoColoured>
+              )}
+              {strapline && <Styles.Strapline>{strapline}</Styles.Strapline>}
+              <Searchbar
+                isLight
+                isLarge
+                placeholder="Search the site"
+                submitInfo={{
+                  postTo: '/search',
+                  params: {
+                    type: 'search',
+                  },
+                }}
+                suggestions={searchSuggestions}
+                maximumMatchesShown={4}
+              />
+            </Styles.MainBox>
+            {promotedLinksArray.length > 0 && <PromotedLinks promotedLinksArray={promotedLinksArray} />}
+          </Styles.StyledMaxWidthContainer>
+        </Styles.Container>
       </Styles.Wrapper>
     </>
   );

--- a/src/library/structure/MemorialHero/MemorialHero.styles.js
+++ b/src/library/structure/MemorialHero/MemorialHero.styles.js
@@ -58,16 +58,7 @@ export const Right = styled.div`
 
 export const Image = styled.div`
   transition: all 0.25s ease;
-  background-image: url('${(props) => props.$image}');
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
   width: 100%;
-  height: 760px;
-  @media screen and (max-width: ${(props) => props.theme.theme_vars.breakpoints.l}) {
-    background-size: cover;
-    height: 350px;
-  }
 `;
 
 export const Wrapperold = styled.div`

--- a/src/library/structure/MemorialHero/MemorialHero.tsx
+++ b/src/library/structure/MemorialHero/MemorialHero.tsx
@@ -1,10 +1,17 @@
-import React, { useContext, useState } from 'react';
-import LazyImage from 'react-lazy-progressive-image';
+import React, { useContext } from 'react';
 import { MemorialHeroProps } from './MemorialHero.types';
 import * as Styles from './MemorialHero.styles';
-import styled, { ThemeContext, ThemeProvider } from 'styled-components';
+import { ThemeContext, ThemeProvider } from 'styled-components';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
-const MemorialHero: React.FC<MemorialHeroProps> = ({ src, placeholder, alt, theme, children, councilServices }) => {
+const MemorialHero: React.FunctionComponent<MemorialHeroProps> = ({
+  src,
+  placeholder,
+  alt,
+  theme,
+  children,
+  councilServices,
+}) => {
   const themeContext = useContext(ThemeContext);
   return (
     <>
@@ -16,15 +23,17 @@ const MemorialHero: React.FC<MemorialHeroProps> = ({ src, placeholder, alt, them
             <ThemeProvider theme={theme}>{councilServices}</ThemeProvider>
           </Styles.Left>
           <Styles.Right>
-            <LazyImage
-              src={src}
-              placeholder={placeholder}
-              visibilitySensorProps={{
-                partialVisibility: true,
-              }}
-            >
-              {(src) => <Styles.Image $image={src} title={alt} />}
-            </LazyImage>
+            <Styles.Image>
+              <ResponsiveImage
+                imageSmall={placeholder}
+                imageLarge={src}
+                imageAltText={alt}
+                smallWidth="144"
+                largeWidth="1440"
+                ratio="16by9"
+                objectFit="contain"
+              />
+            </Styles.Image>
           </Styles.Right>
         </Styles.Container>
       </Styles.Wrapper>

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.test.tsx
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.test.tsx
@@ -36,9 +36,9 @@ describe('NewsArticleFeaturedBlock structure', () => {
     expect(imageSpans).toHaveLength(storydata.NewsArticleData.length);
     imageSpans.forEach((imageSpan, index) => {
       expect(imageSpan).toBeVisible();
-      expect(imageSpan).toHaveStyle('background-image: url(' + storydata.NewsArticleData[index].image72x41 + ')');
+      expect(imageSpan).toHaveAttribute('src', storydata.NewsArticleData[index].image720x450);
       if (storydata.NewsArticleData[index].imageAltText) {
-        expect(imageSpan).toHaveAttribute('aria-label', storydata.NewsArticleData[index].imageAltText);
+        expect(imageSpan).toHaveAttribute('alt', storydata.NewsArticleData[index].imageAltText);
       } else {
         expect(imageSpan).toHaveAttribute('aria-label', '');
       }

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.tsx
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { NewsArticleFeaturedBlockProps } from './NewsArticleFeaturedBlock.types';
 import * as Styles from './NewsArticleFeaturedBlock.styles';
 import NewsArticleDate from '../NewsArticleDate/NewsArticleDate';
@@ -7,6 +6,7 @@ import Heading from '../../components/Heading/Heading';
 import Button from '../../components/Button/Button';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * Block displaying up to 9 news article tiles, with image, title and date for each
@@ -28,21 +28,15 @@ const NewsArticleFeaturedBlock: React.FunctionComponent<NewsArticleFeaturedBlock
                   <Row>
                     {article.image720x405 && (
                       <Column small="full" medium="full" large="full" hasPadding={false}>
-                        <LazyImage
-                          src={article.image720x405}
-                          placeholder={article.image72x41}
-                          visibilitySensorProps={{
-                            partialVisibility: true,
-                          }}
-                        >
-                          {(src) => (
-                            <Styles.ImageContainer
-                              $background={src}
-                              role="img"
-                              aria-label={article.imageAltText ? article.imageAltText : ''}
-                            />
-                          )}
-                        </LazyImage>
+                        <ResponsiveImage
+                          imageSmall={article.image72x41}
+                          imageLarge={article.image720x405}
+                          imageAltText={article.imageAltText ?? ''}
+                          smallWidth="72"
+                          largeWidth="720"
+                          ratio="16by9"
+                          objectFit="contain"
+                        />
                       </Column>
                     )}
                     <Column small="full" medium="full" large="full">

--- a/src/library/structure/NewsArticleImage/NewsArticleImage.tsx
+++ b/src/library/structure/NewsArticleImage/NewsArticleImage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NewsArticleImageProps } from './NewsArticleImage.types';
 import * as Styles from './NewsArticleImage.styles';
-import LazyImage from 'react-lazy-progressive-image';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * An image for a news article
@@ -14,20 +14,16 @@ const NewsArticleImage: React.FunctionComponent<NewsArticleImageProps> = ({
 }) => {
   return (
     <Styles.ImageContainer>
-      <LazyImage
-        src={image1440x810}
-        placeholder={image144x81}
-        visibilitySensorProps={{
-          partialVisibility: true,
-        }}
-      >
-        {(src) => (
-          <>
-            <Styles.StyledImage src={src} alt={imageAltText ? imageAltText : ''} />
-            {imageCaption && <Styles.Small itemprop="copyrightHolder">{imageCaption}</Styles.Small>}
-          </>
-        )}
-      </LazyImage>
+      <ResponsiveImage
+        imageSmall={image144x81}
+        imageLarge={image1440x810}
+        imageAltText={imageAltText ?? ''}
+        smallWidth="144"
+        largeWidth="1440"
+        ratio="16by9"
+        objectFit="contain"
+      />
+      {imageCaption && <Styles.Small itemprop="copyrightHolder">{imageCaption}</Styles.Small>}
     </Styles.ImageContainer>
   );
 };

--- a/src/library/structure/NewsArticleList/NewsArticleList.styles.js
+++ b/src/library/structure/NewsArticleList/NewsArticleList.styles.js
@@ -82,9 +82,7 @@ export const ArticleContent = styled.div`
 export const ImageContainer = styled.span`
   display: block;
   width: 100%;
-  height: 150px;
-  overflow: hidden;
-  background-image: url('${(props) => props.$background}');
+  height: auto;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/library/structure/NewsArticleList/NewsArticleList.tsx
+++ b/src/library/structure/NewsArticleList/NewsArticleList.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { NewsArticleListProps } from './NewsArticleList.types';
 import * as Styles from './NewsArticleList.styles';
 import NewsArticleDate from '../NewsArticleDate/NewsArticleDate';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 const NewsArticleList: React.FunctionComponent<NewsArticleListProps> = ({ results }) => {
   const extractLength = 140;
@@ -17,22 +17,17 @@ const NewsArticleList: React.FunctionComponent<NewsArticleListProps> = ({ result
             <Column isList small="full" medium="full" large="full" key={article.id}>
               <Styles.ArticleContainer href={article.url} title={article.title}>
                 {article.image720x405 && (
-                  <LazyImage
-                    src={article.image720x405}
-                    placeholder={article.image72x41}
-                    visibilitySensorProps={{
-                      partialVisibility: true,
-                    }}
-                  >
-                    {(src) => (
-                      <Styles.ImageContainer
-                        className="news-article-list__image"
-                        $background={src}
-                        role="img"
-                        aria-label={article.imageAltText ? article.imageAltText : 'News article'}
-                      ></Styles.ImageContainer>
-                    )}
-                  </LazyImage>
+                  <Styles.ImageContainer className="news-article-list__image">
+                    <ResponsiveImage
+                      imageSmall={article.image72x41}
+                      imageLarge={article.image720x405}
+                      imageAltText={article.imageAltText ?? 'News article'}
+                      smallWidth="400"
+                      largeWidth="720"
+                      ratio="16by9"
+                      objectFit="contain"
+                    />
+                  </Styles.ImageContainer>
                 )}
                 <Styles.ArticleContent $withImage={article.image720x405 ? true : false}>
                   <Styles.Title className="news-article-list__title">{article.title}</Styles.Title>

--- a/src/library/structure/PromoBanner/PromoBanner.styles.js
+++ b/src/library/structure/PromoBanner/PromoBanner.styles.js
@@ -29,9 +29,6 @@ export const Container = styled.div`
 `;
 
 export const ImageLink = styled.a`
-  background-image: url('${(props) => props.$img}');
-  background-size: cover;
-  background-position: center;
   min-height: 200px;
   width: 100%;
   display: block;

--- a/src/library/structure/PromoBanner/PromoBanner.test.tsx
+++ b/src/library/structure/PromoBanner/PromoBanner.test.tsx
@@ -34,12 +34,16 @@ describe('PromoBanner structure', () => {
     const links = getAllByRole('link');
     expect(links).toHaveLength(2);
 
+    const images = getAllByRole('img');
+
     expect(links[0]).toHaveProperty('href', storydata.PromoBannerData.ctaUrl);
     expect(links[0]).toHaveTextContent('');
     expect(links[0]).toHaveProperty('title', storydata.PromoBannerData.ctaText);
-    expect(links[0]).toHaveStyle(`background-image: url(${storydata.PromoBannerData.image144x81});`);
     expect(links[0]).toHaveStyle('display: block;');
     expect(links[0]).toHaveStyle('width: 100%');
+
+    expect(images).toHaveLength(1);
+    expect(images[0]).toHaveAttribute('src', storydata.PromoBannerData.image1440x810);
 
     expect(links[1]).toHaveProperty('href', storydata.PromoBannerData.ctaUrl);
     expect(links[1]).toHaveTextContent(storydata.PromoBannerData.ctaText);

--- a/src/library/structure/PromoBanner/PromoBanner.tsx
+++ b/src/library/structure/PromoBanner/PromoBanner.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { PromoBannerProps } from './PromoBanner.types';
 import * as Styles from './PromoBanner.styles';
 import Heading from '../../components/Heading/Heading';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * Promotional banner used as the first wide line in a promotional block,
@@ -17,15 +17,18 @@ const PromoBanner: React.FunctionComponent<PromoBannerProps> = ({
   children,
 }) => (
   <Styles.Container>
-    <LazyImage
-      src={image1440x810}
-      placeholder={image144x81}
-      visibilitySensorProps={{
-        partialVisibility: true,
-      }}
-    >
-      {(src) => <Styles.ImageLink $img={src} href={ctaUrl} title={ctaText} />}
-    </LazyImage>
+    <Styles.ImageLink href={ctaUrl} title={ctaText}>
+      <ResponsiveImage
+        imageSmall={image144x81}
+        imageLarge={image1440x810}
+        imageAltText={ctaText}
+        smallWidth="144"
+        largeWidth="1440"
+        ratio="16by9"
+        objectFit="cover"
+      />
+    </Styles.ImageLink>
+
     <Styles.Wrapper>
       <Heading text={title} />
       <Styles.Content>{children}</Styles.Content>

--- a/src/library/structure/PromoBlock/PromoBlock.test.tsx
+++ b/src/library/structure/PromoBlock/PromoBlock.test.tsx
@@ -43,7 +43,7 @@ describe('Promo Block', () => {
 
     expect(images).toHaveLength(2);
 
-    expect(images[0]).toHaveAttribute('aria-label', 'Some sort of image');
-    expect(images[1]).toHaveAttribute('aria-label', 'A graphical thing');
+    expect(images[0]).toHaveAttribute('alt', 'Some sort of image');
+    expect(images[1]).toHaveAttribute('alt', 'A graphical thing');
   });
 });

--- a/src/library/structure/PromoBlock/PromoBlock.tsx
+++ b/src/library/structure/PromoBlock/PromoBlock.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import LazyImage from 'react-lazy-progressive-image';
 import { PromoBlockProps } from './PromoBlock.types';
 import * as Styles from './PromoBlock.styles';
 import sanitizeHtml from 'sanitize-html';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * Promotional campaign block, showing a tile for each campaign, similar to news article featured block.
@@ -18,21 +18,15 @@ const PromoBlock: React.FunctionComponent<PromoBlockProps> = ({ promos }) => (
           {promos.map((promo, index) => (
             <Column isList small="full" medium="one-half" large="auto" key={promo.callToActionURL}>
               <Styles.PromoTile href={promo.callToActionURL}>
-                <LazyImage
-                  src={promo.imageMedium}
-                  placeholder={promo.imageSmall}
-                  visibilitySensorProps={{
-                    partialVisibility: true,
-                  }}
-                >
-                  {(src) => (
-                    <Styles.PromoImage
-                      $background={src}
-                      role="img"
-                      aria-label={promo.imageAltText ? promo.imageAltText : ''}
-                    />
-                  )}
-                </LazyImage>
+                <ResponsiveImage
+                  imageSmall={promo.imageSmall}
+                  imageLarge={promo.imageMedium}
+                  imageAltText={promo.imageAltText ?? ''}
+                  smallWidth="400"
+                  largeWidth="720"
+                  ratio="16by9"
+                  objectFit="cover"
+                />
                 <Styles.PromoText>
                   <Styles.PromoHeadline level={3} text={promo.title} />
                   <Styles.PromoContent

--- a/src/library/structure/SectionLinks/SectionLinks.styles.js
+++ b/src/library/structure/SectionLinks/SectionLinks.styles.js
@@ -75,7 +75,15 @@ export const ImageContainer = styled.span`
   width: 100%;
   display: block;
   margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
-  background: ${(props) => (props.$image ? `url("` + props.$image + `") center center / cover no-repeat` : ``)};
+  /* background: ${(props) => (props.$image ? `url("` + props.$image + `") center center / cover no-repeat` : ``)}; */
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-image: ${(props) => (props.$largeImage ? `url("` + props.$largeImage + `")` : '')};
+  background-image: image-set(
+    ${(props) => `url("${props.$smallImage}")`} 1x,
+    ${(props) => `url("${props.$largeImage}")`} 2x
+  );
 `;
 
 export const Image = styled.img`

--- a/src/library/structure/SectionLinks/SectionLinks.test.tsx
+++ b/src/library/structure/SectionLinks/SectionLinks.test.tsx
@@ -110,9 +110,9 @@ describe('Section Links', () => {
     expect(images).toHaveLength(2);
 
     expect(images[0]).toHaveStyle('background: url("/small-image-1.jpg") center center / cover no-repeat;');
-    expect(images[0]).toHaveAttribute('aria-label', 'The first image alt text');
+    expect(images[0]).toHaveAttribute('alt', 'The first image alt text');
 
     expect(images[1]).toHaveStyle('background: url("/small-image-2.jpg") center center / cover no-repeat;');
-    expect(images[1]).toHaveAttribute('aria-label', 'The second image alt text');
+    expect(images[1]).toHaveAttribute('alt', 'The second image alt text');
   });
 });

--- a/src/library/structure/SectionLinks/SectionLinks.tsx
+++ b/src/library/structure/SectionLinks/SectionLinks.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { SectionLinksProps } from './SectionLinks.types';
 import * as Styles from './SectionLinks.styles';
-import LazyImage from 'react-lazy-progressive-image';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import ResponsiveImage from '../../components/ResponsiveImage/ResponsiveImage';
 
 /**
  * Display a list of links for a section with optional images
@@ -24,21 +24,15 @@ const SectionLinks: React.FunctionComponent<SectionLinksProps> = ({
             {hasImages && (
               <>
                 {link.imageLarge?.trim() ? (
-                  <LazyImage
-                    placeholder={link.imageSmall}
-                    src={link.imageLarge}
-                    visibilitySensorProps={{
-                      partialVisibility: true,
-                    }}
-                  >
-                    {(src) => (
-                      <Styles.ImageContainer
-                        $image={src}
-                        role="img"
-                        aria-label={link.imageAltText}
-                      ></Styles.ImageContainer>
-                    )}
-                  </LazyImage>
+                  <ResponsiveImage
+                    imageSmall={link.imageSmall}
+                    imageLarge={link.imageLarge}
+                    imageAltText={link.imageAltText}
+                    ratio="16by9"
+                    smallWidth="400"
+                    largeWidth="800"
+                    objectFit="cover"
+                  />
                 ) : (
                   <Styles.ImageContainer />
                 )}


### PR DESCRIPTION
Resolves #390

The react-lazy-progressive-image package is deprecated. This PR replaces it with a custom component called ResponsiveImage. 

- It uses a standard image tag and makes use of the `loading="lazy"` attribute to make the images load when scrolled into view. More information [here](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading).
- It uses `srcset` to display smaller images on smaller screen resolutions where possible. 
- It allows you to pass in the image ratio, but also allows you to set whether the image should cover the container or be contained within the container. The inspiration came from [here](https://www.smashingmagazine.com/2021/10/object-fit-background-size-css/)
- It has a ratio called 'auto' that allows the image container to fit the parent container. When using this you need to ensure the parent container has `position: relative;`. This is used on the search box, hero and home hero.
- When it is used instead of a background image, the other containers have been updated to use a higher z-index to make the elements sit above the image. I considered using `background-image: image-set()` instead ([more info here](https://developer.mozilla.org/en-US/docs/Web/CSS/image/image-set)), but this is for screen quality, rather than screen resolutions. 

## Testing
- Checkout this branch and run `npm install`
- Run `npm run dev` to manually test the affected components.
- View the Example Content page. Inspect the network tab and scroll down. You should see the images appear when they scroll into view. 
- Run `npm run test` to run the test suite. 

