### PR TITLE
Fix line height issue with section links

### DIFF
--- a/src/library/structure/SectionLinks/SectionLinks.styles.js
+++ b/src/library/structure/SectionLinks/SectionLinks.styles.js
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import Heading from '../../components/Heading/Heading';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  li {
+    line-height: 1.5;
+  }
+`;
 
 export const SectionTitle = styled(Heading)`
   background: ${(props) =>


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/1081

After applying the fix for list items line height, this has made the section links spacing look wrong (as per screenshot below).
![Screenshot 2025-03-13 at 11 01 33](https://github.com/user-attachments/assets/8aca6644-be31-43d6-8bd0-8814db8d5203)

This PR overwrites the default line height for the section links to make them look more like they did previously. 

## Testing
- Checkout this branch with `git fetch && git checkout fix/section-links-line-height`
- Run `npm install` then `npm run dev`
- Visit the Example pages -> Service Landing Pages` and view the different examples, ensuring that the line spacing of the section links now looks more like the live website. 