### PR TITLE
Add max length to webchat form and character count

### DIFF
--- a/src/library/components/CharacterCount/CharacterCount.stories.tsx
+++ b/src/library/components/CharacterCount/CharacterCount.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import CharacterCount from './CharacterCount';
+import { CharacterCountProps } from './CharacterCount.types';
+import { SBPadding } from '../../../../.storybook/SBPadding';
+
+export default {
+  title: 'Library/Components/Character Count',
+  component: CharacterCount,
+  parameters: {
+    status: {
+      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
+    },
+  },
+};
+
+const Template: StoryFn<CharacterCountProps> = (args) => (
+  <SBPadding>
+    <CharacterCount {...args} />
+  </SBPadding>
+);
+
+export const ExampleCharacterCount = Template.bind({});
+ExampleCharacterCount.args = {
+  maxLength: 150,
+  input: 'This is a test message',
+};
+
+export const ExampleCharacterCountTooLong = Template.bind({});
+ExampleCharacterCountTooLong.args = {
+  maxLength: 20,
+  input: 'This is a test message that is too long for the max length.',
+};

--- a/src/library/components/CharacterCount/CharacterCount.styles.js
+++ b/src/library/components/CharacterCount/CharacterCount.styles.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: block;
+`;
+
+export const Count = styled.div`
+  ${(props) => props.theme.fontStyles};
+  margin-bottom: 25px;
+`;

--- a/src/library/components/CharacterCount/CharacterCount.test.tsx
+++ b/src/library/components/CharacterCount/CharacterCount.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { west_theme } from '../../../themes/theme_generator';
+import CharacterCount from './CharacterCount';
+import { CharacterCountProps } from './CharacterCount.types';
+
+describe('Character Count Component', () => {
+  let props: CharacterCountProps;
+
+  beforeEach(() => {
+    props = {
+      maxLength: 100,
+      input: 'This is a test',
+    };
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={west_theme}>
+        <CharacterCount {...props} />
+      </ThemeProvider>
+    );
+
+  it('should render the character count correctly', () => {
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('CharacterCount');
+
+    expect(component).toHaveTextContent('You have 86 characters remaining.');
+  });
+
+  it('should render zero characters remaining when over the limit', () => {
+    props.maxLength = 10;
+    props.input = 'This is a really long string with too many characters for the limit';
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('CharacterCount');
+
+    expect(component).toHaveTextContent('You have 0 characters remaining.');
+  });
+});

--- a/src/library/components/CharacterCount/CharacterCount.tsx
+++ b/src/library/components/CharacterCount/CharacterCount.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+import { CharacterCountProps } from './CharacterCount.types';
+import * as Styles from './CharacterCount.styles';
+
+const CharacterCount: React.FunctionComponent<CharacterCountProps> = ({ maxLength, input }) => {
+  const [remaining, setRemaining] = useState(maxLength);
+
+  useEffect(() => {
+    const calculatedRemaining = maxLength - input.length;
+    setRemaining(calculatedRemaining < 0 ? 0 : calculatedRemaining);
+  }, [input]);
+
+  return (
+    <Styles.Container data-testid="CharacterCount">
+      <Styles.Count aria-live="polite">You have {remaining} characters remaining.</Styles.Count>
+    </Styles.Container>
+  );
+};
+
+export default CharacterCount;

--- a/src/library/components/CharacterCount/CharacterCount.types.ts
+++ b/src/library/components/CharacterCount/CharacterCount.types.ts
@@ -1,0 +1,11 @@
+export interface CharacterCountProps {
+  /**
+   * The max length of characters allowed
+   */
+  maxLength: number;
+
+  /**
+   * The input string
+   */
+  input: string;
+}

--- a/src/library/components/Textarea/Textarea.stories.tsx
+++ b/src/library/components/Textarea/Textarea.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Textarea from './Textarea';
 import { TextareaProps } from './Textarea.types';
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { StoryFn } from '@storybook/react';
 import { SBPadding } from '../../../../.storybook/SBPadding';
 import MaxWidthContainer from '../../structure/MaxWidthContainer/MaxWidthContainer';
 import PageMain from '../../structure/PageMain/PageMain';
@@ -16,7 +16,7 @@ export default {
   },
 };
 
-const Template: Story<TextareaProps> = (args) => (
+const Template: StoryFn<TextareaProps> = (args) => (
   <SBPadding>
     <MaxWidthContainer>
       <PageMain>

--- a/src/library/components/Textarea/Textarea.styles.js
+++ b/src/library/components/Textarea/Textarea.styles.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const StyledTextarea = styled.textarea`
   ${(props) => props.theme.fontStyles}
   margin-top: 0 !important;
