### PR TITLE
Coroners inquest schedule redesigned layout

### DIFF
--- a/src/library/slices/InquestSchedule/InquestSchedule.stories.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.stories.tsx
@@ -3,7 +3,7 @@ import { StoryFn } from '@storybook/react';
 import InquestSchedule from './InquestSchedule';
 import { InquestScheduleProps } from './InquestSchedule.types';
 import { SBPadding } from '../../../../.storybook/SBPadding';
-import { ExampleInquestScheduleData } from './InquestSchedule.storydata';
+import { ExampleInquestScheduleArray, ExampleInquestScheduleData } from './InquestSchedule.storydata';
 import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
 import PageMain from '../../structure/PageMain/PageMain';
 
@@ -29,12 +29,7 @@ const Template: StoryFn<InquestScheduleProps> = (args) => (
 
 export const ExampleInquestSchedule = Template.bind({});
 ExampleInquestSchedule.args = {
-  caseAppointments: [
-    ExampleInquestScheduleData,
-    ExampleInquestScheduleData,
-    ExampleInquestScheduleData,
-    ExampleInquestScheduleData,
-  ],
+  caseAppointments: ExampleInquestScheduleArray,
   title: 'Upcoming inquests',
 };
 

--- a/src/library/slices/InquestSchedule/InquestSchedule.storydata.ts
+++ b/src/library/slices/InquestSchedule/InquestSchedule.storydata.ts
@@ -10,3 +10,46 @@ export const ExampleInquestScheduleData: CaseAppointmentProps = {
   appointmentType: 'AP Inquest Hearing',
   startDateTime: '2023-02-01T10:00:00',
 };
+
+export const ExampleInquestScheduleArray: CaseAppointmentProps[] = [
+  {
+    fullName: 'A Name',
+    age: 85,
+    placeOfDeath: 'A location',
+    dateTimeOfDeath: '2023-01-01T12:08:00',
+    coroner: 'Coroner Name',
+    courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
+    appointmentType: 'AP Inquest Hearing',
+    startDateTime: '2023-02-01T10:00:00',
+  },
+  {
+    fullName: 'A Name',
+    age: 86,
+    placeOfDeath: 'A location',
+    dateTimeOfDeath: '2023-01-02T09:10:00',
+    coroner: 'Coroner Name',
+    courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
+    appointmentType: 'AP Inquest Hearing',
+    startDateTime: '2023-02-01T09:30:00',
+  },
+  {
+    fullName: 'A Name',
+    age: 87,
+    placeOfDeath: 'A location',
+    dateTimeOfDeath: '2023-01-03T14:30:00',
+    coroner: 'Coroner Name',
+    courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
+    appointmentType: 'AP Inquest Hearing',
+    startDateTime: '2023-02-02T09:00:00',
+  },
+  {
+    fullName: 'A Name',
+    age: 88,
+    placeOfDeath: 'A location',
+    dateTimeOfDeath: '2023-01-04T11:15:00',
+    coroner: 'Coroner Name',
+    courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
+    appointmentType: 'AP Inquest Hearing',
+    startDateTime: '2023-02-02T10:15:00',
+  },
+];

--- a/src/library/slices/InquestSchedule/InquestSchedule.styles.js
+++ b/src/library/slices/InquestSchedule/InquestSchedule.styles.js
@@ -23,5 +23,7 @@ export const InquestTime = styled.div`
 
 export const InquestDetails = styled.div`
   flex-grow: 1;
-  padding-left: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    padding-left: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  }
 `;

--- a/src/library/slices/InquestSchedule/InquestSchedule.styles.js
+++ b/src/library/slices/InquestSchedule/InquestSchedule.styles.js
@@ -3,3 +3,25 @@ import styled from 'styled-components';
 export const Container = styled.div`
   display: block;
 `;
+
+export const InquestContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+
+  @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {
+    flex-wrap: nowrap;
+  }
+`;
+
+export const InquestTime = styled.div`
+  flex-grow: 0;
+  flex-shrink: 0;
+`;
+
+export const InquestDetails = styled.div`
+  flex-grow: 1;
+  padding-left: ${(props) => props.theme.theme_vars.spacingSizes.small};
+`;

