### PR TITLE
Force page break on print after 2 items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "northants-design-system",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "northants-design-system",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "core-js": "^3.20.2",

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
@@ -8,6 +8,10 @@ export const Container = styled.div`
     [data-testid='Column'] {
       padding: ${(props) => props.theme.theme_vars.spacingSizes.extra_small} !important;
     }
+
+    .favourite-outer:nth-of-type(2n + 1) {
+      page-break-after: always;
+    }
   }
 `;
 

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.styles.js
@@ -12,6 +12,10 @@ export const Container = styled.div`
     .favourite-outer:nth-of-type(2n + 1) {
       page-break-after: always;
     }
+
+    .favourite-outer:last-of-type {
+      page-break-after: avoid !important;
+    }
   }
 `;
 

--- a/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
+++ b/src/library/directory/DirectoryShortList/DirectoryShortList.tsx
@@ -72,7 +72,7 @@ About: ${favourite.snippet.replace(/(\r\n|\n|\r)/gm, '').replace(/\s+/g, ' ') ??
                 </Styles.ButtonContainer>
               </Column>
               {favourites.map((favourite) => (
-                <Column key={favourite.id} small="full" medium="full" large="full">
+                <Column key={favourite.id} small="full" medium="full" large="full" classes="favourite-outer">
                   <Styles.FavouriteContainer>
                     <Row>
                       <Column small="full" medium="full" large="full">


### PR DESCRIPTION
Prevent services from going across multiple pages when printing, forcing the page break after every other item in the shortlist. 

## Testing
- Checkout this branch and run `npm run dev`.
- View the Directory Service List and add all services to the shortlist.
- View the Directory Shortlist and press print. Services should not be split across pages.