### PR TITLE
Fix spacing issue with directory service list accordion

### DIFF
--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
@@ -183,6 +183,7 @@ export const LegendButton = styled.button`
   &:active {
     ${(props) => props.theme.linkStylesActive}
   }
+  margin: 0;
 `;
 
 export const AccordionIcon = styled.span`


### PR DESCRIPTION
After fixing the heading styles in the theme generator it applied additional margin to the accordion buttons as they utilise the H4 styles. This change overrides the heading margin back to zero. 

## Testing
- using the master branch, run `npm run dev` and check the Directory Service List stories to see the accordion items having additional margin
- Checkout this branch and run `npm run dev` and the Directory Service List accordions spacing should now be as expected. 