### PR TITLE
Add heading styles to cludo search banners

### DIFF
--- a/src/library/structure/CludoSearch/CludoSearch.styles.js
+++ b/src/library/structure/CludoSearch/CludoSearch.styles.js
@@ -173,6 +173,8 @@ export const Container = styled.div`
     color: ${(props) => props.theme.theme_vars.colours.black};
     width: 100%;
     padding: ${(props) => props.theme.theme_vars.spacingSizes.small};
+    margin-bottom: ${(props) => props.theme.theme_vars.spacingSizes.large};
+    ${(props) => props.theme.headingStyles}
 
     a {
       text-decoration: underline !important;


### PR DESCRIPTION
Resolves https://github.com/FutureNorthants/northants-website/issues/1380

Adds heading styles from theme to the Cludo search banner. 

## Testing
- Checkout this branch with `git fetch && git checkout 1380-bug---headings-not-displaying-correctly-formatted-in-cludo-search-banners`
- Run `npm install` then `npm run dev`
- View Page Examples -> Search Results Page Examples -> Search Results Cludo
- Test searching for `NN11` and there should be a banner displayed. The H3 should now have the heading styling from the theme. 
- Run `npm run test` to manually run tests. 