### PR TITLE
Allow updated google maps url format

### DIFF
--- a/src/library/slices/GoogleMap/GoogleMap.stories.tsx
+++ b/src/library/slices/GoogleMap/GoogleMap.stories.tsx
@@ -39,3 +39,6 @@ GoogleMapWithTitleAndDescriptionDataAutodetectCookies.args =
 
 export const GoogleMapWithInvalidLinks = Template.bind({});
 GoogleMapWithInvalidLinks.args = storydata.GoogleMapWithInvalidLinks;
+
+export const GoogleMapWithUpdatedLink = Template.bind({});
+GoogleMapWithUpdatedLink.args = storydata.GoogleMapWithUpdatedLinkFormat;

--- a/src/library/slices/GoogleMap/GoogleMap.storydata.ts
+++ b/src/library/slices/GoogleMap/GoogleMap.storydata.ts
@@ -38,10 +38,15 @@ export const GoogleMapWithTitleAndDescriptionDataAutodetectCookies = {
 };
 
 export const GoogleMapWithInvalidLinks = {
-    title: 'Invalid embedded map',
-    description: 'This is an attempt to embed a source that is not Google Maps',
-    link_title: 'Click to show a lovely map, it is safe honest',
-    link_url: 'https://en.wikipedia.org/wiki/Honeypot_(computing)',
-    iframe_html: '<iframe src="https://en.wikipedia.org/wiki/Honeypot_(computing)" />',
-    allowCookies: true,
+  title: 'Invalid embedded map',
+  description: 'This is an attempt to embed a source that is not Google Maps',
+  link_title: 'Click to show a lovely map, it is safe honest',
+  link_url: 'https://en.wikipedia.org/wiki/Honeypot_(computing)',
+  iframe_html: '<iframe src="https://en.wikipedia.org/wiki/Honeypot_(computing)" />',
+  allowCookies: true,
+};
+
+export const GoogleMapWithUpdatedLinkFormat = {
+  ...Common,
+  link_url: 'https://maps.app.goo.gl/fwHnJrT7RfAQQ3FN7',
 };

--- a/src/library/slices/GoogleMap/GoogleMap.tsx
+++ b/src/library/slices/GoogleMap/GoogleMap.tsx
@@ -30,7 +30,9 @@ const GoogleMap: React.FunctionComponent<GoogleMapProps> = ({
 
   /* We also check the non-embed link goes to goo.gl/maps or www.google.com/maps */
   if (link_url) {
-    const googl_matches = link_url.match(/^https:\/\/goo.gl\/maps|https:\/\/www.google.com\/maps/gi);
+    const googl_matches = link_url.match(
+      /^https:\/\/goo.gl\/maps|https:\/\/www.google.com\/maps|https:\/\/maps.app.goo.gl/gi
+    );
     link_url = googl_matches?.length == 1 ? link_url : '';
   }
 


### PR DESCRIPTION
Resolves #525 

This allows the new maps link format (maps.app.goo.gl).

## Testing
- Checkout this branch and run `npm run dev`
- View the Slices -> Google Map -> Google Map With Updated Link
- Verify that there is no 'Invalid link' alert message displayed. 
- Clear the cookies and reload the page. The link to the map should display correctly instead of the embedded map. 