### PR TITLE
Show subtitles on YouTube videos by default

### DIFF
--- a/src/library/slices/Video/Video.stories.tsx
+++ b/src/library/slices/Video/Video.stories.tsx
@@ -28,6 +28,14 @@ YoutubeVideo.args = {
   allowCookies: true,
 };
 
+export const YoutubeVideoWithCaptions = Template.bind({});
+YoutubeVideoWithCaptions.args = {
+  video_id: 'B4YqyYBQI3A',
+  provider: 'YouTube',
+  description: 'Watch a video about Borrow Box.',
+  allowCookies: true,
+};
+
 export const VimeoVideo = Template.bind({});
 VimeoVideo.args = {
   video_id: '94177065',

--- a/src/library/slices/Video/Video.test.tsx
+++ b/src/library/slices/Video/Video.test.tsx
@@ -52,7 +52,7 @@ describe('Video Component', () => {
     expect(component).toBeVisible();
 
     const iframe = getByTestId('VideoIframe');
-    expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/videoId?rel=0');
+    expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/videoId?rel=0&cc_load_policy=1');
     expect(iframe).toHaveAttribute('title', 'The video description');
   });
 

--- a/src/library/slices/Video/Video.tsx
+++ b/src/library/slices/Video/Video.tsx
@@ -15,7 +15,7 @@ const Video: React.FunctionComponent<VideoProps> = ({ video_id, provider, descri
   const defineLinks = () => {
     if (provider == VideoProvider.YouTube) {
       watchLink = `https://www.youtube.com/watch?v=${video_id}`;
-      embedLink = `https://www.youtube.com/embed/${video_id}?rel=0`;
+      embedLink = `https://www.youtube.com/embed/${video_id}?rel=0&cc_load_policy=1`;
     }
 
     if (provider == VideoProvider.Vimeo) {


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/945

Adds `&cc_load_policy=1` to the end of the embed url to set close captions to load by default. More information available here: https://developers.google.com/youtube/player_parameters#cc_load_policy

## Testing
- Checkout this branch and run `npm run dev`
- View the Slices -> Video -> YouTube Video With Captions story
- Press play and when the talking starts, the captions/subtitles should automatically show by default
- Run `npm run test` to run tests manually