### PR TITLE
Silktide May 25 fixes

### DIFF
--- a/src/library/components/Textarea/Textarea.styles.js
+++ b/src/library/components/Textarea/Textarea.styles.js
@@ -14,7 +14,8 @@ export const StyledTextarea = styled.textarea`
 
   &:focus {
     outline: none;
-    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 3px;
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+      ${(props) => props.theme.theme_vars.colours.black} 0 0 0 4px;
     transition: box-shadow 0.3s ease 0s;
   }
 `;

--- a/src/library/slices/Accordion/Accordion.styles.js
+++ b/src/library/slices/Accordion/Accordion.styles.js
@@ -68,6 +68,8 @@ export const SectionHeader = styled.div`
 export const SectionHeading = styled.div`
   margin-top: 0 !important;
   margin-bottom: 0 !important;
+  padding-top: ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
+  padding-left: ${(props) => props.theme.theme_vars.spacingSizes.extra_small};
 `;
 
 const SectionButtonIsFilteredStyles = (props) => {
@@ -110,12 +112,8 @@ export const SectionButton = styled.button`
     outline: 3px solid transparent;
     color: ${(props) => props.theme.theme_vars.colours.black};
     background-color: ${(props) => props.theme.theme_vars.colours.focus};
-    -webkit-box-shadow:
-      0 -2px ${(props) => props.theme.theme_vars.colours.focus},
-      0 4px ${(props) => props.theme.theme_vars.colours.black};
-    box-shadow:
-      0 -2px ${(props) => props.theme.theme_vars.colours.focus},
-      0 4px ${(props) => props.theme.theme_vars.colours.black};
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+      ${(props) => props.theme.theme_vars.colours.black} 0 0 0 4px;
     text-decoration: none;
   }
 

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -148,11 +148,8 @@ export const CallToActionLink = styled.a`
   &:hover,
   &:focus {
     text-decoration-style: dotted;
-    text-shadow:
-      2px 2px 4px rgba(150, 150, 150, 0.5),
-      -2px 2px 4px rgba(150, 150, 150, 0.5),
-      2px -2px 4px rgba(150, 150, 150, 0.5),
-      -2px -2px 4px rgba(150, 150, 150, 0.5);
+    text-shadow: 2px 2px 4px rgba(150, 150, 150, 0.5), -2px 2px 4px rgba(150, 150, 150, 0.5),
+      2px -2px 4px rgba(150, 150, 150, 0.5), -2px -2px 4px rgba(150, 150, 150, 0.5);
   }
   &:active {
     transform: translate(3px);
@@ -165,16 +162,17 @@ export const BreadcrumbLink = styled.a`
   color: ${(props) =>
     props.$backgroundBox ? props.theme.theme_vars.colours.action : props.theme.theme_vars.colours.white};
   margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
+  padding: ${(props) => props.theme.theme_vars.spacingSizes.small} 0;
   display: block;
 
-  &:hover,
+  &:hover {
+    ${(props) => props.theme.linkStylesHover};
+  }
   &:focus {
-    text-decoration-style: dashed;
-    text-shadow: ${(props) =>
-      props.$backgroundBox
-        ? 'none'
-        : `2px 2px 4px rgba(150, 150, 150, 0.5), -2px 2px 4px rgba(150, 150, 150, 0.5),
-      2px -2px 4px rgba(150, 150, 150, 0.5), -2px -2px 4px rgba(150, 150, 150, 0.5)`};
+    ${(props) => props.theme.linkStylesFocus};
+  }
+  &:active {
+    ${(props) => props.theme.linkStylesActive};
   }
 `;
 

--- a/src/library/structure/HeroImage/HeroImage.test.tsx
+++ b/src/library/structure/HeroImage/HeroImage.test.tsx
@@ -160,7 +160,7 @@ describe('HeroImage slice', () => {
 
     expect(breadcrumb).toBeVisible();
     expect(breadcrumb).toHaveAttribute('href', '/country-parks');
-    expect(breadcrumb).toHaveStyle(`color: ${west_theme.theme_vars.colours.action}`);
+    expect(breadcrumb).toHaveStyle(`color: ${west_theme.theme_vars.colours.black}`);
 
     expect(queryByText('Home')).toBeNull();
   });

--- a/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.styles.js
+++ b/src/library/structure/SectionLinksSidebar/SectionLinksSidebar.styles.js
@@ -89,9 +89,8 @@ const focusListItem = css`
   color: ${(props) => props.theme.theme_vars.colours.black};
   background-color: ${(props) => props.theme.theme_vars.colours.focus};
   outline: none;
-  box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-  -webkit-box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-  -moz-box-shadow: 0px -2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+  box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+    ${(props) => props.theme.theme_vars.colours.black} 0 0 0 4px;
 `;
 
 export const ListItem = styled.li`
@@ -138,9 +137,8 @@ export const ListItemLink = styled.a`
   }
   &:active {
     transform: translateY(1px);
-    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-    -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-    -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+    box-shadow: ${(props) => props.theme.theme_vars.colours.focus} 0 0 0 2px,
+      ${(props) => props.theme.theme_vars.colours.black} 0 0 0 4px;
   }
 
   @media screen and (min-width: ${(props) => props.theme.theme_vars.breakpoints.m}) {


### PR DESCRIPTION
Updated the following components so the focus state has the gold and black box shadow around the whole link or button. Previously they had just a gold outline, or only the bottom of the link or button was black. 

- Textarea
- Accordion Sections
- HeroImage
- SectionLinksSidebar

## Testing
- Checkout this branch and run `npm install` then `npm run dev`
- Manually test the components and ensure the focus states now have a black and gold box shadow when focused.