### PR TITLE
Separate inquest hearings and openings

### DIFF
--- a/src/library/slices/InquestSchedule/InquestSchedule.storydata.ts
+++ b/src/library/slices/InquestSchedule/InquestSchedule.storydata.ts
@@ -34,12 +34,22 @@ export const ExampleInquestScheduleArray: CaseAppointmentProps[] = [
   },
   {
     fullName: 'A Name',
+    age: 86,
+    placeOfDeath: 'A location',
+    dateTimeOfDeath: '2023-01-02T09:10:00',
+    coroner: 'Coroner Name',
+    courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
+    appointmentType: 'AP Inquest Opening',
+    startDateTime: '2023-02-01T09:30:00',
+  },
+  {
+    fullName: 'A Name',
     age: 87,
     placeOfDeath: 'A location',
     dateTimeOfDeath: '2023-01-03T14:30:00',
     coroner: 'Coroner Name',
     courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
-    appointmentType: 'AP Inquest Hearing',
+    appointmentType: 'AP Inquest Opening',
     startDateTime: '2023-02-02T09:00:00',
   },
   {

--- a/src/library/slices/InquestSchedule/InquestSchedule.styles.js
+++ b/src/library/slices/InquestSchedule/InquestSchedule.styles.js
@@ -2,6 +2,13 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   display: block;
+  box-sizing: border-box;
+`;
+
+export const GroupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.large};
 `;
 
 export const InquestContainer = styled.div`

--- a/src/library/slices/InquestSchedule/InquestSchedule.test.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import InquestSchedule from './InquestSchedule';
 import { InquestScheduleProps } from './InquestSchedule.types';
-import { ExampleInquestScheduleData } from './InquestSchedule.storydata';
+import { ExampleInquestScheduleArray, ExampleInquestScheduleData } from './InquestSchedule.storydata';
 import { ThemeProvider } from 'styled-components';
 import { west_theme } from '../../../themes/theme_generator';
 
@@ -30,6 +30,7 @@ describe('Test Component', () => {
     const component = getByTestId('InquestSchedule');
 
     expect(component).toHaveTextContent('Example Title');
+    expect(component).toHaveTextContent('Hearings');
     expect(component).toHaveTextContent('A Name');
     expect(component).toHaveTextContent('100');
     expect(component).toHaveTextContent('A location');
@@ -38,6 +39,8 @@ describe('Test Component', () => {
     expect(component).toHaveTextContent('Coroner Name');
     expect(component).toHaveTextContent('The Guildhall, St. Giles Square, Northampton, NN1 1DE');
     expect(component).toHaveTextContent('Wednesday 1 February 2023');
+
+    expect(component).not.toHaveTextContent('Openings');
   });
 
   it('should display the message when no results are returned', () => {
@@ -47,5 +50,16 @@ describe('Test Component', () => {
     const component = getByTestId('InquestSchedule');
 
     expect(component).toHaveTextContent("We can't find any results at the moment.");
+  });
+
+  it('should display hearings and openings when set', () => {
+    props.caseAppointments = ExampleInquestScheduleArray;
+
+    const { getByTestId } = renderComponent();
+
+    const component = getByTestId('InquestSchedule');
+
+    expect(component).toHaveTextContent('Hearings');
+    expect(component).toHaveTextContent('Openings');
   });
 });

--- a/src/library/slices/InquestSchedule/InquestSchedule.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.tsx
@@ -1,23 +1,37 @@
 import React from 'react';
-import { InquestScheduleProps } from './InquestSchedule.types';
+import { CaseAppointmentProps, CaseAppointmentType, InquestScheduleProps } from './InquestSchedule.types';
 import * as Styles from './InquestSchedule.styles';
 import Heading from '../../components/Heading/Heading';
 import Row from '../../components/Row/Row';
 import Column from '../../components/Column/Column';
+import { AccordionSectionProps } from '../Accordion/Accordion.types';
+import Accordion from '../Accordion/Accordion';
 
 /**
  * A table displaying a schedule of inquests
  */
 const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAppointments, title, error = false }) => {
-  const inquestDayGrouped = caseAppointments.reduce((acc, inquest) => {
-    const inquestDate = new Date(inquest.startDateTime);
-    const inquestISODay = inquestDate.toISOString().substring(0, 10);
-    if (!acc[inquestISODay]) {
-      acc[inquestISODay] = [];
-    }
-    acc[inquestISODay].push(inquest);
-    return acc;
-  }, {});
+  const hearings: CaseAppointmentProps[] = caseAppointments.filter((appointment) => {
+    return appointment.appointmentType === CaseAppointmentType.Hearing;
+  });
+  const openings: CaseAppointmentProps[] = caseAppointments.filter((appointment) => {
+    return appointment.appointmentType === CaseAppointmentType.Opening;
+  });
+
+  const groupHearingsByDay = (appointments: CaseAppointmentProps[]) => {
+    return appointments.reduce((acc, inquest) => {
+      const inquestDate = new Date(inquest.startDateTime);
+      const inquestISODay = inquestDate.toISOString().substring(0, 10);
+      if (!acc[inquestISODay]) {
+        acc[inquestISODay] = [];
+      }
+      acc[inquestISODay].push(inquest);
+      return acc;
+    }, {});
+  };
+
+  const hearingDayGrouped = groupHearingsByDay(hearings);
+  const openingDayGrouped = groupHearingsByDay(openings);
 
   const formatDate = (inquestDay: Date) => {
     return inquestDay
@@ -34,46 +48,63 @@ const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAp
     return inquestDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   };
 
+  const transformToSections = (groupedData): AccordionSectionProps[] => {
+    return Object.keys(groupedData).map((day) => {
+      const inquestDayDate = new Date(day);
+      return {
+        title: formatDate(inquestDayDate),
+        content: (
+          <Row>
+            {hearingDayGrouped[day]
+              .sort((a, b) => {
+                return new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime();
+              })
+              .map((inquest, key) => {
+                const startDateTime = new Date(inquest.startDateTime);
+                const timeOfDeath = new Date(inquest.dateTimeOfDeath);
+                return (
+                  <Column small="full" medium="full" large="full" key={key}>
+                    <Styles.InquestContainer>
+                      <Styles.InquestTime>
+                        <strong>{formatTime(startDateTime)}</strong>
+                      </Styles.InquestTime>
+                      <Styles.InquestDetails>
+                        <strong>Name:</strong> {inquest.fullName}.
+                        <br />
+                        <strong>Died:</strong> {formatDate(timeOfDeath)} at {inquest.placeOfDeath}. Aged {inquest.age}{' '}
+                        years.
+                        <br />
+                        <strong>Court location:</strong> {inquest.courtroomFullAddress}.
+                        <br />
+                        <strong>Coroner:</strong> {inquest.coroner}.
+                      </Styles.InquestDetails>
+                    </Styles.InquestContainer>
+                  </Column>
+                );
+              })}
+          </Row>
+        ),
+      };
+    });
+  };
+
   return (
     <Styles.Container data-testid="InquestSchedule">
       <Heading level={2} text={title} />
-      {Object.keys(inquestDayGrouped).map((day) => {
-        const inquestDayDate = new Date(day);
-        return (
-          <div key={day}>
-            <Heading level={3} text={formatDate(inquestDayDate)} />
-            <Row>
-              {inquestDayGrouped[day]
-                .sort((a, b) => {
-                  return new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime();
-                })
-                .map((inquest, key) => {
-                  const startDateTime = new Date(inquest.startDateTime);
-                  const timeOfDeath = new Date(inquest.dateTimeOfDeath);
-                  return (
-                    <Column small="full" medium="full" large="full" key={key}>
-                      <Styles.InquestContainer>
-                        <Styles.InquestTime>
-                          <strong>{formatTime(startDateTime)}</strong>
-                        </Styles.InquestTime>
-                        <Styles.InquestDetails>
-                          <strong>Name:</strong> {inquest.fullName}.
-                          <br />
-                          <strong>Died:</strong> {formatDate(timeOfDeath)} at {inquest.placeOfDeath}. Aged {inquest.age}{' '}
-                          years.
-                          <br />
-                          <strong>Court location:</strong> {inquest.courtroomFullAddress}.
-                          <br />
-                          <strong>Coroner:</strong> {inquest.coroner}.
-                        </Styles.InquestDetails>
-                      </Styles.InquestContainer>
-                    </Column>
-                  );
-                })}
-            </Row>
-          </div>
-        );
-      })}
+
+      {Object.keys(hearingDayGrouped).length > 0 && (
+        <Styles.GroupContainer>
+          <Heading level={3} text="Hearings" />
+          <Accordion sections={transformToSections(hearingDayGrouped)} />
+        </Styles.GroupContainer>
+      )}
+
+      {Object.keys(openingDayGrouped).length > 0 && (
+        <Styles.GroupContainer>
+          <Heading level={3} text="Openings" />
+          <Accordion sections={transformToSections(openingDayGrouped)} />
+        </Styles.GroupContainer>
+      )}
 
       {caseAppointments.length === 0 && (
         <div>

--- a/src/library/slices/InquestSchedule/InquestSchedule.types.ts
+++ b/src/library/slices/InquestSchedule/InquestSchedule.types.ts
@@ -25,3 +25,8 @@ export interface CaseAppointmentProps {
   appointmentType: string;
   startDateTime: string;
 }
+
+export enum CaseAppointmentType {
+  Hearing = 'AP Inquest Hearing',
+  Opening = 'AP Inquest Opening',
+}


### PR DESCRIPTION
- Separate Inquest Hearings and Inquest Openings into their own sections
- Make each day an accordion section

## Testing
- Checkout this branch with `git fetch && git checkout 1063-updates-to-coroners-inquest-chart`
- Install dependencies with `npm install`
- Then start the dev server with `npm run dev` 
- Manually test the Slices -> InquestSchedule -> Example Inquest Schedule and test the accordion functionality and that the hearings and openings are grouped and ordered correctly. 
- Run tests with `npm run test` 