### PR TITLE
Update downshift to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "core-js": "^3.20.2",
-        "downshift": "^6.1.7",
+        "downshift": "^9.0",
         "html-react-parser": "^5",
         "react-qr-code": "^2.0.11",
         "sanitize-html": "^2.6.1",
@@ -9631,9 +9631,9 @@
       "dev": true
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -10665,19 +10665,24 @@
       }
     },
     "node_modules/downshift": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
-      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.4.tgz",
+      "integrity": "sha512-6XV/p6+4177d8e8dJ6PoLNSDG1bv52FL18yilKD06oZCb6dFG6f6dXcn3h0B1ggcrOkN3hIvL11Qt15Y5McbXw==",
       "dependencies": {
-        "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^1.0.17",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "tslib": "^2.3.0"
+        "@babel/runtime": "^7.22.15",
+        "compute-scroll-into-view": "^3.0.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
         "react": ">=16.12.0"
       }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
@@ -19012,7 +19017,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-property": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "core-js": "^3.20.2",
-    "downshift": "^6.1.7",
+    "downshift": "^9.0",
     "html-react-parser": "^5",
     "react-qr-code": "^2.0.11",
     "sanitize-html": "^2.6.1",

--- a/src/library/components/Autocomplete/Autocomplete.tsx
+++ b/src/library/components/Autocomplete/Autocomplete.tsx
@@ -129,7 +129,7 @@ const Autocomplete: React.FunctionComponent<AutocompleteProps> = ({
                 )}
               </>
             )}
-            <div {...getRootProps(undefined, { suppressRefError: true })}>
+            <div {...getRootProps({}, { suppressRefError: true })}>
               <Styles.AutocompleteTextInput
                 {...getInputProps({
                   name: name,


### PR DESCRIPTION
Resolves #348 

Updated downshift to the latest version (9 now rather than 8 as the issue states). I read through the migration guides and they seem to be focused on changes to the useCombobox and useSelect hooks which we are not using. The only change made was to replace undefined with an empty object as typescript was giving an error. 

## Testing

- Checkout this branch and run `npm install` to update dependencies
- Run `npm run dev` and view the Autocomplete stories to manually test the autocomplete works as expected
- Run `npm run test` to run the test suite
- Run `yalc publish` then in the frontend run `yalc add northants-design-system && npm install && npm run dev` to manually test the search bar shows suggestions and searches when an option is selected. 