### PR TITLE
Accessibility fixes for google translate link

### DIFF
--- a/src/library/components/GoogleTranslate/GoogleTranslate.styles.js
+++ b/src/library/components/GoogleTranslate/GoogleTranslate.styles.js
@@ -26,7 +26,27 @@ export const Container = styled.div`
   }
 
   #google_translate_element {
-    margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.medium};
+    margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+
+    a {
+      padding: 14px 0;
+      display: inline-block;
+
+      &:hover {
+        ${(props) => props.theme.linkStyles};
+      }
+      &:active {
+        ${(props) => props.theme.linkStylesActive};
+      }
+      &:focus {
+        ${(props) => props.theme.linkStylesFocus};
+      }
+    }
+
+    a::after {
+      content: ' (opens in new window)';
+      font-weight: normal;
+    }
   }
 `;
 


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/1188
Resolves https://github.com/FutureNorthants/northants-website/issues/1187

- Add '(opens in new window)' text to link 
- Add padding around link to make it over 45px high (AAA rating)

## Testing
- Checkout this branch with `git fetch && git checkout 1188-accessibility---add-and-opens-in-new-link-text-next-to-power-by-google-translate-text`
- Run `npm install` then `npm run dev`
- View Page examples -> Homepage -> Example homepage no search
- Expand the Translate menu in the header
- The link should now have `(opens in new window)` as part of the link text
- The link should have padding above and below
- The link should now have a focus state to indicate when the link is focused with the keyboard, as well as hover and active states