### PR TITLE
Add toggle buttons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import DropDownFilter from './library/components/DropDownFilter/DropDownFilter';
 import PromotedLinks from './library/components/PromotedLinks/PromotedLinks';
 import StaticMap from './library/components/StaticMap/StaticMap';
 import TextInput from './library/components/TextInput/TextInput';
+import ToggleButtons from './library/components/ToggleButtons/ToggleButtons';
 
 export {
   Autocomplete,
@@ -29,6 +30,7 @@ export {
   PromotedLinks,
   StaticMap,
   TextInput,
+  ToggleButtons,
 };
 
 // Slices

--- a/src/library/components/ToggleButtons/ToggleButtons.stories.tsx
+++ b/src/library/components/ToggleButtons/ToggleButtons.stories.tsx
@@ -30,11 +30,13 @@ export const ExampleToggleButtons = Template.bind({});
 ExampleToggleButtons.args = {
   buttons: [
     {
-      title: 'Most used',
+      label: 'Most used',
+      ariaLabel: 'View the list in most used order',
       onClick: () => {},
     },
     {
-      title: 'Alphabetical',
+      label: 'Alphabetical',
+      ariaLabel: 'View the list in alphabetical order',
       onClick: () => {},
     },
   ],

--- a/src/library/components/ToggleButtons/ToggleButtons.stories.tsx
+++ b/src/library/components/ToggleButtons/ToggleButtons.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import ToggleButtons from './ToggleButtons';
+import { ToggleButtonsProps } from './ToggleButtons.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
+import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
+import PageMain from '../../structure/PageMain/PageMain';
+
+export default {
+  title: 'Library/Components/Toggle Buttons',
+  component: ToggleButtons,
+  parameters: {
+    status: {
+      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+    },
+  },
+};
+
+const Template: StoryFn<ToggleButtonsProps> = (args) => (
+  <SBPadding>
+    <MaxWidthContainer>
+      <PageMain>
+        <ToggleButtons {...args} />
+      </PageMain>
+    </MaxWidthContainer>
+  </SBPadding>
+);
+
+export const ExampleToggleButtons = Template.bind({});
+ExampleToggleButtons.args = {
+  buttons: [
+    {
+      title: 'Most used',
+      onClick: () => {},
+    },
+    {
+      title: 'Alphabetical',
+      onClick: () => {},
+    },
+  ],
+};

--- a/src/library/components/ToggleButtons/ToggleButtons.styles.js
+++ b/src/library/components/ToggleButtons/ToggleButtons.styles.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: block;
+  padding-bottom: ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
+  margin-top: ${(props) => props.theme.theme_vars.spacingSizes.medium};
+`;
+
+export const ToggleButton = styled.button`
+  background-color: ${(props) =>
+    props.$isActive ? props.theme.theme_vars.colours.focus : props.theme.theme_vars.colours.white};
+  border: 2px solid
+    ${(props) => (props.$isActive ? props.theme.theme_vars.colours.focus : props.theme.theme_vars.colours.action)};
+  border-radius: ${(props) => props.theme.theme_vars.border_radius};
+  border-bottom: ${(props) => (props.$isActive ? 'none' : `2px solid ${props.theme.theme_vars.colours.action}`)};
+  box-shadow: ${(props) =>
+    props.$isActive ? `none` : `0px -1px 0px 0px ${props.theme.theme_vars.colours.black} inset`};
+  margin-top: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  margin-right: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  line-height: 1.5;
+  font-size: 1rem;
+  cursor: ${(props) => (props.$isActive ? 'auto' : 'pointer')};
+  outline: none;
+
+  &:hover {
+    background: ${(props) =>
+      props.$isActive ? props.theme.theme_vars.colours.focus : props.theme.theme_vars.colours.action_light};
+  }
+
+  &:focus {
+    ${(props) => props.theme.linkStylesFocus};
+  }
+
+  &:active {
+    ${(props) => props.theme.linkStylesActive};
+    transform: ${(props) => (props.$isActive ? 'none' : 'translateY(2px)')};
+    box-shadow: ${(props) =>
+      props.$isActive ? `none` : `0px -1px 0px 0px ${props.theme.theme_vars.colours.black} inset`};
+  }
+`;

--- a/src/library/components/ToggleButtons/ToggleButtons.test.tsx
+++ b/src/library/components/ToggleButtons/ToggleButtons.test.tsx
@@ -12,11 +12,13 @@ describe('ToggleButtons Component', () => {
     props = {
       buttons: [
         {
-          title: 'Service results',
+          title: 'See the service results',
+          label: 'Service results',
           onClick: () => {},
         },
         {
-          title: 'News results',
+          title: 'See the news results',
+          label: 'News results',
           onClick: () => {},
         },
       ],

--- a/src/library/components/ToggleButtons/ToggleButtons.test.tsx
+++ b/src/library/components/ToggleButtons/ToggleButtons.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+import ToggleButtons from './ToggleButtons';
+import { ToggleButtonsProps } from './ToggleButtons.types';
+
+describe('ToggleButtons Component', () => {
+  let props: ToggleButtonsProps;
+
+  beforeEach(() => {
+    props = {
+      buttons: [
+        {
+          title: 'Service results',
+          onClick: () => {},
+        },
+        {
+          title: 'News results',
+          onClick: () => {},
+        },
+      ],
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <ToggleButtons {...props} />
+      </ThemeProvider>
+    );
+
+  it('should renders toggle buttons correctly', () => {
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('ToggleButtons');
+
+    expect(component).toHaveTextContent('Service results');
+    expect(component).toHaveTextContent('News results');
+  });
+});

--- a/src/library/components/ToggleButtons/ToggleButtons.tsx
+++ b/src/library/components/ToggleButtons/ToggleButtons.tsx
@@ -19,11 +19,14 @@ const ToggleButtons: React.FunctionComponent<ToggleButtonsProps> = ({
       <>
         {buttons.map((button, index) => (
           <Styles.ToggleButton
+            type="button"
+            title={button.title}
+            aria-label={button.ariaLabel}
             key={index}
             onClick={() => handleClick(index, button.onClick)}
             $isActive={activeButton == index}
           >
-            {button.title}
+            {button.label}
           </Styles.ToggleButton>
         ))}
       </>

--- a/src/library/components/ToggleButtons/ToggleButtons.tsx
+++ b/src/library/components/ToggleButtons/ToggleButtons.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { ToggleButtonsProps } from './ToggleButtons.types';
+import * as Styles from './ToggleButtons.styles';
+
+const ToggleButtons: React.FunctionComponent<ToggleButtonsProps> = ({
+  buttons,
+  defaultButton = 0,
+  hasTopMargin = false,
+}) => {
+  const [activeButton, setActiveButton] = useState(defaultButton);
+
+  const handleClick = (index, onClick) => {
+    setActiveButton(index);
+    onClick();
+  };
+
+  return (
+    <Styles.Container data-testid="ToggleButtons" $hasTopMargin={hasTopMargin}>
+      <>
+        {buttons.map((button, index) => (
+          <Styles.ToggleButton
+            key={index}
+            onClick={() => handleClick(index, button.onClick)}
+            $isActive={activeButton == index}
+          >
+            {button.title}
+          </Styles.ToggleButton>
+        ))}
+      </>
+    </Styles.Container>
+  );
+};
+
+export default ToggleButtons;

--- a/src/library/components/ToggleButtons/ToggleButtons.types.ts
+++ b/src/library/components/ToggleButtons/ToggleButtons.types.ts
@@ -17,12 +17,22 @@ export interface ToggleButtonsProps {
 
 export interface ToggleButtonProps {
   /**
-   * The title for the button
+   * The optional aria-label text used to describe the button to screen readers
    */
-  title: string;
+  ariaLabel?: string;
+
+  /**
+   * The button label text
+   */
+  label: string;
+
+  /**
+   * The optional title for the button
+   */
+  title?: string;
 
   /**
    * The onClick function when the button is pressed
    */
-  onClick: () => void;
+  onClick?: () => void;
 }

--- a/src/library/components/ToggleButtons/ToggleButtons.types.ts
+++ b/src/library/components/ToggleButtons/ToggleButtons.types.ts
@@ -1,0 +1,28 @@
+export interface ToggleButtonsProps {
+  /**
+   * An array of toggle buttons
+   */
+  buttons: ToggleButtonProps[];
+
+  /**
+   * Set the default active button
+   */
+  defaultButton?: number;
+
+  /**
+   * Should the buttons have top margin
+   */
+  hasTopMargin?: boolean;
+}
+
+export interface ToggleButtonProps {
+  /**
+   * The title for the button
+   */
+  title: string;
+
+  /**
+   * The onClick function when the button is pressed
+   */
+  onClick: () => void;
+}

--- a/src/library/pages/NewsArticle/NewsArticle.stories.tsx
+++ b/src/library/pages/NewsArticle/NewsArticle.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { StoryFn, Meta } from '@storybook/react';
 import { NewsArticle, NewsArticleProps } from './NewsArticle';
 
 export default {

--- a/src/library/pages/SearchResultsPageExample/SearchResultsPageExample.tsx
+++ b/src/library/pages/SearchResultsPageExample/SearchResultsPageExample.tsx
@@ -6,6 +6,7 @@ import Searchbar from '../../structure/Searchbar/Searchbar';
 import Pagination from '../../components/Pagination/Pagination';
 import { SignpostLinkProp } from '../../components/SignpostLinksList/SignpostLinksList.types';
 import { noSearchResults, searchResultsWithServiceArea } from './../../structure/SearchResultsList/SearchResultsData';
+import ToggleButtons from '../../components/ToggleButtons/ToggleButtons';
 
 export interface SearchResultsPageExampleProps {
   results: Array<SearchResultProps>;
@@ -58,6 +59,21 @@ export const SearchResultsPageExample: React.FC<SearchResultsPageExampleProps> =
               searchTerm: 'council tax',
             },
           }}
+        />
+
+        <ToggleButtons
+          buttons={[
+            {
+              title: 'Service results',
+              onClick: () => {},
+            },
+            {
+              title: 'News results',
+              onClick: () => {},
+            },
+          ]}
+          defaultButton={0}
+          hasTopMargin
         />
 
         {results ? <SearchResultsList {...searchResultsWithServiceArea} /> : <SearchResultsList {...noSearchResults} />}

--- a/src/library/pages/SearchResultsPageExample/SearchResultsPageExample.tsx
+++ b/src/library/pages/SearchResultsPageExample/SearchResultsPageExample.tsx
@@ -64,11 +64,13 @@ export const SearchResultsPageExample: React.FC<SearchResultsPageExampleProps> =
         <ToggleButtons
           buttons={[
             {
-              title: 'Service results',
+              label: 'Service results',
+              ariaLabel: 'View the service results',
               onClick: () => {},
             },
             {
-              title: 'News results',
+              label: 'News results',
+              ariaLabel: 'View the news results',
               onClick: () => {},
             },
           ]}

--- a/src/library/structure/SearchResultsList/SearchResultsData.ts
+++ b/src/library/structure/SearchResultsList/SearchResultsData.ts
@@ -1,4 +1,6 @@
-export const searchResults = {
+import { SearchResultsListProps } from './SearchResultsList.types';
+
+export const searchResults: SearchResultsListProps = {
   searchTerm: 'Council tax',
   pageNumber: 1,
   totalResults: 23,
@@ -6,12 +8,15 @@ export const searchResults = {
     {
       title: 'Council tax',
       link: '/council-tax',
+      service: 'Council Tax',
       summary:
         'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+      published: 'one year ago',
     },
     {
       title: 'Paying council tax',
       link: '/',
+      service: 'Payments',
       summary: 'Pay your council tax online',
       signpostLinksArray: [
         {
@@ -37,10 +42,11 @@ export const searchResults = {
       ],
     },
     {
-      title: 'Council tax',
-      link: '/council-tax',
-      summary:
-        'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
+      title: 'Council tax news article',
+      link: '/news/council-tax-news-article',
+      published: '2 years ago',
+      service: 'News',
+      summary: 'An example news article that shows when it was published.',
     },
     {
       title: 'Council tax single CTA',
@@ -81,13 +87,13 @@ export const searchResults = {
   ],
 };
 
-export const noSearchResults = {
+export const noSearchResults: SearchResultsListProps = {
   searchTerm: 'Council tax',
   totalResults: 0,
   results: [],
 };
 
-export const searchResultsWithServiceArea = {
+export const searchResultsWithServiceArea: SearchResultsListProps = {
   searchTerm: 'Council tax',
   pageNumber: 2,
   totalResults: 23,
@@ -126,6 +132,13 @@ export const searchResultsWithServiceArea = {
           url: '/',
         },
       ],
+    },
+    {
+      title: 'Council tax news article',
+      link: '/news/council-tax-news-article',
+      published: '2 years ago',
+      service: 'News',
+      summary: 'An example news article that shows when it was published.',
     },
     {
       service: 'Bins, recycling and waste',

--- a/src/library/structure/SearchResultsList/SearchResultsData.ts
+++ b/src/library/structure/SearchResultsList/SearchResultsData.ts
@@ -11,7 +11,7 @@ export const searchResults: SearchResultsListProps = {
       service: 'Council Tax',
       summary:
         'Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.',
-      published: 'one year ago',
+      published: '18 January 2022',
     },
     {
       title: 'Paying council tax',
@@ -44,9 +44,9 @@ export const searchResults: SearchResultsListProps = {
     {
       title: 'Council tax news article',
       link: '/news/council-tax-news-article',
-      published: '2 years ago',
+      published: '18 January 2022',
       service: 'News',
-      summary: 'An example news article that shows when it was published.',
+      summary: 'An example news article that shows it was published over a year ago.',
     },
     {
       title: 'Council tax single CTA',
@@ -136,9 +136,9 @@ export const searchResultsWithServiceArea: SearchResultsListProps = {
     {
       title: 'Council tax news article',
       link: '/news/council-tax-news-article',
-      published: '2 years ago',
+      published: '18 January 2022',
       service: 'News',
-      summary: 'An example news article that shows when it was published.',
+      summary: 'An example news article that shows it was published over a year ago.',
     },
     {
       service: 'Bins, recycling and waste',

--- a/src/library/structure/SearchResultsList/SearchResultsList.styles.js
+++ b/src/library/structure/SearchResultsList/SearchResultsList.styles.js
@@ -89,7 +89,3 @@ export const SignpostContainer = styled.div`
     }
   }
 `;
-
-export const Published = styled.p`
-  font-weight: bold;
-`;

--- a/src/library/structure/SearchResultsList/SearchResultsList.styles.js
+++ b/src/library/structure/SearchResultsList/SearchResultsList.styles.js
@@ -89,3 +89,7 @@ export const SignpostContainer = styled.div`
     }
   }
 `;
+
+export const Published = styled.p`
+  font-weight: bold;
+`;

--- a/src/library/structure/SearchResultsList/SearchResultsList.tsx
+++ b/src/library/structure/SearchResultsList/SearchResultsList.tsx
@@ -3,6 +3,7 @@ import { SearchResultsListProps } from './SearchResultsList.types';
 import * as Styles from './SearchResultsList.styles';
 import SignpostLinksList from '../../components/SignpostLinksList/SignpostLinksList';
 import { ThemeContext } from 'styled-components';
+import { NewsArticleOldBanner } from '../PageStructures';
 
 const SearchResultsList: React.FunctionComponent<SearchResultsListProps> = ({
   searchTerm,
@@ -11,6 +12,12 @@ const SearchResultsList: React.FunctionComponent<SearchResultsListProps> = ({
   pageNumber = 0,
 }) => {
   const themeContext = useContext(ThemeContext);
+  const isOld = (date): boolean => {
+    const currentDate = new Date();
+    const dateObject = new Date(date);
+    return Math.ceil(Math.abs(currentDate.getTime() - dateObject.getTime()) / (1000 * 60 * 60 * 24)) > 365;
+  };
+
   if (totalResults === 0) {
     return (
       <Styles.Container data-testid="SearchResultsList">
@@ -29,9 +36,7 @@ const SearchResultsList: React.FunctionComponent<SearchResultsListProps> = ({
           <Styles.Result key={i}>
             {result.service && <Styles.ServiceArea>{result.service}</Styles.ServiceArea>}
             <Styles.Title href={result.link}>{result.title}</Styles.Title>
-            {result.published && result.service === 'News' && (
-              <Styles.Published>Published {result.published}</Styles.Published>
-            )}
+            {result.published && result.service === 'News' && isOld(result.published) && <NewsArticleOldBanner />}
             <Styles.Summary>{result.summary}</Styles.Summary>
             {result.signpostLinksArray && themeContext.cardinal_name === 'north' && (
               <Styles.SignpostContainer>

--- a/src/library/structure/SearchResultsList/SearchResultsList.tsx
+++ b/src/library/structure/SearchResultsList/SearchResultsList.tsx
@@ -29,6 +29,9 @@ const SearchResultsList: React.FunctionComponent<SearchResultsListProps> = ({
           <Styles.Result key={i}>
             {result.service && <Styles.ServiceArea>{result.service}</Styles.ServiceArea>}
             <Styles.Title href={result.link}>{result.title}</Styles.Title>
+            {result.published && result.service === 'News' && (
+              <Styles.Published>Published {result.published}</Styles.Published>
+            )}
             <Styles.Summary>{result.summary}</Styles.Summary>
             {result.signpostLinksArray && themeContext.cardinal_name === 'north' && (
               <Styles.SignpostContainer>

--- a/src/library/structure/SearchResultsList/SearchResultsList.tsx
+++ b/src/library/structure/SearchResultsList/SearchResultsList.tsx
@@ -3,7 +3,7 @@ import { SearchResultsListProps } from './SearchResultsList.types';
 import * as Styles from './SearchResultsList.styles';
 import SignpostLinksList from '../../components/SignpostLinksList/SignpostLinksList';
 import { ThemeContext } from 'styled-components';
-import { NewsArticleOldBanner } from '../PageStructures';
+import NewsArticleOldBanner from '../NewsArticleOldBanner/NewsArticleOldBanner';
 
 const SearchResultsList: React.FunctionComponent<SearchResultsListProps> = ({
   searchTerm,

--- a/src/library/structure/SearchResultsList/SearchResultsList.types.ts
+++ b/src/library/structure/SearchResultsList/SearchResultsList.types.ts
@@ -52,4 +52,9 @@ export interface SearchResultProps {
    * If there is a service area tied to the result
    */
   service?: string;
+
+  /**
+   * How long ago the page was last edited or news article was published
+   */
+  published?: string;
 }


### PR DESCRIPTION
Part of [Search engine improvements](https://github.com/FutureNorthants/northants-website/issues/1044).

Add toggle buttons for use in the search results page. This will indicate whether the search is filtered to service pages or news pages. 

The toggle buttons allow us to pass in an onClick event which we can use in the frontend to reload the search results with the news or services content type filter as required (as the page is server side rendered).

## Testing
- Check out this branch and run `npm install` then `npm run dev` to start storybook
- View the Components -> Toggle Buttons
- Test the styles toggling between the two buttons. 

## Future changes
- The Homepage can be refactored to make use of the toggle buttons to help remove duplicated code.