### PR TITLE
Add events link to header

### DIFF
--- a/src/library/pages/Home/HomePage.tsx
+++ b/src/library/pages/Home/HomePage.tsx
@@ -46,7 +46,9 @@ export const HomePage: React.FunctionComponent<HomePageProps> = ({
         {alertBannerContent}
       </PageStructures.AlertBanner>
 
-      {!showSearch && <PageStructures.Header hasDirectoryLink hasNewsLink accessibilityLink="/" hasTranslate />}
+      {!showSearch && (
+        <PageStructures.Header hasDirectoryLink hasNewsLink accessibilityLink="/" hasTranslate hasEventsLink />
+      )}
       <PageStructures.HomeHero
         promotedLinksArray={promotedLinksArray}
         imagesArray={heroArray}

--- a/src/library/structure/Header/Header.stories.tsx
+++ b/src/library/structure/Header/Header.stories.tsx
@@ -48,6 +48,7 @@ HeaderExample.args = {
   hideSearchBar: false,
   searchSuggestions: ['Apply for a parking permit', 'Bin collections', 'Council tax payments'],
   hasTranslate: true,
+  hasEventsLink: true,
 };
 
 export const HeaderNoNewsExample = Template.bind({});
@@ -74,6 +75,7 @@ HeaderCludoSearch.args = {
   hideSearchBar: false,
   searchSuggestions: ['Apply for a parking permit', 'Bin collections', 'Council tax payments'],
   hasTranslate: true,
+  hasEventsLink: true,
   hasCludo: true,
   customerId: parseInt(process.env.NEXT_PUBLIC_CLUDO_CUSTOMER_ID ?? ''),
   engineId: parseInt(process.env.NEXT_PUBLIC_CLUDO_ENGINE_ID ?? ''),

--- a/src/library/structure/Header/Header.test.tsx
+++ b/src/library/structure/Header/Header.test.tsx
@@ -97,4 +97,14 @@ describe('Header', () => {
 
     expect(translateDropdown).toBeVisible();
   });
+
+  it('should show the events link when true', () => {
+    props.hasEventsLink = true;
+
+    const { getByText } = renderComponent();
+
+    const eventsLink = getByText('Events');
+
+    expect(eventsLink).toHaveAttribute('href', '/events');
+  });
 });

--- a/src/library/structure/Header/Header.tsx
+++ b/src/library/structure/Header/Header.tsx
@@ -24,6 +24,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
   hasNewsLink = false,
   hasDirectoryLink = false,
   accessibilityLink,
+  hasEventsLink = false,
   allServicesLink = '/',
   isHomepage = false,
   searchSuggestions = [],
@@ -163,8 +164,13 @@ const Header: React.FunctionComponent<HeaderProps> = ({
                   {allServicesLink && (
                     <Styles.LinksItem>
                       <Styles.Link href={isHomepage ? '#all-services' : allServicesLink + '#all-services'}>
-                        All services
+                        Services
                       </Styles.Link>
+                    </Styles.LinksItem>
+                  )}
+                  {hasEventsLink && (
+                    <Styles.LinksItem>
+                      <Styles.Link href="/events">Events</Styles.Link>
                     </Styles.LinksItem>
                   )}
                   {hasDirectoryLink && (

--- a/src/library/structure/Header/Header.tsx
+++ b/src/library/structure/Header/Header.tsx
@@ -161,16 +161,16 @@ const Header: React.FunctionComponent<HeaderProps> = ({
                       <Styles.Link href="/news">News</Styles.Link>
                     </Styles.LinksItem>
                   )}
+                  {hasEventsLink && (
+                    <Styles.LinksItem>
+                      <Styles.Link href="/events">Events</Styles.Link>
+                    </Styles.LinksItem>
+                  )}
                   {allServicesLink && (
                     <Styles.LinksItem>
                       <Styles.Link href={isHomepage ? '#all-services' : allServicesLink + '#all-services'}>
                         Services
                       </Styles.Link>
-                    </Styles.LinksItem>
-                  )}
-                  {hasEventsLink && (
-                    <Styles.LinksItem>
-                      <Styles.Link href="/events">Events</Styles.Link>
                     </Styles.LinksItem>
                   )}
                   {hasDirectoryLink && (

--- a/src/library/structure/Header/Header.types.ts
+++ b/src/library/structure/Header/Header.types.ts
@@ -30,6 +30,11 @@ export interface HeaderProps {
   hasTranslate?: boolean;
 
   /**
+   * Should the header have an events link? Defaults to false.
+   */
+  hasEventsLink?: boolean;
+
+  /**
    * Link to the list of all services displayed at top right (#all-services anchor added to this)
    */
   allServicesLink?: string;


### PR DESCRIPTION
Resolves part of https://github.com/FutureNorthants/northants-website/issues/1332

- Add events link to header
- Update 'All services' link to 'Services'

## Testing
- Checkout this branch with `git fetch && git checkout 1332-events-calendar-wider-user-testing-feedback-ds`
- Run `npm install` then `npm run dev`
- Navigate to Structure -> Header -> Header example. The events link should now show and `All services` should now say `Services` 
- Test on various screen sizes to ensure it wraps the links correctly and none of them go under the logo
- Go to Pages -> Home Page -> Example Home No Search. The header should now show the Events link and `All services` should now say `Services` 
- Test the homepage in various screen sizes to ensure that it wraps correctly and do not go under the logo or into the page content below. 
