### PR TITLE
Tweaked 'Global Style Reset' file to include styles for g-recaptcha-response

### DIFF
--- a/src/themes/GlobalStyleReset.tsx
+++ b/src/themes/GlobalStyleReset.tsx
@@ -174,4 +174,10 @@ export const GlobalStyleReset: any = createGlobalStyle<any>`
   #goog-gt-tt {
     display: none !important;
   }
+
+  #g-recaptcha-response {
+    border-color: black;
+    border-width: 0;
+    border-style: solid;
+  }
 `;


### PR DESCRIPTION
This branch attempts to resolve one of [August 2025' silktide issues](https://github.com/FutureNorthants/northants-website/issues/1392) where the following WCAG 2.1 issue (specifically: WCAG 2.1 AA 1.4.11) has been reported against instances of Google's `g-recaptcha-response` control.

>"Ensure form controls contrast sufficiently with their surroundings" 

### Back-end preparatory steps ###
- Ensure the 'Docker proxy' is running
- checkout the `preprod_backend` branch
- run `npm install`
- execute `make`
### Design System preparatory steps ###
- checkout this branch
- do a `git pull` followed by `npm install`
- execute `yalc publish`
### Front-end preparatory steps ###
- checkout the `preprod_frontend` branch
- do a `git pull` followed by `npm install`
- execute `yalc add northants-design-system`
- execute `npm run dev`
### Testing ###
- Navigate to any of the following and confirm that the 'Rate my Page' control works as expected:
http://localhost:3000/pregnancy-childbirth-and-babies/pregnancy
http://localhost:3000/staying-fit-well-and-independent/looking-after-yourself
http://localhost:3000/staying-fit-well-and-independent/short-term-support
http://localhost:3000/councillors-and-committees/hm-lord-lieutenant-northamptonshire