### PR TITLE
Send all url parameters for webchat, even when empty

### DIFF
--- a/src/library/slices/WebChat/WebChat.test.tsx
+++ b/src/library/slices/WebChat/WebChat.test.tsx
@@ -13,7 +13,7 @@ describe('WebChat Slice', () => {
   beforeEach(() => {
     props = {
       buttonText: 'Open WebChat',
-      action: '',
+      action: 'http://example.com/1234',
       queues: [
         {
           title: 'Select an option',
@@ -33,6 +33,9 @@ describe('WebChat Slice', () => {
         },
       ],
     };
+
+    // Mock window.open
+    global.open = jest.fn();
   });
 
   const renderComponent = () =>
@@ -158,6 +161,41 @@ describe('WebChat Slice', () => {
 
     await waitFor(() => {
       expect(component).toHaveTextContent('Invalid email address.');
+    });
+  });
+
+  it('submits the data to the url', async () => {
+    const { getByTestId, getByRole, getByLabelText } = renderComponent();
+    const component = getByTestId('WebChat');
+    const startButton = getByRole('button', { name: props.buttonText });
+
+    fireEvent.click(startButton);
+
+    fireEvent.input(getByLabelText('Name'), {
+      target: {
+        value: 'Test Name',
+      },
+    });
+    fireEvent.input(getByLabelText('Subject'), {
+      target: {
+        value: 'An example subject',
+      },
+    });
+    fireEvent.change(getByLabelText('Enquiry Type'), {
+      target: {
+        value: 'council_tax',
+      },
+    });
+
+    fireEvent.submit(getByRole('button', { name: 'Connect to webchat (opens in new window)' }));
+
+    await waitFor(() => {
+      expect(component).not.toHaveTextContent('There is a problem');
+      expect(global.open).toHaveBeenCalled();
+      expect(global.open).toHaveBeenCalledWith(
+        'http://example.com/1234?queue=council_tax&email=&telephone=&reference=&im_name=Test%20Name&im_subject=An%20example%20subject',
+        '_blank'
+      );
     });
   });
 });

--- a/src/library/slices/WebChat/WebChat.tsx
+++ b/src/library/slices/WebChat/WebChat.tsx
@@ -43,33 +43,25 @@ const WebChat: React.FunctionComponent<WebChatProps> = ({
   const onSubmit: SubmitHandler<WebChatFormInputs> = (data) => {
     const params = [];
 
-    if (data.enquiryType) {
-      params.push({
-        key: 'queue',
-        value: data.enquiryType,
-      });
-    }
+    params.push({
+      key: 'queue',
+      value: data.enquiryType ?? '',
+    });
 
-    if (data.email) {
-      params.push({
-        key: 'email',
-        value: data.email,
-      });
-    }
+    params.push({
+      key: 'email',
+      value: data.email ?? '',
+    });
 
-    if (data.telephone) {
-      params.push({
-        key: 'telephone',
-        value: data.telephone,
-      });
-    }
+    params.push({
+      key: 'telephone',
+      value: data.telephone ?? '',
+    });
 
-    if (data.reference) {
-      params.push({
-        key: 'reference',
-        value: data.reference,
-      });
-    }
+    params.push({
+      key: 'reference',
+      value: data.reference ?? '',
+    });
 
     params.push({
       key: 'im_name',


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/1169

Sends all the url parameters, even when empty.

## Testing 
- Checkout this branch and run `npm install` then `npm run dev`
- View the Slices -> Web Chat
- In the docs section, set the action url for the webchat
- Click the button, complete the required fields, leave email, telephone and reference empty, then submit. It should take you to the web chat and the url should contain the empty parameters.  
- The web chat should now load as expected and not error about missing url parameters. 
- Manually run tests with `npm run test`