### PR TITLE
Fix header logo focus and active styles

### DIFF
--- a/src/library/structure/Header/Header.styles.js
+++ b/src/library/structure/Header/Header.styles.js
@@ -117,15 +117,10 @@ export const HomeLink = styled.a`
     }
   }
   &:focus {
-    outline: 2px transparent solid;
-    box-shadow:
-      ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
-      ${(props) =>
-          props.theme.cardinal_name === 'north'
-            ? props.theme.theme_vars.colours.black
-            : props.theme.theme_vars.colours.focus}
-        0 0 0 4px;
-    transition: box-shadow 0.3s ease 0s;
+    ${(props) => props.theme.linkStylesFocus}
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive}
   }
 `;
 


### PR DESCRIPTION
Resolves #544 

Uses the theme default link style focus and active. The focus state has a thin gold outline with an outer black outline. This ensures the outer contrast ratio is maximised. 

## Testing
- Checkout this branch `git fetch && git checkout 544-insufficient-colour-contrast-when-header-logo-focused`
- Run `npm install` then `npm run dev`
- View the Structure -> Header stories and ensure the hover, active and focus states are correct, with the focus now having a black outline. 