--- a/src/library/slices/InquestSchedule/InquestSchedule.test.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.test.tsx
@@ -33,10 +33,11 @@ describe('Test Component', () => {
     expect(component).toHaveTextContent('A Name');
     expect(component).toHaveTextContent('100');
     expect(component).toHaveTextContent('A location');
-    expect(component).toHaveTextContent('01/01/2023, 12:08:00');
+    expect(component).toHaveTextContent('Sunday 1 January 2023');
+    expect(component).not.toHaveTextContent('12:08:00');
     expect(component).toHaveTextContent('Coroner Name');
     expect(component).toHaveTextContent('The Guildhall, St. Giles Square, Northampton, NN1 1DE');
-    expect(component).toHaveTextContent('01/02/2023, 10:00:00');
+    expect(component).toHaveTextContent('Wednesday 1 February 2023');
   });
 
   it('should display the message when no results are returned', () => {

--- a/src/library/slices/InquestSchedule/InquestSchedule.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.tsx
@@ -57,13 +57,14 @@ const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAp
                           <strong>{formatTime(startDateTime)}</strong>
                         </Styles.InquestTime>
                         <Styles.InquestDetails>
-                          {inquest.fullName}.
+                          <strong>Name:</strong> {inquest.fullName}.
                           <br />
-                          Died {formatDate(timeOfDeath)} at {inquest.placeOfDeath}. Aged {inquest.age} years.
+                          <strong>Died:</strong> {formatDate(timeOfDeath)} at {inquest.placeOfDeath}. Aged {inquest.age}{' '}
+                          years.
                           <br />
-                          Court location: {inquest.courtroomFullAddress}.
+                          <strong>Court location:</strong> {inquest.courtroomFullAddress}.
                           <br />
-                          Coroner: {inquest.coroner}.
+                          <strong>Coroner:</strong> {inquest.coroner}.
                         </Styles.InquestDetails>
                       </Styles.InquestContainer>
                     </Column>

--- a/src/library/slices/InquestSchedule/InquestSchedule.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.tsx
@@ -1,54 +1,91 @@
 import React from 'react';
 import { InquestScheduleProps } from './InquestSchedule.types';
 import * as Styles from './InquestSchedule.styles';
+import Heading from '../../components/Heading/Heading';
+import Row from '../../components/Row/Row';
+import Column from '../../components/Column/Column';
 
 /**
  * A table displaying a schedule of inquests
  */
-const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAppointments, title, error = false }) => (
-  <Styles.Container data-testid="InquestSchedule">
-    <div className="table-container">
-      <table>
-        <caption>{title}</caption>
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">Age</th>
-            <th scope="col">Place of death</th>
-            <th scope="col">Date of death</th>
-            <th scope="col">Name of coroner</th>
-            <th scope="col">Location</th>
-            <th scope="col">Date and time</th>
-          </tr>
-        </thead>
-        <tbody>
-          {caseAppointments.map((item, index) => (
-            <tr key={index}>
-              <td>{item.fullName}</td>
-              <td>{item.age}</td>
-              <td>{item.placeOfDeath}</td>
-              <td>{new Date(item.dateTimeOfDeath).toLocaleString('en-GB')}</td>
-              <td>{item.coroner}</td>
-              <td>{item.courtroomFullAddress}</td>
-              <td>{new Date(item.startDateTime).toLocaleString('en-GB')}</td>
-            </tr>
-          ))}
-          {caseAppointments.length === 0 && (
-            <tr>
-              <td colSpan={7}>
-                <p>We can't find any results at the moment.</p>
-                {error ? (
-                  <p> The information is currently unavailable.</p>
-                ) : (
-                  <p>There are no inquests scheduled for next month.</p>
-                )}
-              </td>
-            </tr>
+const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAppointments, title, error = false }) => {
+  const inquestDayGrouped = caseAppointments.reduce((acc, inquest) => {
+    const inquestDate = new Date(inquest.startDateTime);
+    const inquestISODay = inquestDate.toISOString().substring(0, 10);
+    if (!acc[inquestISODay]) {
+      acc[inquestISODay] = [];
+    }
+    acc[inquestISODay].push(inquest);
+    return acc;
+  }, {});
+
+  const formatDate = (inquestDay: Date) => {
+    return inquestDay
+      .toLocaleDateString('en-GB', {
+        weekday: 'long',
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })
+      .replace(',', '');
+  };
+
+  const formatTime = (inquestDate: Date) => {
+    return inquestDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <Styles.Container data-testid="InquestSchedule">
+      <Heading level={2} text={title} />
+      {Object.keys(inquestDayGrouped).map((day) => {
+        const inquestDayDate = new Date(day);
+        return (
+          <div key={day}>
+            <Heading level={3} text={formatDate(inquestDayDate)} />
+            <Row>
+              {inquestDayGrouped[day]
+                .sort((a, b) => {
+                  return new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime();
+                })
+                .map((inquest, key) => {
+                  const startDateTime = new Date(inquest.startDateTime);
+                  const timeOfDeath = new Date(inquest.dateTimeOfDeath);
+                  return (
+                    <Column small="full" medium="full" large="full" key={key}>
+                      <Styles.InquestContainer>
+                        <Styles.InquestTime>
+                          <strong>{formatTime(startDateTime)}</strong>
+                        </Styles.InquestTime>
+                        <Styles.InquestDetails>
+                          {inquest.fullName}.
+                          <br />
+                          Died {formatDate(timeOfDeath)} at {inquest.placeOfDeath}. Aged {inquest.age} years.
+                          <br />
+                          Court location: {inquest.courtroomFullAddress}.
+                          <br />
+                          Coroner: {inquest.coroner}.
+                        </Styles.InquestDetails>
+                      </Styles.InquestContainer>
+                    </Column>
+                  );
+                })}
+            </Row>
+          </div>
+        );
+      })}
+
+      {caseAppointments.length === 0 && (
+        <div>
+          <p>We can't find any results at the moment.</p>
+          {error ? (
+            <p> The information is currently unavailable.</p>
+          ) : (
+            <p>There are no inquests scheduled for next month.</p>
           )}
-        </tbody>
-      </table>
-    </div>
-  </Styles.Container>
-);
+        </div>
+      )}
+    </Styles.Container>
+  );
+};
 
 export default InquestSchedule;


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/959

Replaced the table layout as it was difficult to use on smaller screen sizes. The schedule is now grouped by day and then displayed in time order, with the data in a column layout, instead of in a table. 

## Testing
- Checkout this branch and run `npm run dev`
- Visit the Slices -> Inquest Schedule slice to manually test the layouts, for when there is data, when there isn't data and when an error occurs. 
- Test layouts on mobile devices to ensure content is still readable on smaller screens. 
- Run test script with `npm run test` 