### PR TITLE
Check inquest appointment type includes the hearing term

### DIFF
--- a/src/library/slices/InquestSchedule/InquestSchedule.storydata.ts
+++ b/src/library/slices/InquestSchedule/InquestSchedule.storydata.ts
@@ -7,7 +7,7 @@ export const ExampleInquestScheduleData: CaseAppointmentProps = {
   dateTimeOfDeath: '2023-01-01T12:08:00',
   coroner: 'Coroner Name',
   courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
-  appointmentType: 'AP Inquest Hearing',
+  appointmentType: 'AP - Inquest Hearing',
   startDateTime: '2023-02-01T10:00:00',
 };
 
@@ -19,7 +19,7 @@ export const ExampleInquestScheduleArray: CaseAppointmentProps[] = [
     dateTimeOfDeath: '2023-01-01T12:08:00',
     coroner: 'Coroner Name',
     courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
-    appointmentType: 'AP Inquest Hearing',
+    appointmentType: 'BC - Inquest Hearings',
     startDateTime: '2023-02-01T10:00:00',
   },
   {
@@ -29,7 +29,7 @@ export const ExampleInquestScheduleArray: CaseAppointmentProps[] = [
     dateTimeOfDeath: '2023-01-02T09:10:00',
     coroner: 'Coroner Name',
     courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
-    appointmentType: 'AP Inquest Hearing',
+    appointmentType: 'C D - Inquest Hearing',
     startDateTime: '2023-02-01T09:30:00',
   },
   {
@@ -59,7 +59,7 @@ export const ExampleInquestScheduleArray: CaseAppointmentProps[] = [
     dateTimeOfDeath: '2023-01-03T14:30:00',
     coroner: 'Coroner Name',
     courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
-    appointmentType: 'AP Inquest Opening',
+    appointmentType: 'AD - Inquest Opening',
     startDateTime: '2023-02-02T09:00:00',
   },
   {
@@ -80,7 +80,7 @@ export const ExampleInquestScheduleArray: CaseAppointmentProps[] = [
     dateTimeOfDeath: '2023-01-04T11:15:00',
     coroner: 'Coroner Name',
     courtroomFullAddress: 'The Guildhall, St. Giles Square, Northampton, NN1 1DE',
-    appointmentType: 'AP Inquest In Writing',
+    appointmentType: 'AZ - Inquest In Writing',
     startDateTime: '2023-02-02T10:15:00',
   },
 ];

--- a/src/library/slices/InquestSchedule/InquestSchedule.tsx
+++ b/src/library/slices/InquestSchedule/InquestSchedule.tsx
@@ -12,13 +12,13 @@ import Accordion from '../Accordion/Accordion';
  */
 const InquestSchedule: React.FunctionComponent<InquestScheduleProps> = ({ caseAppointments, title, error = false }) => {
   const hearings: CaseAppointmentProps[] = caseAppointments.filter((appointment) => {
-    return appointment.appointmentType === CaseAppointmentType.Hearing;
+    return appointment.appointmentType.toLowerCase().includes(CaseAppointmentType.Hearing);
   });
   const openings: CaseAppointmentProps[] = caseAppointments.filter((appointment) => {
-    return appointment.appointmentType === CaseAppointmentType.Opening;
+    return appointment.appointmentType.toLowerCase().includes(CaseAppointmentType.Opening);
   });
   const writings: CaseAppointmentProps[] = caseAppointments.filter((appointment) => {
-    return appointment.appointmentType === CaseAppointmentType.Writing;
+    return appointment.appointmentType.toLowerCase().includes(CaseAppointmentType.Writing);
   });
 
   const groupHearingsByDay = (appointments: CaseAppointmentProps[]) => {

--- a/src/library/slices/InquestSchedule/InquestSchedule.types.ts
+++ b/src/library/slices/InquestSchedule/InquestSchedule.types.ts
@@ -27,7 +27,7 @@ export interface CaseAppointmentProps {
 }
 
 export enum CaseAppointmentType {
-  Hearing = 'AP Inquest Hearing',
-  Opening = 'AP Inquest Opening',
-  Writing = 'AP Inquest In Writing',
+  Hearing = 'hearing',
+  Opening = 'opening',
+  Writing = 'writing',
 }


### PR DESCRIPTION
Resolves #1204

Check if the appointment type contains the relevant term to group the appointments. It was unknown that the appointment type contained the initials of the coroner. 

## Testing
- Checkout this branch `git fetch && git checkout 1204-inquest-schedule-slice-hearings-filter-needs-to-be-updated`
- Run `npm install` then `npm run dev`
- View the Slices -> Inquest Schedule and check that the items are still grouped correctly with the updated appointment types in the story data file
- Run tests with `npm run test`