### PR TITLE
Override proximity and hide postcode search in directory page

### DIFF
--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.stories.tsx
@@ -71,6 +71,22 @@ ExampleDirectoryServiceList.args = {
   customTaxonomyFilters: ['facilities', 'language'],
   ageInMonths: true,
   hasDocuments: true,
+  proximity: 4,
+};
+
+export const DirectoryServiceNoPostcodeSearch = Template.bind({});
+DirectoryServiceNoPostcodeSearch.args = {
+  services: [],
+  totalResults: 0,
+  categories: ExampleDirectoryCategories,
+  pageNumber: 1,
+  perPage: 5,
+  directoryPath: '/directory/local-offer',
+  shortListPath: '/directory/local-offer/short-list',
+  customTaxonomyFilters: ['facilities', 'language'],
+  ageInMonths: true,
+  hasDocuments: true,
+  showPostcodeSearch: false,
 };
 
 export const DirectoryServiceNoResults = Template.bind({});

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.test.tsx
@@ -213,4 +213,20 @@ describe('Test Component', () => {
     expect(clearSearch).toBeVisible();
     expect(clearSearch).toHaveStyle(`border: 3px solid ${west_theme.theme_vars.colours.negative}`);
   });
+
+  it('hides the postcode search', () => {
+    props.showPostcodeSearch = false;
+
+    const { queryByLabelText } = renderComponent();
+
+    expect(queryByLabelText('Postcode (optional)')).toBeNull();
+  });
+
+  it('overrides the proximity for the postcode search', () => {
+    props.proximity = 6;
+
+    const { getByText } = renderComponent();
+
+    expect(getByText('Enter a postcode to see results within 6 miles')).toBeVisible();
+  });
 });

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -28,6 +28,8 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
   services,
   search = '',
   setSearch,
+  proximity = 2,
+  showPostcodeSearch = true,
   postcode = '',
   setPostcode,
   totalResults = 0,
@@ -218,18 +220,21 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                     }}
                   />
                 </Column>
-                <Column small="full" medium="one-half" large="one-third">
-                  <Styles.Label htmlFor="postcode">Postcode (optional)</Styles.Label>
-                  <HintText text="Enter a postcode to see results within 2 miles" />
-                  <Input
-                    name="postcode"
-                    type="text"
-                    defaultValue={postcodeSearch}
-                    id="postcode"
-                    onChange={(e) => setPostcodeSearch(e.target.value)}
-                    autocomplete="postal-code"
-                  />
-                </Column>
+                {showPostcodeSearch && (
+                  <Column small="full" medium="one-half" large="one-third">
+                    <Styles.Label htmlFor="postcode">Postcode (optional)</Styles.Label>
+                    <HintText text={`Enter a postcode to see results within ${proximity} miles`} />
+                    <Input
+                      name="postcode"
+                      type="text"
+                      defaultValue={postcodeSearch}
+                      id="postcode"
+                      onChange={(e) => setPostcodeSearch(e.target.value)}
+                      autocomplete="postal-code"
+                    />
+                  </Column>
+                )}
+
                 <Column small="full" medium="one-half" large="one-third">
                   <Styles.ButtonContainer>
                     <Styles.Button onClick={submitSearch} type="submit">

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.types.ts
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.types.ts
@@ -33,6 +33,16 @@ export interface DirectoryServiceListProps {
   setSearch: Dispatch<SetStateAction<string>>;
 
   /**
+   * The optional proximity the postcode will search. Defaults to 2 miles.
+   */
+  proximity?: number;
+
+  /**
+   * Should the postcode search be shown? Defaults to true.
+   */
+  showPostcodeSearch?: boolean;
+
+  /**
    * The postcode search term
    */
   postcode?: string;


### PR DESCRIPTION
Relates to https://github.com/FutureNorthants/OpenReferral/issues/273

- Allow hiding the postcode search in the DirectoryServiceList
- Allow overriding the proximity for the postcode search

## Testing
- Checkout this branch and run `npm install` then run `npm run dev`
- View the Directory -> Directory Service List and test the Directory Service No Postcode Search. It should not show the postcode field. 
- View the Example Directory Service List and test that the postcode help text is updated to 4 miles instead of the default 2 miles. 
- Manually run test suite with `npm run test`
- Manually test build with `npm run build`