### PR TITLE
Include rate this page form content in html so it is translated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9423,9 +9423,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -9447,7 +9447,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -9462,6 +9462,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -14825,9 +14829,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "node_modules/path-type": {

--- a/src/library/structure/RateThisPage/RateThisPage.styles.js
+++ b/src/library/structure/RateThisPage/RateThisPage.styles.js
@@ -10,6 +10,23 @@ export const FormContainer = styled(Container)`
   }
 `;
 
+export const PanelWrapper = styled.div`
+  display: ${(props) => (props.$show ? 'flex' : 'none')};
+`;
+
+export const FormWrapper = styled.div`
+  display: ${(props) => (props.$show ? 'flex' : 'none')};
+`;
+
+export const ShowQuestion = styled.div`
+  display: ${(props) => (props.$show ? 'flex' : 'none')};
+`;
+
+export const ShowFullForm = styled.div`
+  display: ${(props) => (props.$show ? 'flex' : 'none')};
+  flex-direction: column;
+`;
+
 export const Legend = styled.legend`
   margin-bottom: 5px;
   font-weight: bold;

--- a/src/library/structure/RateThisPage/RateThisPage.test.tsx
+++ b/src/library/structure/RateThisPage/RateThisPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import RateThisPage from './RateThisPage';
 import { RateThisPageProps } from './RateThisPage.types';
 import { ThemeProvider } from 'styled-components';
@@ -52,5 +52,21 @@ describe('RateThisPage Component', () => {
     fireEvent.click(getByText('I have feedback about the information on this page'));
 
     expect(component).toHaveTextContent('Did you come across any barriers or issues with this webpage?');
+  });
+
+  it('should not require additional questions when you select yes', async () => {
+    const { getByTestId, getByLabelText, getByText } = renderComponent();
+
+    const component = getByTestId('RateThisPage');
+    const isHelpfulYesRadio = getByLabelText('Yes');
+    const submitButton = getByText('Submit');
+
+    fireEvent.click(isHelpfulYesRadio);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(component).not.toHaveTextContent('There is a problem');
+      expect(component).not.toHaveTextContent('The field how easy is it to find what you are looking for is required.');
+    });
   });
 });

--- a/src/library/structure/RateThisPage/RateThisPage.test.tsx
+++ b/src/library/structure/RateThisPage/RateThisPage.test.tsx
@@ -39,12 +39,15 @@ describe('RateThisPage Component', () => {
 
     const component = getByTestId('RateThisPage');
     const isHelpfulNoRadio = getByLabelText('No');
+    const question = getByText('Did you come across any barriers or issues with this webpage?');
+    const feedbackMessage = getByText('Your feedback will help us improve our website and the content we include.');
 
-    expect(component).not.toHaveTextContent('Did you come across any barriers or issues with this webpage?');
+    expect(question).not.toBeVisible();
+    expect(feedbackMessage).not.toBeVisible();
 
     fireEvent.click(isHelpfulNoRadio);
 
-    expect(component).toHaveTextContent('Your feedback will help us improve our website and the content we include.');
+    expect(feedbackMessage).toBeVisible();
 
     fireEvent.click(getByText('I have feedback about the information on this page'));
 

--- a/src/library/structure/RateThisPage/RateThisPage.tsx
+++ b/src/library/structure/RateThisPage/RateThisPage.tsx
@@ -139,11 +139,12 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
 
   return (
     <Styles.FormContainer as="section" data-testid="RateThisPage" aria-label="Rate This Page">
-      {isSuccessful ? (
+      <Styles.PanelWrapper $show={isSuccessful}>
         <Panel heading="Thank you for your feedback.">
           {String(watchIsHelpful) === 'No' && <p>Your comments will help us improve the website.</p>}
         </Panel>
-      ) : (
+      </Styles.PanelWrapper>
+      <Styles.FormWrapper $show={!isSuccessful}>
         <form onSubmit={executeCaptcha} ref={fullFormRef}>
           <Row>
             {errors && Object.keys(errors).length > 0 && <ErrorSummary errors={errors} />}
@@ -179,229 +180,224 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
               </fieldset>
             </Column>
 
-            {showQuestion && (
-              <>
-                <Column small="full" medium="full" large="one-half">
-                  <Styles.QuestionContainer>
-                    <Styles.QuestionTitle>Content</Styles.QuestionTitle>
-                    <p>You may have comments about the content on the webpage. For example:</p>
-                    <ul>
-                      <li>The information on this page is difficult to understand</li>
-                      <li>This page isn't giving me the information I need</li>
-                      <li>This page contains information that is wrong or out of date</li>
-                      <li>This page could have been written or presented better</li>
-                    </ul>
-                    <p>Your feedback will help us improve our website and the content we include.</p>
-                    <Styles.QuestionButton>
-                      <FormButton
-                        text="I have feedback about the information on this page"
-                        type="button"
-                        size="medium"
-                        onClick={handleQuestionButton}
-                      />
-                    </Styles.QuestionButton>
-                  </Styles.QuestionContainer>
-                </Column>
-                <Column small="full" medium="full" large="one-half">
-                  <Styles.QuestionContainer>
-                    <Styles.QuestionTitle>Service</Styles.QuestionTitle>
-                    <p>You may have comments about the quality of the service that's been provided. For example:</p>
-                    <ul>
-                      <li>I have waited too long for something to happen</li>
-                      <li>I'm struggling to contact the service</li>
-                      <li>I don't think I have been treated fairly</li>
-                      <li>I feel as if I have been misled</li>
-                    </ul>
-                    <Styles.QuestionButton>
-                      <Button url={complaintsFormLink}>I have a comment or complaint about this service</Button>
-                    </Styles.QuestionButton>
-                  </Styles.QuestionContainer>
-                </Column>
-              </>
-            )}
-
-            {showFullForm && (
-              <>
-                <Column small="full" medium="full" large="full">
-                  <fieldset aria-describedby="HowEasyToFindLegend">
-                    <Styles.Legend id="HowEasyToFindLegend">
-                      How easy was it to find what you were looking for?
-                    </Styles.Legend>
-                    <Styles.Hint>1 being very easy and 5 being extremely difficult.</Styles.Hint>
-                    <Controller
-                      name="HowEasyToFind"
-                      control={control}
-                      rules={{
-                        pattern: {
-                          value: /^[1-5]+$/i,
-                          message: 'The field how easy is it to find what you are looking for is invalid.',
-                        },
-                        required: {
-                          value: true,
-                          message: 'The field how easy is it to find what you are looking for is required.',
-                        },
-                      }}
-                      render={({ field: { onChange, value } }) => (
-                        <>
-                          {errors.HowEasyToFind && (
-                            <Styles.FormErrorText id="HowEasyToFindError">
-                              <Styles.Hidden>Error:</Styles.Hidden> {errors.HowEasyToFind.message}
-                            </Styles.FormErrorText>
-                          )}
-                          {RatingValues.map((ratingValue, index) => (
-                            <RadioCheckboxInput
-                              key={index}
-                              value={ratingValue.value}
-                              label={ratingValue.label}
-                              checked={String(value) == ratingValue.value}
-                              name="HowEasyToFind"
-                              singleSelection={true}
-                              onChange={onChange}
-                              isErrored={errors.HowEasyToFind ? true : false}
-                            />
-                          ))}
-                        </>
-                      )}
+            <Styles.ShowQuestion $show={showQuestion}>
+              <Column small="full" medium="full" large="one-half">
+                <Styles.QuestionContainer>
+                  <Styles.QuestionTitle>Content</Styles.QuestionTitle>
+                  <p>You may have comments about the content on the webpage. For example:</p>
+                  <ul>
+                    <li>The information on this page is difficult to understand</li>
+                    <li>This page isn't giving me the information I need</li>
+                    <li>This page contains information that is wrong or out of date</li>
+                    <li>This page could have been written or presented better</li>
+                  </ul>
+                  <p>Your feedback will help us improve our website and the content we include.</p>
+                  <Styles.QuestionButton>
+                    <FormButton
+                      text="I have feedback about the information on this page"
+                      type="button"
+                      size="medium"
+                      onClick={handleQuestionButton}
                     />
-                  </fieldset>
-                </Column>
+                  </Styles.QuestionButton>
+                </Styles.QuestionContainer>
+              </Column>
+              <Column small="full" medium="full" large="one-half">
+                <Styles.QuestionContainer>
+                  <Styles.QuestionTitle>Service</Styles.QuestionTitle>
+                  <p>You may have comments about the quality of the service that's been provided. For example:</p>
+                  <ul>
+                    <li>I have waited too long for something to happen</li>
+                    <li>I'm struggling to contact the service</li>
+                    <li>I don't think I have been treated fairly</li>
+                    <li>I feel as if I have been misled</li>
+                  </ul>
+                  <Styles.QuestionButton>
+                    <Button url={complaintsFormLink}>I have a comment or complaint about this service</Button>
+                  </Styles.QuestionButton>
+                </Styles.QuestionContainer>
+              </Column>
+            </Styles.ShowQuestion>
 
-                <Column small="full" medium="full" large="full">
-                  <fieldset aria-describedby="HowEasyToUnderstandLegend">
-                    <Styles.Legend id="HowEasyToUnderstandLegend">
-                      How easy was this content to understand?
-                    </Styles.Legend>
-                    <Styles.Hint>1 being very easy and 5 being extremely difficult.</Styles.Hint>
-                    <Controller
-                      name="HowEasyToUnderstand"
-                      control={control}
-                      rules={{
-                        pattern: {
-                          value: /^[1-5]+$/i,
-                          message: 'The field how easy was this content to understand is invalid.',
-                        },
-                        required: {
-                          value: true,
-                          message: 'The field how easy was this content to understand is required.',
-                        },
-                      }}
-                      render={({ field: { onChange, value } }) => (
-                        <>
-                          {errors.HowEasyToUnderstand && (
-                            <Styles.FormErrorText id="HowEasyToUnderstandError">
-                              <Styles.Hidden>Error:</Styles.Hidden> {errors.HowEasyToUnderstand.message}
-                            </Styles.FormErrorText>
-                          )}
-                          {RatingValues.map((ratingValue, index) => (
-                            <RadioCheckboxInput
-                              key={index}
-                              value={ratingValue.value}
-                              label={ratingValue.label}
-                              checked={String(value) == ratingValue.value}
-                              name="HowEasyToUnderstand"
-                              singleSelection={true}
-                              onChange={onChange}
-                              isErrored={errors.HowEasyToUnderstand ? true : false}
-                            />
-                          ))}
-                        </>
-                      )}
-                    />
-                  </fieldset>
-                </Column>
-
-                <Column small="full" medium="full" large="full">
-                  <Styles.Label htmlFor="BarriersOrIssues">
-                    Did you come across any barriers or issues with this webpage?
-                  </Styles.Label>
+            <Styles.ShowFullForm $show={showFullForm}>
+              <Column small="full" medium="full" large="full">
+                <fieldset aria-describedby="HowEasyToFindLegend">
+                  <Styles.Legend id="HowEasyToFindLegend">
+                    How easy was it to find what you were looking for?
+                  </Styles.Legend>
+                  <Styles.Hint>1 being very easy and 5 being extremely difficult.</Styles.Hint>
                   <Controller
-                    name="BarriersOrIssues"
+                    name="HowEasyToFind"
                     control={control}
                     rules={{
-                      maxLength: {
-                        value: 3000,
-                        message:
-                          'The field did you come across any barriers or issues with this webpage must be less than 3000 characters.',
+                      pattern: {
+                        value: /^[1-5]+$/i,
+                        message: 'The field how easy is it to find what you are looking for is invalid.',
                       },
                       required: {
                         value: true,
-                        message: 'The field did you come across any barriers or issues with this webpage is required.',
+                        message: 'The field how easy is it to find what you are looking for is required.',
                       },
                     }}
                     render={({ field: { onChange, value } }) => (
                       <>
-                        <Textarea
-                          id="BarriersOrIssues"
-                          name="BarriersOrIssues"
-                          value={value}
-                          placeholder=""
-                          onChange={onChange}
-                          isErrored={errors.BarriersOrIssues ? true : false}
-                          errorText={errors.BarriersOrIssues ? errors.BarriersOrIssues.message : null}
-                          isFullWidth
-                        />
+                        {errors.HowEasyToFind && (
+                          <Styles.FormErrorText id="HowEasyToFindError">
+                            <Styles.Hidden>Error:</Styles.Hidden> {errors.HowEasyToFind.message}
+                          </Styles.FormErrorText>
+                        )}
+                        {RatingValues.map((ratingValue, index) => (
+                          <RadioCheckboxInput
+                            key={index}
+                            value={ratingValue.value}
+                            label={ratingValue.label}
+                            checked={String(value) == ratingValue.value}
+                            name="HowEasyToFind"
+                            singleSelection={true}
+                            onChange={onChange}
+                            isErrored={errors.HowEasyToFind ? true : false}
+                          />
+                        ))}
                       </>
                     )}
                   />
-                </Column>
+                </fieldset>
+              </Column>
 
-                <Column small="full" medium="full" large="full">
-                  <Styles.Label htmlFor="HowCanWeImprove">How could this page be improved? (optional)</Styles.Label>
+              <Column small="full" medium="full" large="full">
+                <fieldset aria-describedby="HowEasyToUnderstandLegend">
+                  <Styles.Legend id="HowEasyToUnderstandLegend">How easy was this content to understand?</Styles.Legend>
+                  <Styles.Hint>1 being very easy and 5 being extremely difficult.</Styles.Hint>
                   <Controller
-                    name="HowCanWeImprove"
+                    name="HowEasyToUnderstand"
                     control={control}
                     rules={{
-                      maxLength: {
-                        value: 3000,
-                        message: 'The field how could this page be improved must be less than 3000 characters.',
+                      pattern: {
+                        value: /^[1-5]+$/i,
+                        message: 'The field how easy was this content to understand is invalid.',
+                      },
+                      required: {
+                        value: true,
+                        message: 'The field how easy was this content to understand is required.',
                       },
                     }}
                     render={({ field: { onChange, value } }) => (
-                      <Textarea
-                        id="HowCanWeImprove"
-                        name="HowCanWeImprove"
-                        value={value}
-                        placeholder=""
-                        onChange={onChange}
-                        isErrored={errors.HowCanWeImprove ? true : false}
-                        errorText={errors.HowCanWeImprove ? errors.HowCanWeImprove.message : null}
-                        isFullWidth
-                      />
+                      <>
+                        {errors.HowEasyToUnderstand && (
+                          <Styles.FormErrorText id="HowEasyToUnderstandError">
+                            <Styles.Hidden>Error:</Styles.Hidden> {errors.HowEasyToUnderstand.message}
+                          </Styles.FormErrorText>
+                        )}
+                        {RatingValues.map((ratingValue, index) => (
+                          <RadioCheckboxInput
+                            key={index}
+                            value={ratingValue.value}
+                            label={ratingValue.label}
+                            checked={String(value) == ratingValue.value}
+                            name="HowEasyToUnderstand"
+                            singleSelection={true}
+                            onChange={onChange}
+                            isErrored={errors.HowEasyToUnderstand ? true : false}
+                          />
+                        ))}
+                      </>
                     )}
                   />
-                </Column>
+                </fieldset>
+              </Column>
 
-                <Column small="full" medium="full" large="full">
-                  <Styles.Label htmlFor="Email">
-                    Please leave your email below if you are happy for us to contact you further (optional)
-                  </Styles.Label>
-                  <Controller
-                    name="Email"
-                    control={control}
-                    rules={{
-                      maxLength: { value: 150, message: 'The email address must be less than 150 characters.' },
-                      pattern: {
-                        value:
-                          /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-                        message: 'Invalid email address.',
-                      },
-                    }}
-                    render={({ field: { onChange, onBlur, value, ref } }) => (
-                      <Input
-                        id="Email"
-                        name="Email"
+              <Column small="full" medium="full" large="full">
+                <Styles.Label htmlFor="BarriersOrIssues">
+                  Did you come across any barriers or issues with this webpage?
+                </Styles.Label>
+                <Controller
+                  name="BarriersOrIssues"
+                  control={control}
+                  rules={{
+                    maxLength: {
+                      value: 3000,
+                      message:
+                        'The field did you come across any barriers or issues with this webpage must be less than 3000 characters.',
+                    },
+                    required: {
+                      value: true,
+                      message: 'The field did you come across any barriers or issues with this webpage is required.',
+                    },
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <>
+                      <Textarea
+                        id="BarriersOrIssues"
+                        name="BarriersOrIssues"
                         value={value}
                         placeholder=""
                         onChange={onChange}
-                        isErrored={errors.Email ? true : false}
-                        errorText={errors.Email ? errors.Email.message : null}
+                        isErrored={errors.BarriersOrIssues ? true : false}
+                        errorText={errors.BarriersOrIssues ? errors.BarriersOrIssues.message : null}
                         isFullWidth
                       />
-                    )}
-                  />
-                </Column>
-              </>
-            )}
+                    </>
+                  )}
+                />
+              </Column>
+
+              <Column small="full" medium="full" large="full">
+                <Styles.Label htmlFor="HowCanWeImprove">How could this page be improved? (optional)</Styles.Label>
+                <Controller
+                  name="HowCanWeImprove"
+                  control={control}
+                  rules={{
+                    maxLength: {
+                      value: 3000,
+                      message: 'The field how could this page be improved must be less than 3000 characters.',
+                    },
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <Textarea
+                      id="HowCanWeImprove"
+                      name="HowCanWeImprove"
+                      value={value}
+                      placeholder=""
+                      onChange={onChange}
+                      isErrored={errors.HowCanWeImprove ? true : false}
+                      errorText={errors.HowCanWeImprove ? errors.HowCanWeImprove.message : null}
+                      isFullWidth
+                    />
+                  )}
+                />
+              </Column>
+
+              <Column small="full" medium="full" large="full">
+                <Styles.Label htmlFor="Email">
+                  Please leave your email below if you are happy for us to contact you further (optional)
+                </Styles.Label>
+                <Controller
+                  name="Email"
+                  control={control}
+                  rules={{
+                    maxLength: { value: 150, message: 'The email address must be less than 150 characters.' },
+                    pattern: {
+                      value:
+                        /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+                      message: 'Invalid email address.',
+                    },
+                  }}
+                  render={({ field: { onChange, onBlur, value, ref } }) => (
+                    <Input
+                      id="Email"
+                      name="Email"
+                      value={value}
+                      placeholder=""
+                      onChange={onChange}
+                      isErrored={errors.Email ? true : false}
+                      errorText={errors.Email ? errors.Email.message : null}
+                      isFullWidth
+                    />
+                  )}
+                />
+              </Column>
+            </Styles.ShowFullForm>
+
             <Column small="full" medium="full" large="full">
               <input type="hidden" {...register('ReCaptcha')} />
               {/* Terms are required when recaptcha badge is hidden */}
@@ -431,7 +427,7 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
             )}
           </Row>
         </form>
-      )}
+      </Styles.FormWrapper>
       <div id={recaptchaContainerId} className="g-recaptcha" />
     </Styles.FormContainer>
   );

--- a/src/library/structure/RateThisPage/RateThisPage.tsx
+++ b/src/library/structure/RateThisPage/RateThisPage.tsx
@@ -235,7 +235,7 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
                         message: 'The field how easy is it to find what you are looking for is invalid.',
                       },
                       required: {
-                        value: true,
+                        value: showFullForm,
                         message: 'The field how easy is it to find what you are looking for is required.',
                       },
                     }}
@@ -277,7 +277,7 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
                         message: 'The field how easy was this content to understand is invalid.',
                       },
                       required: {
-                        value: true,
+                        value: showFullForm,
                         message: 'The field how easy was this content to understand is required.',
                       },
                     }}
@@ -320,7 +320,7 @@ const RateThisPage: React.FunctionComponent<RateThisPageProps> = ({
                         'The field did you come across any barriers or issues with this webpage must be less than 3000 characters.',
                     },
                     required: {
-                      value: true,
+                      value: showFullForm,
                       message: 'The field did you come across any barriers or issues with this webpage is required.',
                     },
                   }}


### PR DESCRIPTION
- Include the form content in the HTML but use CSS to show and hide the relevant sections.
- Set the required fields only when showFullForm is true

## Testing
- Checkout this branch with `git fetch && git checkout 1178-rate-this-page-feature---doesnt-translate-fully-when-google-translate-widget-is-in-place`
- Run `npm install` then `npm run dev`
- View Structure -> Rate This Page -> Example Rate This Page 
- Test the form content displays as expected and that the validation works as expected. 
    - If you select Yes then the other form fields should not be required. 
    - If you select No then it should display additional question boxes. Click 'I have feedback about the information on this page' then the rest of the form should display. 
- View Example Pages -> Content Page -> Example Content Page
    - Translate the page into another language from the header
    - Retest the above test and check that the Rate This Page form content and questions are now translated

## Frontend testing
- In the design system, run `yalc publish`
- In the frontend, run `yalc add northants-design-system` then `npm install` then `npm run dev`
- Visit a service page and retest the Rate This Page form behaves as expected.
- Translate the page using the header and then retest that the form content is also translated.