### PR TITLE
Set secondary button background to white

### DIFF
--- a/src/library/components/Button/Button.styles.js
+++ b/src/library/components/Button/Button.styles.js
@@ -45,7 +45,7 @@ export const StyledButton = styled.a`
   &.button--secondary {
     color: ${(props) =>
       props.$colourOverride ? props.$colourOverride : props.theme.theme_vars.colours.action} !important;
-    background-color: transparent;
+    background-color: ${(props) => props.theme.theme_vars.colours.white};
     border: 3px solid
       ${(props) => (props.$colourOverride ? props.$colourOverride : props.theme.theme_vars.colours.action)};
 


### PR DESCRIPTION
Resolves #502 

The HeroImage component uses the CallToAction slice, which uses the Button component... 

The background was set to transparent, but this meant that the contrast between the text and the background could be unknown. This updates the secondary button styles so that the background is white, ensuring accessible contrast between the blue text and the white background. 

## Testing
- Checkout this branch and run `npm run dev`
- View the Components -> Buttons -> Secondary and check the button has a white background 
- View the Structure -> Hero Image -> Hero Image With Custom Search and check the button has a white background
- Use the [Silktide browser plugin](https://silktide.com/toolbar/) to test the colour contrast between the button text and the button background. 