### PR TITLE
Update thank you text and reorder content sections

### DIFF
--- a/src/library/components/Panel/Panel.styles.js
+++ b/src/library/components/Panel/Panel.styles.js
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   background-color: ${(props) => props.theme.theme_vars.colours.positive};
   padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
   display: flex;

--- a/src/library/structure/RateThisPage/RateThisPage.tsx
+++ b/src/library/structure/RateThisPage/RateThisPage.tsx
@@ -140,7 +140,12 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
   return (
     <Styles.FormContainer as="section" data-testid="RateThisPage" aria-label="Rate This Page">
       {isSuccessful ? (
-        <Panel heading="Thank you for your feedback." />
+        <Panel heading="Thank you for your feedback.">
+          <p>
+            If you have left your email address, we will be in touch with you about your feedback in the next 5 working
+            days.
+          </p>
+        </Panel>
       ) : (
         <form onSubmit={executeCaptcha} ref={fullFormRef}>
           <Row>
@@ -181,21 +186,6 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
               <>
                 <Column small="full" medium="full" large="one-half">
                   <Styles.QuestionContainer>
-                    <Styles.QuestionTitle>Service</Styles.QuestionTitle>
-                    <p>You may have comments about the quality of the service that's been provided. For example:</p>
-                    <ul>
-                      <li>I have waited too long for something to happen</li>
-                      <li>I'm struggling to contact the service</li>
-                      <li>I don't think I have been treated fairly</li>
-                      <li>I feel as if I have been misled</li>
-                    </ul>
-                    <Styles.QuestionButton>
-                      <Button url={complaintsFormLink}>I have a comment or complaint about this service</Button>
-                    </Styles.QuestionButton>
-                  </Styles.QuestionContainer>
-                </Column>
-                <Column small="full" medium="full" large="one-half">
-                  <Styles.QuestionContainer>
                     <Styles.QuestionTitle>Content</Styles.QuestionTitle>
                     <p>You may have comments about the content on the webpage. For example:</p>
                     <ul>
@@ -212,6 +202,21 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
                         size="medium"
                         onClick={handleQuestionButton}
                       />
+                    </Styles.QuestionButton>
+                  </Styles.QuestionContainer>
+                </Column>
+                <Column small="full" medium="full" large="one-half">
+                  <Styles.QuestionContainer>
+                    <Styles.QuestionTitle>Service</Styles.QuestionTitle>
+                    <p>You may have comments about the quality of the service that's been provided. For example:</p>
+                    <ul>
+                      <li>I have waited too long for something to happen</li>
+                      <li>I'm struggling to contact the service</li>
+                      <li>I don't think I have been treated fairly</li>
+                      <li>I feel as if I have been misled</li>
+                    </ul>
+                    <Styles.QuestionButton>
+                      <Button url={complaintsFormLink}>I have a comment or complaint about this service</Button>
                     </Styles.QuestionButton>
                   </Styles.QuestionContainer>
                 </Column>


### PR DESCRIPTION
This resolves [feedback from the issue](https://github.com/FutureNorthants/northants-website/issues/879#issuecomment-2145024497)

- Add paragraph of text to the thank you message
- Reorder the sections so the content goes first 
- Update styles on panel component to fix layout bug when text was added. 

## Testing
- Checkout this branch and run `npm run dev` 
- View the Structure -> Rate this page -> Successful rate this page
- Select 'Yes' and press 'Submit' to see the updated thank you text. 
- Refresh the page and this time press 'No'. The 'Content' box should now be before the 'Service' box. 