### PR TITLE
Store UPRN and address as cookie when cookies accepted

### DIFF
--- a/src/library/pages/BinFinderExample/BinFinderPageExample.tsx
+++ b/src/library/pages/BinFinderExample/BinFinderPageExample.tsx
@@ -11,6 +11,18 @@ export interface BinFinderPageExampleProps {
 export const BinFinderPageExample: React.FunctionComponent<BinFinderPageExampleProps> = ({ title, contactInfo }) => {
   return (
     <>
+      <PageStructures.CookieBanner
+        title="Tell us whether you accept cookies"
+        paragraph={
+          <p>
+            We use <a href="/your-council/cookies">cookies to collect information</a> about how you use this website. We
+            use this information to make it work as well as possible and help make improvements.
+          </p>
+        }
+        acceptButtonText="Accept all cookies"
+        rejectButtonText="Reject all cookies"
+        acceptCallback={() => {}}
+      />
       <PageStructures.Header />
       <PageStructures.MaxWidthContainer>
         <PageStructures.Breadcrumbs

--- a/src/library/slices/BinFinder/BinFinder.tsx
+++ b/src/library/slices/BinFinder/BinFinder.tsx
@@ -21,6 +21,7 @@ import Column from '../../components/Column/Column';
 import Heading from '../../components/Heading/Heading';
 import { ThemeContext } from 'styled-components';
 import sanitizeHtml from 'sanitize-html';
+import { wereCookiesAccepted, getCookie } from '../../helpers/cookies';
 
 interface AddressOptionProps {
   title: string;
@@ -61,8 +62,34 @@ const BinFinder: React.FunctionComponent<BinFinderProps> = ({ title, contactInfo
     },
   });
 
+  const uprnCookieName = 'uprn-cookie';
+
+  // Try and retrieve uprn and address stored in cookie if cookies accepted
+  useEffect(() => {
+    if (wereCookiesAccepted()) {
+      const addressCookie = getCookie(uprnCookieName);
+
+      if (addressCookie !== null) {
+        const parsedCookie = JSON.parse(addressCookie);
+        setUprn(parsedCookie.uprn ?? '');
+        setAddress(parsedCookie.address ?? '');
+      }
+    }
+  }, []);
+
   useEffect(() => {
     if (uprn) {
+      // Store uprn and address in cookie if cookies accepted
+      if (wereCookiesAccepted()) {
+        let date = new Date();
+        date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000);
+        const cookie = {
+          uprn: uprn,
+          address: address,
+        };
+        document.cookie = `${uprnCookieName}=${JSON.stringify(cookie)};expires=${date.toUTCString()};path=/`;
+      }
+
       getBinCollections();
     }
   }, [uprn]);


### PR DESCRIPTION
Resolves #464 

Once you have found an address and it's UPRN (and cookies were accepted), it will store these in a cookie that can be retrieved next time the page is loaded. This prevents the need to get the address each time and save users time. 

## Testing
- Checkout this branch and run `npm run dev`
- Clear the cookies for the site to start fresh.
- Visit the Page Examples -> Bin Collection Day -> Bin Finder Example. You should see the cookies banner at the top of the page, indicating cookies have not been accepted. 
- Do a search for a postcode and address as you would normally and get the bin collection details as you would normally. 
- Refresh the page and the form should reset to asking for the postcode once more and not show your collection details.
- Now click Accept Cookies and the page should reload.
- Repeat the search as before and get the bin collection details.
- Refresh the page and the bin collection details should now load in automatically. 