### PR TITLE
Add clear shortlist and copy to clipboard buttons to directory shortlist

### DIFF
--- a/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.tsx
+++ b/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.tsx
@@ -50,6 +50,10 @@ export const DirectoryShortListProvider: React.FunctionComponent<DirectoryShortL
     return typeof favourites.find((favourite) => favourite.id === id) !== 'undefined';
   };
 
+  const clearShortlist = () => {
+    setFavourites([]);
+  };
+
   const value = {
     favourites: {
       favourites: favourites,
@@ -57,6 +61,7 @@ export const DirectoryShortListProvider: React.FunctionComponent<DirectoryShortL
     },
     toggleFavourites: toggleFavourites,
     isFavourite: isFavourite,
+    clearShortlist: clearShortlist,
   };
 
   return <DirectoryShortListContext.Provider value={value}>{children}</DirectoryShortListContext.Provider>;

--- a/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.types.ts
+++ b/src/library/contexts/DirectoryShortListProvider/DirectoryShortListProvider.types.ts
@@ -29,6 +29,7 @@ export interface DirectoryShortListContextType {
     fees?: string
   ) => void;
   isFavourite?: (id: string) => boolean;
+  clearShortlist?: () => void;
 }
 
 export interface ShortListProps {

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
@@ -66,16 +66,16 @@ export const FavouriteContainer = styled.div`
   }
 `;
 
-export const PrintContainer = styled.div`
+export const ButtonContainer = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 
   @media print {
     display: none;
   }
 `;
 
-export const PrintButton = styled.button`
+export const ActionButton = styled.button`
   border: 2px solid ${(props) => props.theme.theme_vars.colours.action};
   border-radius: ${(props) => props.theme.theme_vars.border_radius};
   background: ${(props) => props.theme.theme_vars.colours.action};
@@ -113,3 +113,32 @@ export const SubTitle = styled.p`
   font-weight: bold;
   margin-top: ${(props) => props.theme.theme_vars.spacingSizes.medium};
 `;
+
+export const ClearShortlistButton = styled.button`
+  border: 1px solid ${(props) => props.theme.theme_vars.colours.negative};
+  background: ${(props) => props.theme.theme_vars.colours.white};
+  color: ${(props) => props.theme.theme_vars.colours.negative};
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  cursor: pointer;
+  border-radius: ${(props) => props.theme.theme_vars.border_radius};
+  min-height: 42px;
+  margin-right: ${(props) => props.theme.theme_vars.spacingSizes.medium};
+  font-weight: bold;
+
+  &:hover {
+    background: ${(props) => props.theme.theme_vars.colours.action_light};
+    color: ${(props) => props.theme.theme_vars.colours.action_dark};
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus}
+  }
+
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
+  }
+`;
+
+export const CopyButton = styled.button``;

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.test.tsx
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import DirectoryShortList from './DirectoryShortList';
 import { DirectoryShortListProps } from './DirectoryShortList.types';
 import { DirectoryShortListProvider } from '../../contexts/DirectoryShortListProvider/DirectoryShortListProvider';
@@ -58,5 +58,37 @@ describe('DirectoryShortList Component', () => {
 
     expect(component).toHaveTextContent('No items in the shortlist');
     expect(component).not.toHaveTextContent('Easy Read Documents');
+  });
+
+  it('should clear the shortlist', async () => {
+    // Force confirm 'OK' to be pressed
+    window.confirm = jest.fn(() => true);
+    shortlistKey = 'DirectoryShort';
+    const { getByTestId, getByRole } = renderComponent();
+    const component = getByTestId('DirectoryShortList');
+    const clearButton = getByRole('button', { name: 'Clear Shortlist' });
+
+    expect(component).toHaveTextContent('Easy Read Documents');
+
+    fireEvent.click(clearButton);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(component).not.toHaveTextContent('Easy Read Documents');
+  });
+
+  it('should not clear the shortlist when pressing cancel', async () => {
+    // Force confirm 'Cancel' to be pressed
+    window.confirm = jest.fn(() => false);
+    shortlistKey = 'DirectoryShort';
+    const { getByTestId, getByRole } = renderComponent();
+    const component = getByTestId('DirectoryShortList');
+    const clearButton = getByRole('button', { name: 'Clear Shortlist' });
+
+    expect(component).toHaveTextContent('Easy Read Documents');
+
+    fireEvent.click(clearButton);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(component).toHaveTextContent('Easy Read Documents');
   });
 });


### PR DESCRIPTION
- Add a button to clear the shortlist. It displays a confirmation asking if you are sure before clearing.
- Add a button that will copy the shortlist data to the clipboard.

## Testing Clear button
- Checkout this branch and run `npm run dev` 
- Visit the Example Directory Service List page and add some items to your shortlist
- Visit the Example Directory Shortlist page and see the shortlist items.
- Click 'Clear Shortlist' button. Press 'Cancel' and the shortlist items should still display. 
- Click 'Clear Shortlist' button and then press 'OK'. The shortlist should now be empty. 

## Testing Copy button
- Checkout this branch and run `npm run dev` 
- Visit the Example Directory Service List page and add some items to your shortlist
- Visit the Example Directory Shortlist page and see the shortlist items.
- Click the 'Copy to clipboard' button. You should get an alert that confirms it has copied to clipboard.
- Paste into a text editor to see the shortlist data. Test it appears correct. 