### PR TITLE
Fix May 24 silktide accessibility findings

### DIFF
--- a/src/library/components/PromotedLinks/PromotedLinks.styles.js
+++ b/src/library/components/PromotedLinks/PromotedLinks.styles.js
@@ -35,11 +35,14 @@ export const PromotedLink = styled.a`
   background: ${(props) => props.theme.theme_vars.colours.white};
   background: ${(props) => props.theme.theme_vars.colours.white}F2;
   border-radius: 3px;
-  box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.action} inset,
+  box-shadow:
+    0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.action} inset,
     0px 4px 15px rgba(0, 0, 0, 0.11);
-  -webkit-box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.action} inset,
+  -webkit-box-shadow:
+    0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.action} inset,
     0px 4px 15px rgba(0, 0, 0, 0.11);
-  -moz-box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.action} inset,
+  -moz-box-shadow:
+    0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.action} inset,
     0px 4px 15px rgba(0, 0, 0, 0.11);
 
   padding: 20px 15px;
@@ -56,21 +59,31 @@ export const PromotedLink = styled.a`
 
   &:focus {
     ${(props) => props.theme.linkStylesFocus};
-    box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
-      0px 4px 15px rgba(0, 0, 0, 0.11);
-    -webkit-box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
-      0px 4px 15px rgba(0, 0, 0, 0.11);
-    -moz-box-shadow: 0px -4px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
-      0px 4px 15px rgba(0, 0, 0, 0.11);
+    box-shadow:
+      0 0 0 2px ${(props) => props.theme.theme_vars.colours.black},
+      0 0 0 4px ${(props) => props.theme.theme_vars.colours.focus};
+    -webkit-box-shadow:
+      0 0 0 2px ${(props) => props.theme.theme_vars.colours.black},
+      0 0 0 4px ${(props) => props.theme.theme_vars.colours.focus};
+    -moz-box-shadow:
+      0 0 0 2px ${(props) => props.theme.theme_vars.colours.black},
+      0 0 0 4px ${(props) => props.theme.theme_vars.colours.focus};
+
+    span {
+      color: ${(props) => props.theme.theme_vars.colours.black};
+    }
   }
   &:active {
     ${(props) => props.theme.linkStylesActive};
     transform: translateY(3px);
-    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
+    box-shadow:
+      0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
       0px 4px 15px rgba(0, 0, 0, 0.11);
-    -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
+    -webkit-box-shadow:
+      0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
       0px 4px 15px rgba(0, 0, 0, 0.11);
-    -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
+    -moz-box-shadow:
+      0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset,
       0px 4px 15px rgba(0, 0, 0, 0.11);
   }
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.s}) {

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -12,6 +12,7 @@ export const Container = styled.div`
   flex-direction: row;
   align-items: flex-end;
   position: relative;
+  background-color: ${(props) => props.theme.theme_vars.colours.grey_darkest};
 
   &::before {
     content: '';
@@ -147,8 +148,11 @@ export const CallToActionLink = styled.a`
   &:hover,
   &:focus {
     text-decoration-style: dotted;
-    text-shadow: 2px 2px 4px rgba(150, 150, 150, 0.5), -2px 2px 4px rgba(150, 150, 150, 0.5),
-      2px -2px 4px rgba(150, 150, 150, 0.5), -2px -2px 4px rgba(150, 150, 150, 0.5);
+    text-shadow:
+      2px 2px 4px rgba(150, 150, 150, 0.5),
+      -2px 2px 4px rgba(150, 150, 150, 0.5),
+      2px -2px 4px rgba(150, 150, 150, 0.5),
+      -2px -2px 4px rgba(150, 150, 150, 0.5);
   }
   &:active {
     transform: translate(3px);


### PR DESCRIPTION
Resolves #478 

- Update the focus styles on PromotedLinks so they have both black and gold for increased contrast. It has also been updated to surround the whole link, rather than just the bottom of the link, to make the focus selection more obvious. 
- Set a background colour to the HeroImage container to ensure there is a colour contrast background for the white text. It looks like the automated scan cannot determine the background colour as it is an image. Any other recommendations for this issue are welcome. 

## Testing
- Checkout this branch and run `npm run dev` 
- View the Pages -> Homepage, then click into the search bar. Press tab to move focus to the promoted links and test the contrast when focused.
- View the Pages -> Service Landing Page -> Micro Site Example, then check the image and text still display as expected. Check other Micro Site stories to ensure they still behave as expected. There may be a flash of the dark grey background before the image loads because the images are designed to lazy load. 