-  margin-bottom: 25px;
+  margin-bottom: ${(props) => (props.maxLength ? '0' : '25px')};
   padding: 5px;
   border: solid
     ${(props) => (props.$isErrored ? props.theme.theme_vars.colours.negative : props.theme.theme_vars.colours.black)};

--- a/src/library/components/Textarea/Textarea.tsx
+++ b/src/library/components/Textarea/Textarea.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TextareaProps } from './Textarea.types';
 import * as Styles from './Textarea.styles';
+import CharacterCount from '../CharacterCount/CharacterCount';
 
 /**
  * Primary UI component for user interaction
@@ -22,16 +23,19 @@ const Textarea: React.FunctionComponent<TextareaProps> = ({
     <>
       {errorText && <Styles.ErrorText id={`${name}Error`}>{errorText}</Styles.ErrorText>}
       {typeof value !== 'undefined' ? (
-        <Styles.StyledTextarea
-          onChange={onChange}
-          placeholder={placeholder}
-          name={name}
-          $isErrored={isErrored}
-          maxLength={maxLength}
-          value={value}
-          id={id}
-          $isFullWidth={isFullWidth}
-        />
+        <>
+          <Styles.StyledTextarea
+            onChange={onChange}
+            placeholder={placeholder}
+            name={name}
+            $isErrored={isErrored}
+            maxLength={maxLength}
+            value={value}
+            id={id}
+            $isFullWidth={isFullWidth}
+          />
+          {maxLength && typeof value === 'string' && <CharacterCount maxLength={maxLength} input={value} />}
+        </>
       ) : (
         <Styles.StyledTextarea
           onChange={onChange}

--- a/src/library/slices/WebChat/WebChat.tsx
+++ b/src/library/slices/WebChat/WebChat.tsx
@@ -136,6 +136,7 @@ const WebChat: React.FunctionComponent<WebChatProps> = ({
                       errorText={errors.name ? errors.name.message : null}
                       isFullWidth
                       autocomplete="name"
+                      maxLength={50}
                     />
                   )}
                 />
@@ -185,6 +186,7 @@ const WebChat: React.FunctionComponent<WebChatProps> = ({
                       errorText={errors.email ? errors.email.message : null}
                       isFullWidth
                       autocomplete="email"
+                      maxLength={100}
                     />
                   )}
                 />
@@ -207,6 +209,7 @@ const WebChat: React.FunctionComponent<WebChatProps> = ({
                       errorText={errors.telephone ? errors.telephone.message : null}
                       isFullWidth
                       autocomplete="tel"
+                      maxLength={20}
                     />
                   )}
                 />
@@ -228,6 +231,7 @@ const WebChat: React.FunctionComponent<WebChatProps> = ({
                       isErrored={errors.reference ? true : false}
                       errorText={errors.reference ? errors.reference.message : null}
                       isFullWidth
+                      maxLength={50}
                     />
                   )}
                 />
@@ -250,6 +254,7 @@ const WebChat: React.FunctionComponent<WebChatProps> = ({
                       isErrored={errors.subject ? true : false}
                       errorText={errors.subject ? errors.subject.message : null}
                       isFullWidth
+                      maxLength={100}
                     />
                   )}
                 />


### PR DESCRIPTION
Resolves #534 

- Updated the web chat form so the inputs and textarea have max length attribute set
- Add a character count component that states how many characters are remaining
- Added character count to textarea component when the max length is set

## Testing
- Checkout this branch `git fetch` then `git checkout 534-textarea-should-have-a-maxlength`
- Run `npm install` then `npm run dev`
- Go to Pages -> Example Contact Page and click the Launch webchat button
- Test that the maxlength attribute is set on the inputs and the textarea
- Test that the character count counts down as you type on the subject textarea field