### PR TITLE
Update focus states to use the standard linkStylesFocus 

### DIFF
--- a/src/library/components/Button/Button.styles.js
+++ b/src/library/components/Button/Button.styles.js
@@ -26,14 +26,12 @@ export const StyledButton = styled.a`
         props.$colourOverride ? props.$colourOverride : props.theme.theme_vars.colours.action_dark};
     }
     &:focus {
-      outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
       border-color: ${(props) => props.theme.theme_vars.colours.focus};
       ${(props) => props.theme.linkStylesFocus}
     }
     &:active {
       transform: translateY(2px);
-      outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
       border-color: ${(props) => props.theme.theme_vars.colours.focus};
       ${(props) => props.theme.linkStylesActive}

--- a/src/library/components/Button/Button.styles.js
+++ b/src/library/components/Button/Button.styles.js
@@ -49,13 +49,11 @@ export const StyledButton = styled.a`
         props.$colourOverride ? props.$colourOverride : props.theme.theme_vars.colours.action}1A;
     }
     &:focus {
-      outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
       border-color: ${(props) => props.theme.theme_vars.colours.focus};
       ${(props) => props.theme.linkStylesFocus}
     }
     &:active {
-      outline: none;
       transform: translateY(2px);
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
       border-color: ${(props) => props.theme.theme_vars.colours.focus};

--- a/src/library/components/Button/Button.styles.js
+++ b/src/library/components/Button/Button.styles.js
@@ -28,18 +28,15 @@ export const StyledButton = styled.a`
     &:focus {
       outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
-      background-color: ${(props) => props.theme.theme_vars.colours.focus};
-      box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -webkit-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -moz-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+      border-color: ${(props) => props.theme.theme_vars.colours.focus};
+      ${(props) => props.theme.linkStylesFocus}
     }
     &:active {
       transform: translateY(2px);
+      outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
-      background-color: ${(props) => props.theme.theme_vars.colours.focus};
-      box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+      border-color: ${(props) => props.theme.theme_vars.colours.focus};
+      ${(props) => props.theme.linkStylesActive}
     }
   }
   &.button--secondary {
@@ -56,20 +53,15 @@ export const StyledButton = styled.a`
     &:focus {
       outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
-      background-color: ${(props) => props.theme.theme_vars.colours.focus};
-      border-color: transparent;
-      box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -webkit-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -moz-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+      border-color: ${(props) => props.theme.theme_vars.colours.focus};
+      ${(props) => props.theme.linkStylesFocus}
     }
     &:active {
+      outline: none;
       transform: translateY(2px);
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
-      background-color: ${(props) => props.theme.theme_vars.colours.focus};
-      border-color: transparent !important;
-      box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+      border-color: ${(props) => props.theme.theme_vars.colours.focus};
+      ${(props) => props.theme.linkStylesActive}
     }
   }
   &.button--small {
@@ -78,14 +70,14 @@ export const StyledButton = styled.a`
   }
   &.button--medium {
     font-size: 14px;
-    padding: 11px 20px;
+    padding: 12px 20px;
 
     &.button--secondary {
-      padding: 8px 12px;
+      padding: 12px 12px;
     }
   }
   &.button--large {
     font-size: 16px;
-    padding: 14px 24px;
+    padding: 16px 24px;
   }
 `;

--- a/src/library/components/EventLink/EventLink.styles.js
+++ b/src/library/components/EventLink/EventLink.styles.js
@@ -30,9 +30,7 @@ export const Container = styled.a`
   flex-wrap: wrap;
   cursor: pointer;
   background: ${(props) => props.theme.theme_vars.colours.white} !important;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.15) !important;
-  -webkit-box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.15) !important;
-  -moz-box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.15) !important;
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.15);
   transition: box-shadow 0.3s ease;
   ${promotedStyles};
   border-radius: ${(props) => props.theme.theme_vars.border_radius};
@@ -52,7 +50,7 @@ export const Container = styled.a`
   }
 
   &:focus {
-    outline: none;
+    ${(props) => props.theme.linkStylesFocus};
 
     .event-list__title {
       ${(props) => props.theme.linkStylesFocus};
@@ -60,7 +58,7 @@ export const Container = styled.a`
   }
 
   &:active {
-    outline: none;
+    ${(props) => props.theme.linkStylesActive};
 
     .event-list__title {
       ${(props) => props.theme.linkStylesActive};

--- a/src/library/components/FormButton/FormButton.styles.js
+++ b/src/library/components/FormButton/FormButton.styles.js
@@ -24,20 +24,15 @@ export const StyledButton = styled.button`
       background-color: ${(props) => props.theme.theme_vars.colours.action_dark};
     }
     &:focus {
-      outline: none;
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
       background-color: ${(props) => props.theme.theme_vars.colours.focus};
-      box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -webkit-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -moz-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+      ${(props) => props.theme.linkStylesFocus}
     }
     &:active {
       transform: translateY(2px);
       color: ${(props) => props.theme.theme_vars.colours.black} !important;
       background-color: ${(props) => props.theme.theme_vars.colours.focus};
-      box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-      -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+      ${(props) => props.theme.linkStylesActive}
     }
   }
   &.button--secondary {
@@ -49,9 +44,15 @@ export const StyledButton = styled.button`
       background-color: ${(props) => props.theme.theme_vars.colours.action}1A;
     }
     &:focus {
-      outline: none;
-      border: 2px solid ${(props) => props.theme.theme_vars.colours.focus};
-      background-color: ${(props) => props.theme.theme_vars.colours.action}1A;
+      color: ${(props) => props.theme.theme_vars.colours.black} !important;
+      border-color: ${(props) => props.theme.theme_vars.colours.focus};
+      ${(props) => props.theme.linkStylesFocus}
+    }
+    &:active {
+      transform: translateY(2px);
+      color: ${(props) => props.theme.theme_vars.colours.black} !important;
+      border-color: ${(props) => props.theme.theme_vars.colours.focus};
+      ${(props) => props.theme.linkStylesActive}
     }
   }
   &.button--small {

--- a/src/library/slices/Accordion/Accordion.stories.tsx
+++ b/src/library/slices/Accordion/Accordion.stories.tsx
@@ -229,3 +229,40 @@ export const ExampleLongTitleAccordion: Story = {
     ],
   },
 };
+
+export const ExampleShortTitleAccordion: Story = {
+  args: {
+    sections: [
+      {
+        title: 'A',
+        content: (
+          <p>
+            <h2>Cras justo odio</h2>, dapibus ac facilisis in, <strong>egestas eget quam.</strong> Fusce dapibus, tellus
+            ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Maecenas
+            faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Praesent
+            commodo cursus magna, vel scelerisque nisl consectetur et. Donec ullamcorper nulla non metus auctor
+            fringilla. Etiam porta sem malesuada magna mollis euismod.
+          </p>
+        ),
+      },
+      {
+        title: 'B',
+        content: (
+          <p>
+            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+            vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+          </p>
+        ),
+      },
+      {
+        title: 'C',
+        content: (
+          <p>
+            Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+            vestibulum. Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra augue.
+          </p>
+        ),
+      },
+    ],
+  },
+};

--- a/src/library/slices/Accordion/Accordion.styles.js
+++ b/src/library/slices/Accordion/Accordion.styles.js
@@ -105,6 +105,7 @@ export const SectionButton = styled.button`
   cursor: pointer;
   -webkit-appearance: none;
   text-decoration: underline;
+  min-width: ${(props) => props.theme.theme_vars.spacingSizes.x_large};
 
   ${SectionButtonIsFilteredStyles}
 

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -144,6 +144,8 @@ export const CallToActionLink = styled.a`
   margin-top: 10px;
   display: inline-block;
   outline: none;
+  padding-top: 9px;
+  padding-bottom: 9px;
 
   &:hover {
     ${(props) => props.theme.linkStylesHover}

--- a/src/library/structure/HeroImage/HeroImage.styles.js
+++ b/src/library/structure/HeroImage/HeroImage.styles.js
@@ -138,21 +138,24 @@ export const Content = styled.div`
 export const CallToActionLink = styled.a`
   ${(props) => props.theme.fontStyles}
   text-decoration: underline;
-  color: ${(props) => props.theme.theme_vars.colours.white} !important;
+  color: ${(props) => props.theme.theme_vars.colours.white};
   width: 100%;
   padding: 0;
   margin-top: 10px;
   display: inline-block;
   outline: none;
 
-  &:hover,
+  &:hover {
+    ${(props) => props.theme.linkStylesHover}
+    color: ${(props) => props.theme.theme_vars.colours.white};
+  }
+
   &:focus {
-    text-decoration-style: dotted;
-    text-shadow: 2px 2px 4px rgba(150, 150, 150, 0.5), -2px 2px 4px rgba(150, 150, 150, 0.5),
-      2px -2px 4px rgba(150, 150, 150, 0.5), -2px -2px 4px rgba(150, 150, 150, 0.5);
+    ${(props) => props.theme.linkStylesFocus}
   }
   &:active {
     transform: translate(3px);
+    ${(props) => props.theme.linkStylesActive}
   }
 `;
 

--- a/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.styles.js
+++ b/src/library/structure/NewsArticleFeaturedBlock/NewsArticleFeaturedBlock.styles.js
@@ -42,9 +42,7 @@ export const ArticleContainer = styled.a`
     props.theme.cardinal_name === 'north'
       ? props.theme.theme_vars.colours.white
       : props.theme.theme_vars.colours.grey_light} !important;
-  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08) !important;
-  -webkit-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08) !important;
-  -moz-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08) !important;
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08);
   transition: box-shadow 0.3s ease;
   border-bottom: 5px solid ${(props) => props.theme.theme_vars.colours.action};
   border-radius: ${(props) => props.theme.theme_vars.border_radius};
@@ -68,11 +66,7 @@ export const ArticleContainer = styled.a`
   }
 
   &:focus {
-    outline: none;
-    border-bottom: 5px solid ${(props) => props.theme.theme_vars.colours.focus};
-    box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
-    -webkit-box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
-    -moz-box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
+    ${(props) => props.theme.linkStylesFocus}
 
     .article_title {
       ${(props) => props.theme.linkStylesFocus};
@@ -80,14 +74,8 @@ export const ArticleContainer = styled.a`
   }
 
   &:active {
-    outline: none;
     transform: translateY(3px);
-    border-bottom: 5px solid transparent;
-    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.15), 0px 2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} !important;
-    -webkit-box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.15),
-      0px 2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} !important;
-    -moz-box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.15),
-      0px 2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} !important;
+    ${(props) => props.theme.linkStylesActive}
 
     .article_title {
       ${(props) => props.theme.linkStylesActive};
@@ -131,5 +119,6 @@ export const DateContainer = styled.div`
 
 export const ViewAllContainer = styled.div`
   text-align: center;
-  margin-top: 25px;
+  margin-top: ${(props) => props.theme.theme_vars.spacingSizes.large};
+  padding-bottom: ${(props) => props.theme.theme_vars.spacingSizes.small};
 `;

--- a/src/library/structure/PromoBlock/PromoBlock.styles.js
+++ b/src/library/structure/PromoBlock/PromoBlock.styles.js
@@ -30,9 +30,7 @@ export const PromoTile = styled.a`
     props.theme.cardinal_name === 'north'
       ? props.theme.theme_vars.colours.white
       : props.theme.theme_vars.colours.grey_light} !important;
-  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08) !important;
-  -webkit-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08) !important;
-  -moz-box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08) !important;
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08);
   transition: box-shadow 0.3s ease;
   border-bottom: 5px solid ${(props) => props.theme.theme_vars.colours.action};
   border-radius: ${(props) => props.theme.theme_vars.border_radius};
@@ -47,28 +45,16 @@ export const PromoTile = styled.a`
 
   &:hover {
     border-bottom: 5px solid ${(props) => props.theme.theme_vars.colours.action_dark};
-    box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
-    -webkit-box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
-    -moz-box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
+    ${(props) => props.theme.linkStylesHover}
   }
 
   &:focus {
-    outline: none;
-    border-bottom: 5px solid ${(props) => props.theme.theme_vars.colours.focus};
-    box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
-    -webkit-box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
-    -moz-box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15) !important;
+    ${(props) => props.theme.linkStylesFocus}
   }
 
   &:active {
-    outline: none;
     transform: translateY(3px);
-    border-bottom: 5px solid transparent;
-    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.15), 0px 2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} !important;
-    -webkit-box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.15),
-      0px 2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} !important;
-    -moz-box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.15),
-      0px 2px 0px 0px ${(props) => props.theme.theme_vars.colours.black} !important;
+    ${(props) => props.theme.linkStylesActive}
   }
 `;
 

--- a/src/library/structure/ServicesLinksList/ServicesLinksList.styles.js
+++ b/src/library/structure/ServicesLinksList/ServicesLinksList.styles.js
@@ -324,23 +324,11 @@ export const ReorderButton = styled.button`
     }
   }
   &:focus:not(.chosen) {
-    outline: none;
-    border-color: transparent;
-    background: ${(props) => props.theme.theme_vars.colours.focus};
-    color: ${(props) => props.theme.theme_vars.colours.black};
     border-color: ${(props) => props.theme.theme_vars.colours.focus};
-    box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-    -webkit-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-    -moz-box-shadow: 0px -3px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+    ${(props) => props.theme.linkStylesFocus}
   }
   &:active:not(.chosen) {
     transform: translateY(2px);
-    border-color: transparent;
-    background: ${(props) => props.theme.theme_vars.colours.focus};
-    color: ${(props) => props.theme.theme_vars.colours.black};
-    border-color: ${(props) => props.theme.theme_vars.colours.focus};
-    box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-    -webkit-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
-    -moz-box-shadow: 0px -1px 0px 0px ${(props) => props.theme.theme_vars.colours.black} inset;
+    ${(props) => props.theme.linkStylesActive}
   }
 `;


### PR DESCRIPTION
- Update focus states to use the standard linkStylesFocus. This ensures the whole link has a box shadow, rather than just the bottom border
- Add min width to accordion buttons for when the labels are short 
- Make buttons a bit bigger so medium buttons meet the minimum target size of 44px high
- Removed some vendor prefixes for box shadows

## Testing
- Checkout this branch with `git fetch && git checkout fix/aug-25-accessibility-silktide`
- Run `npm install`
- Run tests with `npm run test`
- Run `npm run dev` to launch the design system
- Test the following components focus state:
    - Button (also test height of medium button over 44px)
    - Event link
    - Accordion (also test min width)
    - HeroImage call to action link
    - NewsArticleFeaturedBlock
    - PromoBlock
    - ServiceLinksList reorder controls
    - FormButton - used in CookiesBanner