### PR TITLE
Hide directions button when no lat lon

### DIFF
--- a/src/library/directory/DirectoryService/DirectoryService.stories.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.stories.tsx
@@ -3,7 +3,12 @@ import { StoryFn } from '@storybook/react';
 import DirectoryService from './DirectoryService';
 import { DirectoryServiceProps } from './DirectoryService.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
-import { ExampleService, MultipleLocations, OneVisitableLocation } from './DirectoryService.storydata';
+import {
+  ExampleService,
+  MultipleLocations,
+  OneVisitableLocation,
+  OneVisitableLocationNoLatLon,
+} from './DirectoryService.storydata';
 import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
 import { DirectoryShortListProvider, PageMain } from '../../..';
 
@@ -48,6 +53,12 @@ export const ExampleDirectoryServiceNotVisitable = Template.bind({});
 ExampleDirectoryServiceNotVisitable.args = {
   ...ExampleService,
   ...{ service_at_locations: OneVisitableLocation },
+};
+
+export const ExampleDirectoryServiceVisitableNoLatLon = Template.bind({});
+ExampleDirectoryServiceVisitableNoLatLon.args = {
+  ...ExampleService,
+  ...{ service_at_locations: OneVisitableLocationNoLatLon },
 };
 
 export const ExampleDirectoryNoLogo = Template.bind({});

--- a/src/library/directory/DirectoryService/DirectoryService.storydata.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.storydata.tsx
@@ -293,3 +293,30 @@ export const OneVisitableLocation: LocationProps[] = [
     ],
   },
 ];
+
+export const OneVisitableLocationNoLatLon: LocationProps[] = [
+  {
+    id: 126,
+    name: 'County Hall',
+    description: 'One more council building',
+    latitude: '',
+    longitude: '',
+    is_visitable: true,
+    physical_addresses: [
+      {
+        id: 123,
+        address_1: 'County Hall, St Giles Square',
+        city: 'Northampton',
+        state_province: 'Northamptonshire',
+        postal_code: 'NN1 1DE',
+        country: 'United Kingdom',
+      },
+    ],
+    accessibility_for_disabilities: [
+      {
+        id: 3,
+        accessibility: 'Restaurant/Café',
+      },
+    ],
+  },
+];

--- a/src/library/directory/DirectoryService/DirectoryService.tsx
+++ b/src/library/directory/DirectoryService/DirectoryService.tsx
@@ -122,10 +122,12 @@ const DirectoryService: React.FunctionComponent<DirectoryServiceProps> = ({
                                 .join(' <br />'),
                             }}
                           />
-                          <Button
-                            url={`https://google.com/maps/dir//${location.latitude},${location.longitude}`}
-                            text="Get directions"
-                          />
+                          {location.latitude && location.longitude && (
+                            <Button
+                              url={`https://google.com/maps/dir//${location.latitude},${location.longitude}`}
+                              text="Get directions"
+                            />
+                          )}
                         </Styles.PhysicalAddress>
                       ))}
                       {location?.accessibility_for_disabilities.length > 0 && (


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/913 

Hide the 'Get directions' button on the DirectoryService when there is no latitude or longitude. 

## Testing
- Checkout this branch and run `npm run dev` 
- View the Example Directory Service Visitable No Lat Lon and ensure the map does not show and there is no 'Get directions' button. 