### PR TITLE
Adjust line height for list items with links

### DIFF
--- a/src/library/pages/ContentPage/ContentPage.tsx
+++ b/src/library/pages/ContentPage/ContentPage.tsx
@@ -82,13 +82,18 @@ export const ContentPage: React.FunctionComponent<ContentPageProps> = ({}) => (
         <p>text inbetween lists</p>
         <ul>
           <li>
-            <a href="#">list link 1</a>
+            This is a long <a href="#">list link 1</a> that should wrap onto the next line so you get an idea of how the
+            adjusted <a href="#">line height</a> will look.
           </li>
           <li>
-            <a href="#">list link 2</a>
+            This is another example of how a <a href="#">list link 2</a> looks when it wraps onto another line for
+            comparison.
           </li>
           <li>
             <a href="#">list link 3</a>
+          </li>
+          <li>
+            <a href="#">list link 4</a>
           </li>
         </ul>
         <Divider />

--- a/src/themes/GlobalStyleReset.tsx
+++ b/src/themes/GlobalStyleReset.tsx
@@ -133,9 +133,14 @@ export const GlobalStyleReset: any = createGlobalStyle<any>`
     left: 1.25rem;
     padding-right: 1.25rem;
   }
+  main li {
+    line-height: 44px;
+  }
   main li > a {
-    display: inline-block;
+    display: inline-flex;
     min-height: 44px;
+    justify-content: center;
+    align-items: center;
   }
   blockquote,
   q {

--- a/src/themes/GlobalStyleReset.tsx
+++ b/src/themes/GlobalStyleReset.tsx
@@ -133,7 +133,7 @@ export const GlobalStyleReset: any = createGlobalStyle<any>`
     left: 1.25rem;
     padding-right: 1.25rem;
   }
-  main li {
+  main li:has(a) {
     line-height: 44px;
   }
   main li > a {

--- a/src/themes/GlobalStyleReset.tsx
+++ b/src/themes/GlobalStyleReset.tsx
@@ -133,7 +133,7 @@ export const GlobalStyleReset: any = createGlobalStyle<any>`
     left: 1.25rem;
     padding-right: 1.25rem;
   }
-  main li:has(a) {
+  main li {
     line-height: 44px;
   }
   main li > a {


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/1232

Increase the line height of li to 44px so it is the same as the link. 

## Testing
- Checkout this branch and run `npm install`
- Run `npm run dev`
- Visit the Page Examples -> Content page, then scroll down to the lists and the lists with links to preview the changes. 
- The list items should now have consistent spacing whether there are links or not. 