### PR TITLE
Remove the Google popup form

### DIFF
--- a/src/library/components/GoogleTranslate/GoogleTranslate.tsx
+++ b/src/library/components/GoogleTranslate/GoogleTranslate.tsx
@@ -15,6 +15,10 @@ const GoogleTranslate: React.FunctionComponent<GoogleTranslateProps> = ({
       },
       'google_translate_element'
     );
+    const popupForm = document.getElementById('goog-gt-vt');
+    if (popupForm) {
+      popupForm.remove();
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/1195

After the new window.google.translate.TranslateElement() method is run, this removes the container for the translate form (with id `goog-gt-vt`) and SilkTide browser plugin no longer records the issues for the form. Unknown if this will work for the SilkTide index. 

## Testing
- Checkout this branch with `git fetch && git checkout 1195-google-translate-hiding-form-rating-element`
- Run `npm install`
- Run `npm run dev` and view Page examples -> Homepage -> Example home no search
- Test out the Google Translate functionality that it still works as expected 
- Run the SilkTide browser plugin and test that the [issue reported by Silktide](https://index.silktide.com/website/west-northamptonshire/january-2025/recommendations/identify-input-purpose) is no longer there. 