### PR TITLE
Increase directory button sizes to meet minimum target size

### DIFF
--- a/src/library/components/Pagination/Pagination.styles.js
+++ b/src/library/components/Pagination/Pagination.styles.js
@@ -11,7 +11,7 @@ const resetButtonStyles = `
   background: transparent;
   border: none;
   cursor: pointer;
-  padding: 8px 15px;
+  padding: 10px 15px;
 `;
 
 export const Previous = styled.button`
@@ -64,7 +64,7 @@ export const NumberContainer = styled.li`
 
 export const Number = styled.button`
   ${resetButtonStyles}
-  padding: 8px 12px;
+  padding: 10px 12px;
   ${(props) => props.theme.fontStyles}
   ${(props) => props.theme.linkStyles}
 

--- a/src/library/components/Pagination/Pagination.styles.js
+++ b/src/library/components/Pagination/Pagination.styles.js
@@ -65,6 +65,7 @@ export const NumberContainer = styled.li`
 export const Number = styled.button`
   ${resetButtonStyles}
   padding: 10px 12px;
+  min-width: 44px;
   ${(props) => props.theme.fontStyles}
   ${(props) => props.theme.linkStyles}
 

--- a/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.styles.js
+++ b/src/library/directory/DirectoryAddToShortList/DirectoryAddToShortList.styles.js
@@ -7,7 +7,7 @@ export const AddToShortlist = styled.button`
   color: ${(props) =>
     props.$favourite ? props.theme.theme_vars.colours.negative : props.theme.theme_vars.colours.action};
   cursor: pointer;
-  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  padding: ${(props) => `14px ${props.theme.theme_vars.spacingSizes.small}`};
   font-weight: bold;
   display: flex;
   flex-direction: row;

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.styles.js
@@ -9,6 +9,7 @@ export const Container = styled.div`
 
   input[type='text'] {
     margin-bottom: 0;
+    min-height: 44px;
   }
 `;
 
@@ -50,7 +51,7 @@ export const Button = styled.button`
   padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
   cursor: pointer;
   border-radius: ${(props) => props.theme.theme_vars.border_radius};
-  min-height: 42px;
+  min-height: 44px;
   margin-right: ${(props) => props.theme.theme_vars.spacingSizes.medium};
   font-weight: bold;
 
@@ -79,7 +80,7 @@ export const ButtonText = styled.span`
 export const ResultInfo = styled.div`
   width: 100%;
   border-bottom: 1px solid ${(props) => props.theme.theme_vars.colours.grey};
-  color: ${(props) => props.theme.theme_vars.colours.grey_dark};
+  color: ${(props) => props.theme.theme_vars.colours.grey_darkest};
 `;
 
 const serviceBackground = (props) => {
@@ -170,8 +171,8 @@ export const LegendButton = styled.button`
   cursor: pointer;
   text-align: left;
   padding-right: 30px;
-  padding-top: ${(props) => props.theme.theme_vars.spacingSizes.small};
-  padding-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  padding-top: 12px;
+  padding-bottom: 12px;
   ${(props) => props.theme.theme_vars.h4}
   ${(props) => props.theme.linkStyles}
   &:hover {
@@ -241,7 +242,7 @@ export const TextLink = styled.button`
   position: relative;
   z-index: 1;
   margin: 0;
-  padding: ${(props) => props.theme.theme_vars.spacingSizes.small} 0;
+  padding: 12.5px 0;
   margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
   border-width: 0;
   color: ${(props) => props.theme.theme_vars.colours.action};
@@ -276,7 +277,7 @@ export const MapToggle = styled.button`
   background: ${(props) => props.theme.theme_vars.colours.white};
   color: ${(props) => props.theme.theme_vars.colours.action};
   cursor: pointer;
-  padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  padding: 12.5px ${(props) => props.theme.theme_vars.spacingSizes.small};
   font-weight: bold;
   display: flex;
   flex-direction: row;

--- a/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
+++ b/src/library/directory/DirectoryServiceList/DirectoryServiceList.tsx
@@ -255,6 +255,7 @@ const DirectoryServiceList: React.FunctionComponent<DirectoryServiceListProps> =
                       url={`${directoryPath}/documents?search=${searchTerm}`}
                       text="View documents and resources"
                       primary={false}
+                      size="large"
                     />
                   </Column>
                 )}


### PR DESCRIPTION
Increases the minimum target size to above 44px to help resolve these issues detected on the directory page:
https://app.index.silktide.com/silktide-index/everything/inspector?scId=2ba2e9b0fb5fac38eff7929b2d62a52a&checkId=ensure-reasonable-target-size&websiteId=3742

## Testing
- Checkout this branch and run `npm install` then `npm run dev`
- View the Directory -> Directory Service List -> Example Directory Service List
- Pop out into it's own frame (top right button with a square and an arrow)
- Use the Silktide browser plugin accessibility check and set it to 2.2 AAA. Ensure minimum target size is not flagged. 
- Check the layout still looks ok with the changes made to the styling. 
- Run tests with `npm run test`